### PR TITLE
GH-789: Add AOT Cache to Dockerfile multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN java \
     -XX:AOTConfiguration=app.aotconf \
     -Dspring.main.web-application-type=none \
     -Daxelix.master.web.static-resources.location=file:/application/dist/ \
-    org.springframework.boot.loader.launch.JarLauncher; exit 0
+    -Dspring.context.exit=onRefresh \
+    org.springframework.boot.loader.launch.JarLauncher
 
 # Step 2: Create AOT cache from the recorded profile (does not execute application code)
 RUN java \


### PR DESCRIPTION
Adds a new `training` stage to the Dockerfile multistage build that implements
The stage performs a two-step AOT cache creation:
  1. **Record** — runs `JarLauncher` to capture class loading profile into `app.aotconf` (crash without infra is expected and handled via
  `exit 0`)
  2. **Create** — compiles the recorded profile into a binary `app.aot` cache without executing application code
  The resulting cache is copied into the `final` image and activated via `-XX:AOTCache=app.aot`.

## Benchmark

  Measured locally on Java 25.0.2 / Spring Boot 3.5.10:

  |                               | Startup time                 | JVM running               |
  |---------------------|--------------------------|-------------------------|
  | Baseline                 | 4.833 s                         | 5.220 s                         |
  | AOT Cache            | 3.929 s                         | 4.246 s                         |
  | **Improvement**  | **−0.904 s (−18.7%)** | **−0.974 s (−18.6%)** |