### PR TITLE
GH-260: Fixed the CyclomaticComplexity error reported by PMD (#260)

### DIFF
--- a/master/src/main/java/com/nucleonforge/axile/master/auth/spi/jwt/service/DefaultJwtEncoderService.java
+++ b/master/src/main/java/com/nucleonforge/axile/master/auth/spi/jwt/service/DefaultJwtEncoderService.java
@@ -41,16 +41,8 @@ public class DefaultJwtEncoderService implements JwtEncoderService {
     }
 
     @Override
-    // TODO: Why PMD complains here? I do not see CyclomaticComplexity here being >= 10
-    @SuppressWarnings("PMD.CyclomaticComplexity")
     public String generateToken(User user) throws JwtTokenGenerationException {
-        if (user == null) {
-            throw new JwtTokenGenerationException("User cannot be null");
-        }
-
-        if (user.username() == null || user.username().isEmpty()) {
-            throw new JwtTokenGenerationException("Username cannot be null or empty");
-        }
+        checkEmptyUserAndUserName(user);
 
         try {
             Instant now = Instant.now();
@@ -67,6 +59,16 @@ public class DefaultJwtEncoderService implements JwtEncoderService {
             throw e;
         } catch (Exception e) {
             throw new JwtTokenGenerationException("Failed to generate JWT token", e);
+        }
+    }
+
+    private void checkEmptyUserAndUserName(User user) {
+        if (user == null) {
+            throw new JwtTokenGenerationException("User cannot be null");
+        }
+
+        if (user.username() == null || user.username().isEmpty()) {
+            throw new JwtTokenGenerationException("Username cannot be null or empty");
         }
     }
 

--- a/master/src/main/java/com/nucleonforge/axile/master/auth/spi/jwt/service/DefaultJwtEncoderService.java
+++ b/master/src/main/java/com/nucleonforge/axile/master/auth/spi/jwt/service/DefaultJwtEncoderService.java
@@ -42,7 +42,7 @@ public class DefaultJwtEncoderService implements JwtEncoderService {
 
     @Override
     public String generateToken(User user) throws JwtTokenGenerationException {
-        checkEmptyUserAndUserName(user);
+        validateUser(user);
 
         try {
             Instant now = Instant.now();
@@ -62,7 +62,7 @@ public class DefaultJwtEncoderService implements JwtEncoderService {
         }
     }
 
-    private void checkEmptyUserAndUserName(User user) {
+    private void validateUser(User user) {
         if (user == null) {
             throw new JwtTokenGenerationException("User cannot be null");
         }


### PR DESCRIPTION
While working on task #260, we found that **PMD** counts the `throw` statement when calculating method complexity. I did not find this case [documented](https://docs.pmd-code.org/latest/pmd_rules_apex_design.html#cyclomaticcomplexity), though I may not have searched thoroughly.

Based on this, it was decided to move the **null-check** logic into a separate method `checkEmptyUserAndUserName` to avoid the **CyclomaticComplexity** error.
