### PR TITLE
GH-888 Skipped "check-linked-issues" job in GitHub Actions when PR hаs "Dependencies" label

### DIFF
--- a/.github/workflows/backend_pull_requests.yaml
+++ b/.github/workflows/backend_pull_requests.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Check for linked issues
         uses: nearform-actions/github-action-check-linked-issues@v1
         with:
-          exclude-labels: "refactoring"
+          exclude-labels: "refactoring, dependencies"
 
   backend-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend_pull_requests.yaml
+++ b/.github/workflows/frontend_pull_requests.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Check for linked issues
         uses: nearform-actions/github-action-check-linked-issues@v1
         with:
-          exclude-labels: "refactoring"
+          exclude-labels: "refactoring, dependencies"
 
   frontend-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes GH-888