### PR TITLE
GH-73 Create main layout

### DIFF
--- a/front-end/src/i18n/locales/en.json
+++ b/front-end/src/i18n/locales/en.json
@@ -1,8 +1,20 @@
 {
   "login": "Login",
+  "logout": "Logout",
   "username": "Username",
   "enterUsername": "Enter username",
   "password": "Password",
   "enterPassword": "Enter password",
-  "loginButtonText": "Sign In"
+  "loginButtonText": "Sign In",
+  "dashboard": "Dashboard",
+  "wallboard": "Wallboard",
+  "insights": "Insights",
+  "details": "Details",
+  "metrics": "Metrics",
+  "environment": "Environment",
+  "configurationProperties": "Configuration Properties",
+  "scheduledTasks": "Scheduled Tasks",
+  "loggers": "Loggers",
+  "mappings": "Mappings",
+  "caches": "Caches"
 }

--- a/front-end/src/i18n/locales/ru.json
+++ b/front-end/src/i18n/locales/ru.json
@@ -1,8 +1,20 @@
 {
   "login": "Вход",
+  "logout": "Выйти",
   "username": "Имя пользователя",
   "enterUsername": "Введите имя пользователя",
   "password": "Пароль",
   "enterPassword": "Введите пароль",
-  "loginButtonText": "Войти"
+  "loginButtonText": "Войти",
+  "dashboard": "Дашборд",
+  "wallboard": "Панель",
+  "insights": "Аналитика",
+  "details": "Детали",
+  "metrics": "Метрики",
+  "environment": "Окружение",
+  "configurationProperties": "Свойства конфигурации",
+  "scheduledTasks": "Запланированные задачи",
+  "loggers": "Логгеры",
+  "mappings": "Сопоставления",
+  "caches": "Кэши"
 }

--- a/front-end/src/layout/DashboardLayout/AdminHeader/index.tsx
+++ b/front-end/src/layout/DashboardLayout/AdminHeader/index.tsx
@@ -1,0 +1,42 @@
+import { Avatar, Dropdown } from "antd";
+import { Link } from "react-router-dom";
+import { Header } from "antd/es/layout/layout";
+import { useTranslation } from "react-i18next";
+import { UserOutlined } from "@ant-design/icons";
+
+import { LanguageSwitcher } from "../../../components/LanguageSwitcher/LanguageSwitcher";
+import Logo from "../../../assets/icons/logo.png";
+import type { MenuProps } from "antd";
+
+import styles from "./styles.module.css";
+
+export const AdminHeader = () => {
+  const { t } = useTranslation();
+
+  const items: MenuProps["items"] = [
+    {
+      key: "1",
+      label: <div>{t("logout")}</div>,
+    },
+  ];
+
+  return (
+    <Header className={styles.Header}>
+      <img src={Logo} alt="Axile logo" className={styles.Logo} />
+      <div className={styles.LinksAndAvatarWrapper}>
+        <div>
+          <Link to="#" className={styles.Link}>
+            {t("dashboard")}
+          </Link>
+          <Link to="#" className={styles.Link}>
+            {t("wallboard")}
+          </Link>
+        </div>
+        <Dropdown menu={{ items }}>
+          <Avatar size={32} icon={<UserOutlined />} className={styles.Avatar} />
+        </Dropdown>
+        <LanguageSwitcher />
+      </div>
+    </Header>
+  );
+};

--- a/front-end/src/layout/DashboardLayout/AdminHeader/styles.module.css
+++ b/front-end/src/layout/DashboardLayout/AdminHeader/styles.module.css
@@ -1,0 +1,39 @@
+.Header {
+  background-color: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.Logo {
+  width: 140px;
+  cursor: pointer;
+}
+
+.LinksAndAvatarWrapper {
+  display: flex;
+  align-items: center;
+}
+
+.Link {
+  transition: all 0.3s;
+  align-self: center;
+  padding: 8px 12px;
+  border-radius: 4px;
+  margin-right: 8px;
+}
+
+.Link:last-child {
+  margin-right: 0;
+}
+
+.Link:hover {
+  color: #00ab55;
+  background-color: #00ab551a;
+}
+
+.Avatar {
+  margin-inline: 30px 20px;
+  background-color: #00ab55;
+  cursor: pointer;
+}

--- a/front-end/src/layout/DashboardLayout/index.tsx
+++ b/front-end/src/layout/DashboardLayout/index.tsx
@@ -1,0 +1,85 @@
+import { Outlet } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import { Layout, Menu, type MenuProps } from "antd";
+
+import { AdminHeader } from "./AdminHeader";
+
+import styles from "./styles.module.css";
+
+const { Content, Sider } = Layout;
+
+type MenuItem = Required<MenuProps>["items"][number];
+
+export const DashboardLayout = () => {
+  const { t } = useTranslation();
+
+  const items: MenuItem[] = [
+    {
+      key: "insights",
+      label: t("insights"),
+      children: [
+        {
+          key: "details",
+          label: t("details"),
+        },
+        {
+          key: "metrics",
+          label: t("metrics"),
+        },
+        {
+          key: "environment",
+          label: t("environment"),
+        },
+        {
+          key: "beans",
+          label: "Beans",
+        },
+        {
+          key: "configurationProperties",
+          label: t("configurationProperties"),
+        },
+        {
+          key: "scheduledTasks",
+          label: t("scheduledTasks"),
+        },
+      ],
+    },
+    { key: "loggers", label: t("loggers") },
+    { key: "jvm", label: "JVM" },
+    { key: "mappings", label: t("mappings") },
+    { key: "caches", label: t("caches") },
+  ];
+
+  return (
+    <Layout className={styles.MainWrapper}>
+      <AdminHeader />
+
+      <Layout>
+        <Sider width={270} className={styles.Sider}>
+          <Menu
+            mode="inline"
+            items={items}
+            className={styles.Menu}
+            // todo fix this in future
+            // onClick={onClick}
+            // onOpenChange={onOpenChange}
+            // selectedKeys={[pathnameMainPart]}
+          />
+        </Sider>
+
+        <Layout style={{ padding: "24px" }}>
+          <Content
+            style={{
+              padding: 24,
+              margin: 0,
+              minHeight: 280,
+              background: "#fff",
+            }}
+          >
+            <Outlet />
+          </Content>
+        </Layout>
+      </Layout>
+    </Layout>
+  );
+};

--- a/front-end/src/layout/DashboardLayout/styles.module.css
+++ b/front-end/src/layout/DashboardLayout/styles.module.css
@@ -1,0 +1,11 @@
+.MainWrapper {
+  min-height: 100vh;
+}
+
+.Sider {
+  background-color: #fff;
+}
+
+.Menu {
+  margin-top: 24px;
+}

--- a/front-end/src/main.tsx
+++ b/front-end/src/main.tsx
@@ -1,12 +1,12 @@
 import { StrictMode } from "react";
+import { ConfigProvider } from "antd";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
-import { ConfigProvider } from "antd";
 
 const theme = {
   token: {
-    colorPrimary: "#55BD34",
+    colorPrimary: "#00AB55",
     fontFamily: "'Golos', sans-serif",
   },
 };

--- a/front-end/src/routes/MainRoutes.tsx
+++ b/front-end/src/routes/MainRoutes.tsx
@@ -1,9 +1,12 @@
 import { Navigate, Route, Routes } from "react-router-dom";
+import { DashboardLayout } from "../layout/DashboardLayout";
 
 export const MainRoutes = () => {
   return (
     <Routes>
-      <Route path="/" element={<>1</>} />
+      <Route path="/" element={<DashboardLayout />}>
+        <Route index element={<>1</>} />
+      </Route>
       <Route path="*" element={<Navigate to="/" />} />
     </Routes>
   );


### PR DESCRIPTION
Created the main layout, which includes:

- Header – the top navigation
- Sidebar – the side navigation panel
- Content – the main content area

Added translation support for header and sidebar content.