### PR TITLE
GH-26 Add flat classpath discovery for JAR metadata

### DIFF
--- a/common/domain/src/main/java/com/nucleonforge/axile/common/domain/FlatJarClassPathEntry.java
+++ b/common/domain/src/main/java/com/nucleonforge/axile/common/domain/FlatJarClassPathEntry.java
@@ -1,0 +1,31 @@
+package com.nucleonforge.axile.common.domain;
+
+/**
+ * Represents a flat dependency JAR that the app relies upon.
+ *
+ * @since 19.08.2025
+ * @author Nikita Kirillov
+ */
+public class FlatJarClassPathEntry implements ClassPathEntry {
+
+    /**
+     * Group ID of the dependency
+     */
+    private String groupId;
+
+    /**
+     * Artifact ID of the dependency
+     */
+    private String artifactId;
+
+    /**
+     * Version of the dependency
+     */
+    private String version;
+
+    public FlatJarClassPathEntry(String groupId, String artifactId, String version) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+    }
+}

--- a/sbs/auto-configuration/src/main/java/com/nucleonforge/axile/autoconfiguration/spring/ClassPathDiscovererAutoConfiguration.java
+++ b/sbs/auto-configuration/src/main/java/com/nucleonforge/axile/autoconfiguration/spring/ClassPathDiscovererAutoConfiguration.java
@@ -1,0 +1,40 @@
+package com.nucleonforge.axile.autoconfiguration.spring;
+
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+import com.nucleonforge.axile.spring.build.FlatClassPathDiscoverer;
+import com.nucleonforge.axile.spring.build.FlatGradleMetadataExtractor;
+import com.nucleonforge.axile.spring.build.FlatMavenMetadataExtractor;
+import com.nucleonforge.axile.spring.build.JarMetadataExtractor;
+
+/**
+ * Spring Boot auto-configuration for JAR metadata discovery.
+ *
+ * @since 20.08.2025
+ * @author Nikita Kirillov
+ */
+@AutoConfiguration
+public class ClassPathDiscovererAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(FlatMavenMetadataExtractor.class)
+    public FlatMavenMetadataExtractor flatMavenMetadataExtractor() {
+        return new FlatMavenMetadataExtractor();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(FlatGradleMetadataExtractor.class)
+    public FlatGradleMetadataExtractor flatGradleMetadataExtractor() {
+        return new FlatGradleMetadataExtractor();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(FlatClassPathDiscoverer.class)
+    public FlatClassPathDiscoverer flatClassPathDiscoverer(List<JarMetadataExtractor> extractors) {
+        return new FlatClassPathDiscoverer(extractors);
+    }
+}

--- a/sbs/spring/src/main/java/com/nucleonforge/axile/spring/build/FlatClassPathDiscoverer.java
+++ b/sbs/spring/src/main/java/com/nucleonforge/axile/spring/build/FlatClassPathDiscoverer.java
@@ -1,0 +1,75 @@
+package com.nucleonforge.axile.spring.build;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarFile;
+
+import com.nucleonforge.axile.common.domain.ClassPath;
+import com.nucleonforge.axile.common.domain.ClassPathEntry;
+import com.nucleonforge.axile.common.domain.FlatJarClassPathEntry;
+
+/**
+ * A {@link ClassPathDiscoverer} implementation that produces a flat representation
+ * of the application's classpath.
+ *
+ * @see FlatJarClassPathEntry
+ * @see JarMetadataExtractor
+ * @since 18.08.2025
+ * @author Nikita Kirillov
+ */
+public class FlatClassPathDiscoverer implements ClassPathDiscoverer {
+
+    private final List<JarMetadataExtractor> extractors;
+
+    public FlatClassPathDiscoverer(List<JarMetadataExtractor> extractors) {
+        this.extractors = extractors;
+    }
+
+    @Override
+    public ClassPath discover() {
+        String classPathProperty = System.getProperty("java.class.path");
+
+        if (classPathProperty != null && !classPathProperty.isEmpty()) {
+            return new ClassPath(discoverFromClassPath(classPathProperty));
+        }
+
+        return new ClassPath(Collections.emptySet());
+    }
+
+    private Set<ClassPathEntry> discoverFromClassPath(String classPathProperty) {
+        Set<ClassPathEntry> entries = new HashSet<>();
+        String[] paths = classPathProperty.split(File.pathSeparator);
+
+        for (String path : paths) {
+            Path jarPath = Paths.get(path);
+            if (Files.exists(jarPath) && path.endsWith(".jar")) {
+                try (JarFile jarFile = new JarFile(jarPath.toFile())) {
+                    FlatJarClassPathEntry entry = extractMetadata(jarFile);
+                    if (entry != null) {
+                        entries.add(entry);
+                    }
+                } catch (IOException ignored) {
+                }
+            }
+        }
+
+        return entries;
+    }
+
+    private FlatJarClassPathEntry extractMetadata(JarFile jarFile) {
+        for (JarMetadataExtractor extractor : extractors) {
+            FlatJarClassPathEntry entry = extractor.extract(jarFile);
+            if (entry != null) {
+                return entry;
+            }
+        }
+        return null;
+    }
+}

--- a/sbs/spring/src/main/java/com/nucleonforge/axile/spring/build/FlatGradleMetadataExtractor.java
+++ b/sbs/spring/src/main/java/com/nucleonforge/axile/spring/build/FlatGradleMetadataExtractor.java
@@ -1,0 +1,97 @@
+package com.nucleonforge.axile.spring.build;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import com.nucleonforge.axile.common.domain.FlatJarClassPathEntry;
+import com.nucleonforge.axile.spring.utils.StringUtils;
+
+/**
+ * Implementation of {@link JarMetadataExtractor} that extracts flat metadata
+ * from a Gradle-generated JAR manifest ({@code META-INF/MANIFEST.MF}).
+ * <p>
+ * Produces {@link FlatJarClassPathEntry} without transitive dependency information.
+ *
+ * @since 19.08.2025
+ * @author Nikita Kirillov
+ */
+public class FlatGradleMetadataExtractor implements JarMetadataExtractor {
+
+    @Override
+    public FlatJarClassPathEntry extract(JarFile jarFile) {
+        try {
+            JarEntry manifestEntry = jarFile.getJarEntry("META-INF/MANIFEST.MF");
+            if (manifestEntry == null) return null;
+
+            try (InputStream is = jarFile.getInputStream(manifestEntry)) {
+                Manifest manifest = new Manifest(is);
+                Attributes attrs = manifest.getMainAttributes();
+
+                FlatJarClassPathEntry entry;
+
+                entry = extractFromImplementation(attrs);
+                if (entry != null) return entry;
+
+                entry = extractFromBundle(attrs);
+                if (entry != null) return entry;
+
+                entry = extractFromAutomaticModule(attrs);
+                if (entry != null) return entry;
+            }
+        } catch (IOException ignored) {
+        }
+        return null;
+    }
+
+    private FlatJarClassPathEntry extractFromImplementation(Attributes attrs) {
+        String title = attrs.getValue("Implementation-Title");
+        String version = attrs.getValue("Implementation-Version");
+        String vendor = attrs.getValue("Implementation-Vendor");
+
+        if (title != null || (vendor != null && version != null)) {
+            return new FlatJarClassPathEntry(
+                    StringUtils.defaultIfBlank(vendor, "unknown-group"),
+                    StringUtils.defaultIfBlank(title, "unknown-artifact"),
+                    StringUtils.defaultIfBlank(version, "unknown-version"));
+        }
+        return null;
+    }
+
+    private FlatJarClassPathEntry extractFromBundle(Attributes attrs) {
+        String name = attrs.getValue("Bundle-SymbolicName");
+        String version = attrs.getValue("Bundle-Version");
+
+        if (name != null && version != null) {
+            return splitNameAndBuildEntry(name, version);
+        }
+        return null;
+    }
+
+    private FlatJarClassPathEntry extractFromAutomaticModule(Attributes attrs) {
+        String moduleName = attrs.getValue("Automatic-Module-Name");
+        if (moduleName != null) {
+            String version = StringUtils.defaultIfBlank(attrs.getValue("Implementation-Version"), "unknown-version");
+            return splitNameAndBuildEntry(moduleName, version);
+        }
+        return null;
+    }
+
+    private FlatJarClassPathEntry splitNameAndBuildEntry(String fullName, String version) {
+        String groupId = "unknown-group";
+        String artifactId = fullName;
+
+        if (fullName.contains(".")) {
+            String[] parts = fullName.split("\\.");
+            if (parts.length > 1) {
+                groupId = String.join(".", Arrays.copyOf(parts, parts.length - 1));
+                artifactId = parts[parts.length - 1];
+            }
+        }
+        return new FlatJarClassPathEntry(groupId, artifactId, version);
+    }
+}

--- a/sbs/spring/src/main/java/com/nucleonforge/axile/spring/build/FlatMavenMetadataExtractor.java
+++ b/sbs/spring/src/main/java/com/nucleonforge/axile/spring/build/FlatMavenMetadataExtractor.java
@@ -1,0 +1,129 @@
+package com.nucleonforge.axile.spring.build;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Stream;
+
+import com.nucleonforge.axile.common.domain.FlatJarClassPathEntry;
+import com.nucleonforge.axile.spring.utils.StringUtils;
+
+/**
+ * Implementation of {@link JarMetadataExtractor} that extracts flat metadata
+ * from Maven-based JAR files.
+ * <p>
+ * Produces {@link FlatJarClassPathEntry} without transitive dependency information.
+ *
+ * @since 19.08.2025
+ * @author Nikita Kirillov
+ */
+public class FlatMavenMetadataExtractor implements JarMetadataExtractor {
+
+    @Override
+    public FlatJarClassPathEntry extract(JarFile jarFile) {
+        FlatJarClassPathEntry fromProperties = tryExtractFromPomProperties(jarFile);
+        if (fromProperties != null) {
+            return fromProperties;
+        }
+        return tryExtractFromPomXml(jarFile);
+    }
+
+    private FlatJarClassPathEntry tryExtractFromPomProperties(JarFile jarFile) {
+        Enumeration<JarEntry> entries = jarFile.entries();
+
+        while (entries.hasMoreElements()) {
+            JarEntry entry = entries.nextElement();
+            String entryName = entry.getName();
+
+            if (entryName.startsWith("META-INF/maven/") && entryName.endsWith("/pom.properties")) {
+                try (InputStream is = jarFile.getInputStream(entry)) {
+                    Properties props = new Properties();
+                    props.load(is);
+
+                    String groupId = props.getProperty("groupId");
+                    String artifactId = props.getProperty("artifactId");
+                    String version = props.getProperty("version");
+
+                    if (groupId != null && artifactId != null && version != null) {
+                        return new FlatJarClassPathEntry(
+                                StringUtils.defaultIfBlank(groupId, "unknown-group"),
+                                StringUtils.defaultIfBlank(artifactId, "unknown-artifact"),
+                                StringUtils.defaultIfBlank(version, "unknown-version"));
+                    }
+                } catch (IOException ignored) {
+                }
+            }
+        }
+        return null;
+    }
+
+    private FlatJarClassPathEntry tryExtractFromPomXml(JarFile jarFile) {
+        Path jarPath = Paths.get(new File(jarFile.getName()).getAbsolutePath());
+        Path pomPath = findPomPath(jarPath);
+
+        if (pomPath == null) {
+            return null;
+        }
+
+        try {
+            String pomContent = Files.readString(pomPath, StandardCharsets.UTF_8);
+
+            String groupId = extractXmlValue(pomContent, "groupId");
+            String artifactId = extractXmlValue(pomContent, "artifactId");
+            String version = extractXmlValue(pomContent, "version");
+
+            return new FlatJarClassPathEntry(
+                    StringUtils.defaultIfBlank(groupId, "unknown-group"),
+                    StringUtils.defaultIfBlank(artifactId, "unknown-artifact"),
+                    StringUtils.defaultIfBlank(version, "unknown-version"));
+
+        } catch (IOException ignored) {
+            return null;
+        }
+    }
+
+    private Path findPomPath(Path jarPath) {
+        // Check in the same directory as the JAR
+        try (Stream<Path> files = Files.list(jarPath.getParent())) {
+            Path pomPath =
+                    files.filter(p -> p.toString().endsWith(".pom")).findFirst().orElse(null);
+            if (pomPath != null) {
+                return pomPath;
+            }
+        } catch (IOException ignore) {
+        }
+
+        // If not found, go one level up and search recursively in all subdirectories
+        Path parent = jarPath.getParent();
+        if (parent != null && parent.getParent() != null) {
+            try (Stream<Path> files = Files.walk(parent.getParent())) {
+                return files.filter(p -> p.toString().endsWith(".pom"))
+                        .findFirst()
+                        .orElse(null);
+            } catch (IOException ignore) {
+            }
+        }
+        return null;
+    }
+
+    private String extractXmlValue(String xml, String tagName) {
+        String startTag = "<" + tagName + ">";
+        String endTag = "</" + tagName + ">";
+        int startIndex = xml.indexOf(startTag);
+        if (startIndex == -1) return null;
+
+        startIndex += startTag.length();
+        int endIndex = xml.indexOf(endTag, startIndex);
+        if (endIndex == -1) return null;
+
+        return xml.substring(startIndex, endIndex).trim();
+    }
+}

--- a/sbs/spring/src/main/java/com/nucleonforge/axile/spring/build/JarMetadataExtractor.java
+++ b/sbs/spring/src/main/java/com/nucleonforge/axile/spring/build/JarMetadataExtractor.java
@@ -1,0 +1,22 @@
+package com.nucleonforge.axile.spring.build;
+
+import java.util.jar.JarFile;
+
+import com.nucleonforge.axile.common.domain.FlatJarClassPathEntry;
+
+/**
+ * Strategy interface for extracting metadata from a JAR file.
+ *
+ * @since 19.08.2025
+ * @author Nikita Kirillov
+ */
+public interface JarMetadataExtractor {
+
+    /**
+     * Extracts metadata from the given JAR file and returns it as a {@link FlatJarClassPathEntry}.
+     *
+     * @param jarFile the JAR file to analyze
+     * @return extracted metadata, or {@code null} if this extractor cannot handle the file
+     */
+    FlatJarClassPathEntry extract(JarFile jarFile);
+}

--- a/sbs/spring/src/main/java/com/nucleonforge/axile/spring/utils/StringUtils.java
+++ b/sbs/spring/src/main/java/com/nucleonforge/axile/spring/utils/StringUtils.java
@@ -7,6 +7,8 @@ package com.nucleonforge.axile.spring.utils;
  */
 public class StringUtils {
 
+    private StringUtils() {}
+
     public static boolean containsIgnoreCase(String source, String destination) {
 
         if (source == null) {
@@ -36,5 +38,9 @@ public class StringUtils {
         }
 
         return false;
+    }
+
+    public static String defaultIfBlank(String value, String defaultValue) {
+        return value != null && !value.isBlank() ? value : defaultValue;
     }
 }

--- a/sbs/spring/src/test/java/com/nucleonforge/axile/spring/utils/StringUtilsTest.java
+++ b/sbs/spring/src/test/java/com/nucleonforge/axile/spring/utils/StringUtilsTest.java
@@ -33,4 +33,19 @@ class StringUtilsTest {
                 Arguments.of("head_case_IGNORED_tail", "CASE_Ig", true),
                 Arguments.of("Letter_missin", "Letter_missing", false));
     }
+
+    @ParameterizedTest
+    @MethodSource("source_defaultIfBlank")
+    void test_defaultIfBlank(String value, String defaultValue, String expected) {
+        assertThat(StringUtils.defaultIfBlank(value, defaultValue)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> source_defaultIfBlank() {
+        return Stream.of(
+                Arguments.of(null, "default", "default"),
+                Arguments.of("", "default", "default"),
+                Arguments.of("   ", "default", "default"),
+                Arguments.of("actual", "default", "actual"),
+                Arguments.of("  text  ", "default", "  text  "));
+    }
 }


### PR DESCRIPTION
- Introduce FlatJarClassPathEntry for simple JAR dependency representation
- Add FlatMavenMetadataExtractor and FlatGradleMetadataExtractor
- Create FlatClassPathDiscoverer that uses all available JarMetadataExtractor beans
- Add Spring Boot auto-configuration for flat classpath discovery