### PR TITLE
GH-918 Handle the role decoding capabilities from OIDC tokens

### DIFF
--- a/master/build.gradle.kts
+++ b/master/build.gradle.kts
@@ -40,6 +40,12 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${springDocSwaggerVersion}")
     implementation("com.paypal:heap-dump-tool:${heapDumpToolVersion}")
     implementation("com.nimbusds:nimbus-jose-jwt:${nimbusJoseJwt}")
+
+    // TODO:
+    //  This library is archived, and it only supports Jackson 2.x
+    //  For now we're gonna get away with it, but Spring Boot 4 already
+    //  establishes a baseline for Jackson 3, but it still ca work with Jackson 2.
+    //  So, we need to decide how are we going to work with this.
     implementation("io.burt:jmespath-jackson:${jmesPathVersion}")
 
     // Runtime

--- a/master/build.gradle.kts
+++ b/master/build.gradle.kts
@@ -12,6 +12,7 @@ val springDocSwaggerVersion = "3.0.1"
 val heapDumpToolVersion = "1.3.3"
 val sqliteVersion = "3.51.2.0"
 val nimbusJoseJwt ="10.8"
+val jmesPathVersion = "0.6.0"
 
 dependencies {
     // Self
@@ -39,7 +40,7 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${springDocSwaggerVersion}")
     implementation("com.paypal:heap-dump-tool:${heapDumpToolVersion}")
     implementation("com.nimbusds:nimbus-jose-jwt:${nimbusJoseJwt}")
-    implementation("com.jayway.jsonpath:json-path")
+    implementation("io.burt:jmespath-jackson:${jmesPathVersion}")
 
     // Runtime
     runtimeOnly("ch.qos.logback:logback-classic")

--- a/master/build.gradle.kts
+++ b/master/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     implementation(platform("org.springframework.ai:spring-ai-bom:${springAiVersion}"))
 
     // Boot Starters
-    implementation("org.springframework.boot:spring-boot-starter-jdbc") // TODO: Do we still need plain JDBC starter? I think no...
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-restclient")
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
@@ -40,6 +39,7 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${springDocSwaggerVersion}")
     implementation("com.paypal:heap-dump-tool:${heapDumpToolVersion}")
     implementation("com.nimbusds:nimbus-jose-jwt:${nimbusJoseJwt}")
+    implementation("com.jayway.jsonpath:json-path")
 
     // Runtime
     runtimeOnly("ch.qos.logback:logback-classic")

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/OAuth2CallbackController.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/OAuth2CallbackController.java
@@ -34,9 +34,9 @@ import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
 import com.axelixlabs.axelix.master.api.external.ApiPaths;
 import com.axelixlabs.axelix.master.api.external.ExternalApiRestController;
 import com.axelixlabs.axelix.master.service.auth.CookieService;
-import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient.Tokens;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcRoleExtractor;
+import com.axelixlabs.axelix.master.service.auth.oauth.Tokens;
 import com.axelixlabs.axelix.master.service.transport.BadRequestException;
 
 /**

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/OAuth2CallbackController.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/OAuth2CallbackController.java
@@ -27,14 +27,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.PasswordlessUser;
+import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.common.auth.core.User;
 import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
 import com.axelixlabs.axelix.master.api.external.ApiPaths;
 import com.axelixlabs.axelix.master.api.external.ExternalApiRestController;
 import com.axelixlabs.axelix.master.service.auth.CookieService;
+import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient.Tokens;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
+import com.axelixlabs.axelix.master.service.auth.oauth.OidcRoleExtractor;
 import com.axelixlabs.axelix.master.service.transport.BadRequestException;
 
 /**
@@ -58,12 +60,17 @@ public class OAuth2CallbackController {
     private final OidcClient oidcClient;
     private final CookieService cookieService;
     private final JwtEncoderService jwtEncoderService;
+    private final OidcRoleExtractor oidcRoleExtractor;
 
     public OAuth2CallbackController(
-            OidcClient oidcClient, CookieService cookieService, JwtEncoderService jwtEncoderService) {
+            OidcClient oidcClient,
+            CookieService cookieService,
+            JwtEncoderService jwtEncoderService,
+            OidcRoleExtractor oidcRoleExtractor) {
         this.oidcClient = oidcClient;
         this.cookieService = cookieService;
         this.jwtEncoderService = jwtEncoderService;
+        this.oidcRoleExtractor = oidcRoleExtractor;
     }
 
     @GetMapping(path = ApiPaths.OAuth2Api.CALLBACK)
@@ -74,11 +81,13 @@ public class OAuth2CallbackController {
             throw new BadRequestException("The authorization code is required");
         }
 
-        String oidcToken = oidcClient.exchangeCodeForIdToken(code);
+        Tokens tokens = oidcClient.exchangeCodeForTokens(code);
 
-        String username = oidcClient.validateOAuth2JwtTokenAndExtractUsername(oidcToken);
+        String username = oidcClient.validateIdTokenAndExtractUsername(tokens.idToken());
 
-        User user = new PasswordlessUser(username, Set.of(DefaultRole.ADMIN));
+        Role role = oidcRoleExtractor.extractRole(tokens);
+
+        User user = new PasswordlessUser(username, Set.of(role));
 
         String ourToken = jwtEncoderService.generateToken(user);
 

--- a/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/SecurityAutoConfiguration.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/SecurityAutoConfiguration.java
@@ -189,8 +189,7 @@ public class SecurityAutoConfiguration {
 
         @Bean
         public OidcRoleExtractor oidcRoleExtractor(OidcClient oidcClient, OAuth2Properties oAuth2Properties) {
-            return new OidcRoleExtractor(
-                    oidcClient, oAuth2Properties.roleAttributePath(), oAuth2Properties.roleMapping());
+            return new OidcRoleExtractor(oidcClient, oAuth2Properties.roleAttributePath());
         }
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/SecurityAutoConfiguration.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/SecurityAutoConfiguration.java
@@ -52,6 +52,7 @@ import com.axelixlabs.axelix.master.service.auth.MasterAuthorityResolver;
 import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcMetadataProvider;
+import com.axelixlabs.axelix.master.service.auth.oauth.OidcRoleExtractor;
 import com.axelixlabs.axelix.master.service.auth.provider.StaticAdminUserProvider;
 
 /**
@@ -184,6 +185,12 @@ public class SecurityAutoConfiguration {
         @Bean
         public OidcMetadataProvider oidcMetadataProvider(RestClient restClient, OAuth2Properties oAuth2Properties) {
             return new OidcMetadataProvider(restClient, oAuth2Properties.issuerUri());
+        }
+
+        @Bean
+        public OidcRoleExtractor oidcRoleExtractor(OidcClient oidcClient, OAuth2Properties oAuth2Properties) {
+            return new OidcRoleExtractor(
+                    oidcClient, oAuth2Properties.roleAttributePath(), oAuth2Properties.roleMapping());
         }
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/SecurityAutoConfiguration.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/SecurityAutoConfiguration.java
@@ -50,6 +50,7 @@ import com.axelixlabs.axelix.master.service.auth.CookieService;
 import com.axelixlabs.axelix.master.service.auth.DefaultCookieService;
 import com.axelixlabs.axelix.master.service.auth.MasterAuthorityResolver;
 import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient;
+import com.axelixlabs.axelix.master.service.auth.oauth.JmesPathOidcRoleExtractor;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcMetadataProvider;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcRoleExtractor;
@@ -189,7 +190,7 @@ public class SecurityAutoConfiguration {
 
         @Bean
         public OidcRoleExtractor oidcRoleExtractor(OidcClient oidcClient, OAuth2Properties oAuth2Properties) {
-            return new OidcRoleExtractor(oidcClient, oAuth2Properties.roleAttributePath());
+            return new JmesPathOidcRoleExtractor(oidcClient, oAuth2Properties.roleAttributePath());
         }
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/properties/OAuth2Properties.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/properties/OAuth2Properties.java
@@ -17,9 +17,6 @@
  */
 package com.axelixlabs.axelix.master.autoconfiguration.auth.properties;
 
-import java.util.List;
-import java.util.Map;
-
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -33,13 +30,23 @@ import static com.axelixlabs.axelix.master.autoconfiguration.auth.SecurityAutoCo
 /**
  * Configuration properties for OAuth2/OIDC authentication.
  *
- * @param issuerUri     the base URL of the OIDC provider. Used to discover endpoints
- *                      via {@code /.well-known/openid-configuration}
- * @param clientId      the client identifier issued during registration with the OIDC provider
- * @param clientSecret  the client secret issued during registration.
- * @param baseUrl       the base URL of this application.
- * @param usernameClaim the JWT claim to use as the username. If not specified,
- *                      falls back to {@code preferred_username}, then {@code name}, then {@code sub}
+ * @param issuerUri         the base URL of the OIDC provider. Used to discover endpoints
+ *                          via {@code /.well-known/openid-configuration}
+ *
+ * @param clientId          the client identifier issued during registration with the OIDC provider
+ *
+ * @param clientSecret      the client secret issued during registration.
+ *
+ * @param baseUrl           the base URL of this application.
+ *
+ * @param usernameClaim     the JWT claim to use as the username. If not specified,
+ *                          falls back to {@code preferred_username}, then {@code name}, then {@code sub}.
+ *
+ * @param scopes            OAuth2 scopes requested during authorization code flow.
+ *
+ * @param roleAttributePath JMESPath expression evaluated against the ID token claims first,
+ *                          and then against the userinfo endpoint response if needed. The expression
+ *                          should resolve to an Axelix role name like {@code admin} or {@code editor}
  *
  * @since 27.02.2026
  * @author Nikita Kirillov
@@ -53,12 +60,9 @@ public record OAuth2Properties(
         String baseUrl,
         @Nullable String usernameClaim,
         String scopes,
-        @Nullable String roleAttributePath,
-        Map<String, List<String>> roleMapping) {
+        @Nullable String roleAttributePath) {
 
     private static final String DEFAULT_SCOPE = "openid";
-    private static final Map<String, List<String>> DEFAULT_ROLE_MAPPING =
-            Map.of("admin", List.of("admin"), "editor", List.of("editor"));
 
     public OAuth2Properties {
         Assert.notNull(issuerUri, "OAuth2 issuer-uri is required. Set " + OAUTH_PROPERTIES_PREFIX + ".issuer-uri");
@@ -69,10 +73,6 @@ public record OAuth2Properties(
 
         if (scopes == null) {
             scopes = DEFAULT_SCOPE;
-        }
-
-        if (roleMapping == null) {
-            roleMapping = DEFAULT_ROLE_MAPPING;
         }
     }
 

--- a/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/properties/OAuth2Properties.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/properties/OAuth2Properties.java
@@ -17,10 +17,16 @@
  */
 package com.axelixlabs.axelix.master.autoconfiguration.auth.properties;
 
+import java.util.List;
+import java.util.Map;
+
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.Assert;
+
+import com.axelixlabs.axelix.master.api.external.ApiPaths;
+import com.axelixlabs.axelix.master.autoconfiguration.web.WebAutoConfiguration;
 
 import static com.axelixlabs.axelix.master.autoconfiguration.auth.SecurityAutoConfiguration.OAUTH_PROPERTIES_PREFIX;
 
@@ -31,7 +37,7 @@ import static com.axelixlabs.axelix.master.autoconfiguration.auth.SecurityAutoCo
  *                      via {@code /.well-known/openid-configuration}
  * @param clientId      the client identifier issued during registration with the OIDC provider
  * @param clientSecret  the client secret issued during registration.
- * @param redirectUri   the URI to redirect to after successful authentication.
+ * @param baseUrl       the base URL of this application.
  * @param usernameClaim the JWT claim to use as the username. If not specified,
  *                      falls back to {@code preferred_username}, then {@code name}, then {@code sub}
  *
@@ -44,22 +50,33 @@ public record OAuth2Properties(
         String issuerUri,
         String clientId,
         String clientSecret,
-        String redirectUri,
+        String baseUrl,
         @Nullable String usernameClaim,
-        String scopes) {
+        String scopes,
+        @Nullable String roleAttributePath,
+        Map<String, List<String>> roleMapping) {
 
     private static final String DEFAULT_SCOPE = "openid";
+    private static final Map<String, List<String>> DEFAULT_ROLE_MAPPING =
+            Map.of("admin", List.of("admin"), "editor", List.of("editor"));
 
     public OAuth2Properties {
         Assert.notNull(issuerUri, "OAuth2 issuer-uri is required. Set " + OAUTH_PROPERTIES_PREFIX + ".issuer-uri");
         Assert.notNull(clientId, "OAuth2 client-id is required. Set " + OAUTH_PROPERTIES_PREFIX + ".client-id");
         Assert.notNull(
                 clientSecret, "OAuth2 client-secret is required. Set " + OAUTH_PROPERTIES_PREFIX + ".client-secret");
-        Assert.notNull(
-                redirectUri, "OAuth2 redirect-uri is required. Set " + OAUTH_PROPERTIES_PREFIX + ".redirect-uri");
+        Assert.notNull(baseUrl, "OAuth2 base-url is required. Set " + OAUTH_PROPERTIES_PREFIX + ".base-url");
 
         if (scopes == null) {
             scopes = DEFAULT_SCOPE;
         }
+
+        if (roleMapping == null) {
+            roleMapping = DEFAULT_ROLE_MAPPING;
+        }
+    }
+
+    public String redirectUri() {
+        return baseUrl + WebAutoConfiguration.EXTERNAL_API_PATH + ApiPaths.OAuth2Api.CALLBACK;
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClient.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClient.java
@@ -29,11 +29,13 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.ObjectMapper;
 
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -85,7 +87,7 @@ public class DefaultOidcClient implements OidcClient {
      * @see <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.2.1">RFC 6749 Section 3.2.1 Client Authentication</a>
      */
     @Override
-    public String exchangeCodeForIdToken(String code) throws OidcTokenExchangeException {
+    public Tokens exchangeCodeForTokens(String code) throws OidcTokenExchangeException {
         try {
             MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
             body.add("grant_type", "authorization_code");
@@ -102,16 +104,7 @@ public class DefaultOidcClient implements OidcClient {
                     .retrieve()
                     .body(new ParameterizedTypeReference<>() {});
 
-            if (response == null) {
-                throw new OidcTokenExchangeException("OIDC token endpoint returned empty response");
-            }
-
-            Object idTokenObj = response.get("id_token");
-            if (!(idTokenObj instanceof String idToken)) {
-                throw new OidcTokenExchangeException("Invalid or missing id_token in response from OIDC provider");
-            }
-
-            return idToken;
+            return validateAndExtractTokens(response);
 
         } catch (OidcTokenExchangeException e) {
             throw e;
@@ -130,10 +123,10 @@ public class DefaultOidcClient implements OidcClient {
      * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation"> OpenID Connect Core 1.0 - ID Token Validation</a>
      */
     @Override
-    public String validateOAuth2JwtTokenAndExtractUsername(String token)
+    public String validateIdTokenAndExtractUsername(String idToken)
             throws ExpiredJwtTokenException, InvalidJwtTokenException, JwtParsingException {
         try {
-            String kid = extractPublicKeyId(token);
+            String kid = extractPublicKeyId(idToken);
             PublicKey publicKey = fetchPublicKey(kid);
 
             Claims claims = Jwts.parser()
@@ -141,7 +134,7 @@ public class DefaultOidcClient implements OidcClient {
                     .requireIssuer(oAuth2Properties.issuerUri())
                     .requireAudience(oAuth2Properties.clientId())
                     .build()
-                    .parseSignedClaims(token)
+                    .parseSignedClaims(idToken)
                     .getPayload();
 
             return extractUsername(claims);
@@ -153,6 +146,41 @@ public class DefaultOidcClient implements OidcClient {
         } catch (Exception e) {
             throw new JwtParsingException("Unexpected error while decoding OAuth2Jwt token", e);
         }
+    }
+
+    @Override
+    @Nullable
+    public String validateAccessTokenAndExtractUserInfo(String accessToken) throws OidcTokenExchangeException {
+        try {
+            String userInfoEndpoint = oidcMetadataProvider.getUserInfoEndpoint();
+
+            return restClient
+                    .get()
+                    .uri(userInfoEndpoint)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .body(String.class);
+
+        } catch (Exception e) {
+            throw new OidcTokenExchangeException(
+                    "Failed to validate access token via user_info endpoint: %s".formatted(e.getMessage()), e);
+        }
+    }
+
+    private Tokens validateAndExtractTokens(@Nullable Map<String, Object> response) {
+        if (response == null) {
+            throw new OidcTokenExchangeException("OIDC token endpoint returned empty response");
+        }
+
+        if (!(response.get("id_token") instanceof String idToken)) {
+            throw new OidcTokenExchangeException("Invalid or missing id_token in response from OIDC provider");
+        }
+
+        if (!(response.get("access_token") instanceof String accessToken)) {
+            throw new OidcTokenExchangeException("Invalid or missing access_token in response from OIDC provider");
+        }
+
+        return new Tokens(idToken, accessToken);
     }
 
     private String extractPublicKeyId(String token) {
@@ -244,4 +272,10 @@ public class DefaultOidcClient implements OidcClient {
 
         return claims.getSubject();
     }
+
+    /**
+     * @param idToken    the ID token (JWT) containing user identity claims
+     * @param accessToken the access token for accessing UserInfo endpoint and protected resources
+     */
+    public record Tokens(String idToken, String accessToken) {}
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClient.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClient.java
@@ -155,6 +155,7 @@ public class DefaultOidcClient implements OidcClient {
 
     @Override
     @Nullable
+    @SuppressWarnings({"PMD.CyclomaticComplexity"})
     public String validateAccessTokenAndExtractUserInfo(String accessToken)
             throws OidcTokenExchangeException, OidcMetadataUnavailableException {
 

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClient.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClient.java
@@ -181,10 +181,11 @@ public class DefaultOidcClient implements OidcClient {
                         "Failed to validate access token via user_info endpoint: %s".formatted(e.getMessage()), e);
             }
 
-            throw new OidcMetadataUnavailableException("Failed to decode the response from user_info OIDC endpoint");
+            throw new OidcMetadataUnavailableException("Failed to decode the response from user_info OIDC endpoint", e);
+        } catch (OidcMetadataUnavailableException e) {
+            throw e;
         } catch (Exception e) {
-
-            throw new OidcMetadataUnavailableException("Failed to decode the response from user_info OIDC endpoint");
+            throw new OidcMetadataUnavailableException("Failed to decode the response from user_info OIDC endpoint", e);
         }
     }
 

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClient.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClient.java
@@ -21,6 +21,7 @@ import java.security.PublicKey;
 import java.text.ParseException;
 import java.util.Base64;
 import java.util.Map;
+import java.util.Set;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWK;
@@ -36,15 +37,19 @@ import tools.jackson.databind.ObjectMapper;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
 import com.axelixlabs.axelix.common.auth.exception.ExpiredJwtTokenException;
 import com.axelixlabs.axelix.common.auth.exception.InvalidJwtTokenException;
 import com.axelixlabs.axelix.common.auth.exception.JwtParsingException;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.properties.OAuth2Properties;
+import com.axelixlabs.axelix.master.exception.auth.OidcMetadataUnavailableException;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
 
 /**
@@ -150,20 +155,36 @@ public class DefaultOidcClient implements OidcClient {
 
     @Override
     @Nullable
-    public String validateAccessTokenAndExtractUserInfo(String accessToken) throws OidcTokenExchangeException {
+    public String validateAccessTokenAndExtractUserInfo(String accessToken)
+            throws OidcTokenExchangeException, OidcMetadataUnavailableException {
+
         try {
             String userInfoEndpoint = oidcMetadataProvider.getUserInfoEndpoint();
 
-            return restClient
+            String userInfoBody = restClient
                     .get()
                     .uri(userInfoEndpoint)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                     .retrieve()
                     .body(String.class);
 
+            if (userInfoBody == null) {
+                throw new OidcMetadataUnavailableException(
+                        "Failed to decode the response from user_info OIDC endpoint");
+            }
+
+            return userInfoBody;
+        } catch (HttpClientErrorException e) {
+            if (Set.of((HttpStatusCode) HttpStatus.UNAUTHORIZED, HttpStatus.FORBIDDEN)
+                    .contains(e.getStatusCode())) {
+                throw new OidcTokenExchangeException(
+                        "Failed to validate access token via user_info endpoint: %s".formatted(e.getMessage()), e);
+            }
+
+            throw new OidcMetadataUnavailableException("Failed to decode the response from user_info OIDC endpoint");
         } catch (Exception e) {
-            throw new OidcTokenExchangeException(
-                    "Failed to validate access token via user_info endpoint: %s".formatted(e.getMessage()), e);
+
+            throw new OidcMetadataUnavailableException("Failed to decode the response from user_info OIDC endpoint");
         }
     }
 
@@ -272,10 +293,4 @@ public class DefaultOidcClient implements OidcClient {
 
         return claims.getSubject();
     }
-
-    /**
-     * @param idToken    the ID token (JWT) containing user identity claims
-     * @param accessToken the access token for accessing UserInfo endpoint and protected resources
-     */
-    public record Tokens(String idToken, String accessToken) {}
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractor.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractor.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.service.auth.oauth;
+
+import java.util.Base64;
+import java.util.Base64.Decoder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.burt.jmespath.Expression;
+import io.burt.jmespath.jackson.JacksonRuntime;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.axelixlabs.axelix.common.auth.core.DefaultRole;
+import com.axelixlabs.axelix.common.auth.core.Role;
+import com.axelixlabs.axelix.master.exception.auth.OidcMetadataUnavailableException;
+import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
+
+/**
+ * Extracts user role from OIDC tokens using a JMESPath expression.
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ */
+public class JmesPathOidcRoleExtractor implements OidcRoleExtractor {
+
+    private static final Logger log = LoggerFactory.getLogger(JmesPathOidcRoleExtractor.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Decoder decoder = Base64.getUrlDecoder();
+
+    @Nullable
+    private final Expression<JsonNode> jmesPathExpression;
+
+    private final OidcClient oidcClient;
+
+    public JmesPathOidcRoleExtractor(OidcClient oidcClient, @Nullable String roleAttributePath) {
+        this.oidcClient = oidcClient;
+
+        if (roleAttributePath != null && !roleAttributePath.isEmpty()) {
+            this.jmesPathExpression = new JacksonRuntime().compile(roleAttributePath);
+        } else {
+            this.jmesPathExpression = null;
+        }
+    }
+
+    /**
+     * First tries to evaluate the configured JMESPath expression against ID token claims,
+     * then evaluates it against the userInfo endpoint response if needed.
+     *
+     * @return extracted role, or DefaultRole.VIEWER (fallback).
+     */
+    @Override
+    public Role extractRole(Tokens tokens) {
+        if (jmesPathExpression == null) {
+            return DefaultRole.VIEWER;
+        }
+
+        Role role = extractRoleFromIdToken(tokens.idToken());
+
+        if (role == null) {
+            role = extractRoleFromUserInfo(tokens.accessToken());
+        }
+
+        return role != null ? role : DefaultRole.VIEWER;
+    }
+
+    @Nullable
+    private Role extractRoleFromIdToken(String idToken) {
+        try {
+            String json = decodeIdToken(idToken);
+            return extractRoleFromJson(json);
+        } catch (Exception e) {
+            log.debug("Failed to extract role from ID token: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    @Nullable
+    private Role extractRoleFromUserInfo(String accessToken) {
+        try {
+            String userInfo = oidcClient.validateAccessTokenAndExtractUserInfo(accessToken);
+
+            if (userInfo == null) {
+                return null;
+            }
+
+            return extractRoleFromJson(userInfo);
+        } catch (OidcTokenExchangeException | OidcMetadataUnavailableException e) {
+            log.debug("Failed to extract role from UserInfo: {}", e.getMessage());
+        }
+
+        return null;
+    }
+
+    @Nullable
+    private Role extractRoleFromJson(String json) {
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(json);
+            @SuppressWarnings("NullAway")
+            JsonNode evaluatedResult = jmesPathExpression.search(root);
+
+            if (evaluatedResult == null || evaluatedResult.isNull() || !evaluatedResult.isTextual()) {
+                return null;
+            }
+
+            return stringToRole(evaluatedResult.asText());
+        } catch (Exception e) {
+            log.warn("Failed to extract role from JSON: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private String decodeIdToken(String idToken) {
+        String[] parts = idToken.split("\\.");
+        byte[] decoded = decoder.decode(parts[1]);
+        return new String(decoded);
+    }
+
+    @Nullable
+    private Role stringToRole(String name) {
+        return switch (name.toLowerCase()) {
+            case "admin" -> DefaultRole.ADMIN;
+            case "editor" -> DefaultRole.EDITOR;
+            case "viewer" -> DefaultRole.VIEWER;
+            default -> null;
+        };
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcClient.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcClient.java
@@ -24,7 +24,6 @@ import com.axelixlabs.axelix.common.auth.exception.InvalidJwtTokenException;
 import com.axelixlabs.axelix.common.auth.exception.JwtProcessingException;
 import com.axelixlabs.axelix.master.exception.auth.OidcMetadataUnavailableException;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
-import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient.Tokens;
 
 /**
  * OIDC client for authorization code exchange and public key retrieval.

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcClient.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcClient.java
@@ -22,6 +22,7 @@ import org.jspecify.annotations.Nullable;
 import com.axelixlabs.axelix.common.auth.exception.ExpiredJwtTokenException;
 import com.axelixlabs.axelix.common.auth.exception.InvalidJwtTokenException;
 import com.axelixlabs.axelix.common.auth.exception.JwtProcessingException;
+import com.axelixlabs.axelix.master.exception.auth.OidcMetadataUnavailableException;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
 import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient.Tokens;
 
@@ -72,8 +73,8 @@ public interface OidcClient {
      *
      * @param accessToken access token to verify
      * @return userInfo json
-     * @throws OidcTokenExchangeException if the token is invalid, expired, malformed,
-     *                                    or the userinfo_endpoint is unavailable
+     * @throws OidcTokenExchangeException       if the token is invalid, expired or malformed
+     * @throws OidcMetadataUnavailableException if userinfo_endpoint is unavailable
      */
     @Nullable
     String validateAccessTokenAndExtractUserInfo(String accessToken) throws OidcTokenExchangeException;

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcClient.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcClient.java
@@ -17,10 +17,13 @@
  */
 package com.axelixlabs.axelix.master.service.auth.oauth;
 
+import org.jspecify.annotations.Nullable;
+
 import com.axelixlabs.axelix.common.auth.exception.ExpiredJwtTokenException;
 import com.axelixlabs.axelix.common.auth.exception.InvalidJwtTokenException;
 import com.axelixlabs.axelix.common.auth.exception.JwtProcessingException;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
+import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient.Tokens;
 
 /**
  * OIDC client for authorization code exchange and public key retrieval.
@@ -35,10 +38,10 @@ public interface OidcClient {
      * Authorization Code Flow as defined in RFC 6749 Section 4.1.3.
      *
      * @param code the authorization code received from the OIDC provider
-     * @return the ID Token string
+     * @return the Tokens object containing id token and access token
      * @throws OidcTokenExchangeException if the exchange fails or the response is invalid
      */
-    String exchangeCodeForIdToken(String code) throws OidcTokenExchangeException;
+    Tokens exchangeCodeForTokens(String code) throws OidcTokenExchangeException;
 
     /**
      * Validates the given OIDC ID Token and extracts the username from its claims.
@@ -51,12 +54,27 @@ public interface OidcClient {
      * @see <a href="https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation">
      *      OpenID Connect Core 1.0 - ID Token Validation</a>
      *
-     * @param token the OIDC ID Token to validate and process
+     * @param idToken the OIDC ID Token to validate and process
      * @return the extracted username
      * @throws ExpiredJwtTokenException if the token has expired
      * @throws InvalidJwtTokenException if the token signature is invalid or tampered
      * @throws JwtProcessingException   if the token cannot be parsed
      */
-    String validateOAuth2JwtTokenAndExtractUsername(String token)
+    String validateIdTokenAndExtractUsername(String idToken)
             throws ExpiredJwtTokenException, InvalidJwtTokenException, JwtProcessingException;
+
+    /**
+     * Verifies the given OAuth2 access token by calling the OIDC provider's userinfo_endpoint.
+     *
+     * <p><b>Note:</b> This method requires the provider to support the userinfo_endpoint,
+     * which is RECOMMENDED but not mandatory in OpenID Connect Discovery 1.0.
+     * If the endpoint is not available, a {@link OidcTokenExchangeException} will be thrown.</p>
+     *
+     * @param accessToken access token to verify
+     * @return userInfo json
+     * @throws OidcTokenExchangeException if the token is invalid, expired, malformed,
+     *                                    or the userinfo_endpoint is unavailable
+     */
+    @Nullable
+    String validateAccessTokenAndExtractUserInfo(String accessToken) throws OidcTokenExchangeException;
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcClient.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcClient.java
@@ -76,5 +76,6 @@ public interface OidcClient {
      * @throws OidcMetadataUnavailableException if userinfo_endpoint is unavailable
      */
     @Nullable
-    String validateAccessTokenAndExtractUserInfo(String accessToken) throws OidcTokenExchangeException;
+    String validateAccessTokenAndExtractUserInfo(String accessToken)
+            throws OidcTokenExchangeException, OidcMetadataUnavailableException;
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcMetadataProvider.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcMetadataProvider.java
@@ -74,6 +74,7 @@ public class OidcMetadataProvider {
         if (userInfoEndpoint != null) {
             return userInfoEndpoint;
         }
+
         throw new OidcMetadataUnavailableException("OIDC provider at " + issuerUri
                 + " does not provide a userinfo_endpoint. This endpoint is required for our authentication flow.");
     }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcMetadataProvider.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcMetadataProvider.java
@@ -68,6 +68,16 @@ public class OidcMetadataProvider {
         return oidcMetadata.require().authorizationEndpoint();
     }
 
+    public String getUserInfoEndpoint() {
+        String userInfoEndpoint = oidcMetadata.require().userInfoEndpoint();
+
+        if (userInfoEndpoint != null) {
+            return userInfoEndpoint;
+        }
+        throw new OidcMetadataUnavailableException("OIDC provider at " + issuerUri
+                + " does not provide a userinfo_endpoint. This endpoint is required for our authentication flow.");
+    }
+
     private OidcMetadata fetchOidcMetadata() {
         try {
             Map<String, Object> body = restClient
@@ -98,6 +108,7 @@ public class OidcMetadataProvider {
         String issuer = getStringValue(body, "issuer");
         String jwksUri = getStringValue(body, "jwks_uri");
         String tokenEndpoint = getStringValue(body, "token_endpoint");
+        String userInfoEndpoint = getStringValue(body, "userinfo_endpoint");
         String authorizationEndpoint = getStringValue(body, "authorization_endpoint");
 
         if (ObjectUtils.anyNull(issuer, jwksUri, tokenEndpoint, authorizationEndpoint)) {
@@ -112,12 +123,19 @@ public class OidcMetadataProvider {
             throw new OidcMetadataUnavailableException(issuerUri);
         }
 
+        if (userInfoEndpoint == null) {
+            log.warn(
+                    "OIDC provider at {} does not provide a userinfo_endpoint. "
+                            + "MCP server OAuth2 authentication via userinfo_endpoint will not be available.",
+                    issuerUri);
+        }
+
         if (!Objects.equals(issuer, issuerUri)) {
             log.error("OIDC issuer mismatch: expected '{}' but got '{}'", issuerUri, issuer);
             throw new OidcMetadataUnavailableException(issuerUri);
         }
 
-        return new OidcMetadata(jwksUri, tokenEndpoint, authorizationEndpoint);
+        return new OidcMetadata(jwksUri, tokenEndpoint, authorizationEndpoint, userInfoEndpoint);
     }
 
     @Nullable
@@ -132,6 +150,14 @@ public class OidcMetadataProvider {
      * @param jwksUri               URL of the OIDC provider's JWK Set, used to fetch public keys for token verification
      * @param tokenEndpoint         URL of the token endpoint, used to exchange the authorization code for an ID Token
      * @param authorizationEndpoint URL of the authorization endpoint, used to initiate the OAuth2 login flow.
+     * @param userInfoEndpoint      URL of the userinfo_endpoint, used to obtain claims about the authenticated user.
+     *                              This field is <b>OPTIONAL</b> per OpenID Connect Discovery 1.0 and may be {@code null}.
+     *
+     * See: <a href="https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata">OpenID Provider Metadata</a>
      */
-    public record OidcMetadata(String jwksUri, String tokenEndpoint, String authorizationEndpoint) {}
+    public record OidcMetadata(
+            String jwksUri,
+            String tokenEndpoint,
+            String authorizationEndpoint,
+            @Nullable String userInfoEndpoint) {}
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcRoleExtractor.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcRoleExtractor.java
@@ -19,27 +19,32 @@ package com.axelixlabs.axelix.master.service.auth.oauth;
 
 import java.util.Base64;
 import java.util.Base64.Decoder;
-import java.util.List;
-import java.util.Map;
 
-import com.jayway.jsonpath.JsonPath;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.burt.jmespath.Expression;
+import io.burt.jmespath.JmesPath;
+import io.burt.jmespath.jackson.JacksonRuntime;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.Role;
+import com.axelixlabs.axelix.master.exception.auth.OidcMetadataUnavailableException;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
 import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient.Tokens;
 
 /**
- * Extracts user role from OIDC tokens.
+ * Extracts user role from OIDC tokens using a JMESPath expression.
  *
  * @author Nikita Kirillov
  */
 public class OidcRoleExtractor {
 
     private static final Logger log = LoggerFactory.getLogger(OidcRoleExtractor.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final JmesPath<JsonNode> JMES_PATH = new JacksonRuntime();
 
     private final Decoder decoder = Base64.getUrlDecoder();
     private final OidcClient oidcClient;
@@ -47,18 +52,14 @@ public class OidcRoleExtractor {
     @Nullable
     private final String roleAttributePath;
 
-    private final Map<String, List<String>> roleMapping;
-
-    public OidcRoleExtractor(
-            OidcClient oidcClient, @Nullable String roleAttributePath, Map<String, List<String>> roleMapping) {
+    public OidcRoleExtractor(OidcClient oidcClient, @Nullable String roleAttributePath) {
         this.oidcClient = oidcClient;
         this.roleAttributePath = roleAttributePath;
-        this.roleMapping = roleMapping;
     }
 
     /**
-     * First we try to extract the role from the idToken,
-     * then we try to extract the role from the userInfo endpoint.
+     * First tries to evaluate the configured JMESPath expression against ID token claims,
+     * then evaluates it against the userInfo endpoint response if needed.
      *
      * @return extracted role, or DefaultRole.VIEWER (fallback).
      */
@@ -91,38 +92,30 @@ public class OidcRoleExtractor {
     private Role extractRoleFromUserInfo(String accessToken) {
         try {
             String userInfo = oidcClient.validateAccessTokenAndExtractUserInfo(accessToken);
+
             if (userInfo == null) {
                 return null;
             }
             return extractRoleFromJson(userInfo);
-        } catch (OidcTokenExchangeException e) {
+        } catch (OidcTokenExchangeException | OidcMetadataUnavailableException e) {
             log.debug("Failed to extract role from UserInfo: {}", e.getMessage());
         }
+
         return null;
     }
 
     @Nullable
     private Role extractRoleFromJson(String json) {
         try {
-            Object readData = JsonPath.read(json, roleAttributePath);
-            List<String> externalRoles = (readData instanceof List<?> list)
-                    ? list.stream().map(Object::toString).toList()
-                    : List.of(readData.toString());
+            JsonNode jsonNode = OBJECT_MAPPER.readTree(json);
+            Expression<JsonNode> expression = JMES_PATH.compile(roleAttributePath);
+            JsonNode jmesResult = expression.search(jsonNode);
 
-            for (String externalRole : externalRoles) {
-                String targetName = roleMapping.entrySet().stream()
-                        .filter(entry ->
-                                entry.getValue().stream().anyMatch(value -> value.equalsIgnoreCase(externalRole)))
-                        .map(Map.Entry::getKey)
-                        .findFirst()
-                        .orElse(externalRole);
-
-                Role role = stringToRole(targetName);
-
-                if (role != null) {
-                    return role;
-                }
+            if (jmesResult == null || jmesResult.isNull() || !jmesResult.isTextual()) {
+                return null;
             }
+
+            return stringToRole(jmesResult.asText());
         } catch (Exception e) {
             log.warn("Failed to extract role from JSON: {}", e.getMessage());
         }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcRoleExtractor.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcRoleExtractor.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.service.auth.oauth;
+
+import java.util.Base64;
+import java.util.Base64.Decoder;
+import java.util.List;
+import java.util.Map;
+
+import com.jayway.jsonpath.JsonPath;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.axelixlabs.axelix.common.auth.core.DefaultRole;
+import com.axelixlabs.axelix.common.auth.core.Role;
+import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
+import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient.Tokens;
+
+/**
+ * Extracts user role from OIDC tokens.
+ *
+ * @author Nikita Kirillov
+ */
+public class OidcRoleExtractor {
+
+    private static final Logger log = LoggerFactory.getLogger(OidcRoleExtractor.class);
+
+    private final Decoder decoder = Base64.getUrlDecoder();
+    private final OidcClient oidcClient;
+
+    @Nullable
+    private final String roleAttributePath;
+
+    private final Map<String, List<String>> roleMapping;
+
+    public OidcRoleExtractor(
+            OidcClient oidcClient, @Nullable String roleAttributePath, Map<String, List<String>> roleMapping) {
+        this.oidcClient = oidcClient;
+        this.roleAttributePath = roleAttributePath;
+        this.roleMapping = roleMapping;
+    }
+
+    /**
+     * First we try to extract the role from the idToken,
+     * then we try to extract the role from the userInfo endpoint.
+     *
+     * @return extracted role, or DefaultRole.VIEWER (fallback).
+     */
+    public Role extractRole(Tokens tokens) {
+        if (roleAttributePath == null || roleAttributePath.isBlank()) {
+            return DefaultRole.VIEWER;
+        }
+
+        Role role = extractRoleFromIdToken(tokens.idToken());
+
+        if (role == null) {
+            role = extractRoleFromUserInfo(tokens.accessToken());
+        }
+
+        return role != null ? role : DefaultRole.VIEWER;
+    }
+
+    @Nullable
+    private Role extractRoleFromIdToken(String idToken) {
+        try {
+            String json = decodeIdToken(idToken);
+            return extractRoleFromJson(json);
+        } catch (Exception e) {
+            log.debug("Failed to extract role from ID token: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    @Nullable
+    private Role extractRoleFromUserInfo(String accessToken) {
+        try {
+            String userInfo = oidcClient.validateAccessTokenAndExtractUserInfo(accessToken);
+            if (userInfo == null) {
+                return null;
+            }
+            return extractRoleFromJson(userInfo);
+        } catch (OidcTokenExchangeException e) {
+            log.debug("Failed to extract role from UserInfo: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    @Nullable
+    private Role extractRoleFromJson(String json) {
+        try {
+            Object readData = JsonPath.read(json, roleAttributePath);
+            List<String> externalRoles = (readData instanceof List<?> list)
+                    ? list.stream().map(Object::toString).toList()
+                    : List.of(readData.toString());
+
+            for (String externalRole : externalRoles) {
+                String targetName = roleMapping.entrySet().stream()
+                        .filter(entry ->
+                                entry.getValue().stream().anyMatch(value -> value.equalsIgnoreCase(externalRole)))
+                        .map(Map.Entry::getKey)
+                        .findFirst()
+                        .orElse(externalRole);
+
+                Role role = stringToRole(targetName);
+
+                if (role != null) {
+                    return role;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to extract role from JSON: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private String decodeIdToken(String idToken) {
+        String[] parts = idToken.split("\\.");
+        byte[] decoded = decoder.decode(parts[1]);
+        return new String(decoded);
+    }
+
+    @Nullable
+    private Role stringToRole(String name) {
+        return switch (name.toLowerCase()) {
+            case "admin" -> DefaultRole.ADMIN;
+            case "editor" -> DefaultRole.EDITOR;
+            default -> null;
+        };
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/Tokens.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/Tokens.java
@@ -17,20 +17,13 @@
  */
 package com.axelixlabs.axelix.master.service.auth.oauth;
 
-import com.axelixlabs.axelix.common.auth.core.Role;
-
 /**
- * The component that is capable to extract the role that belongs to current user based on the pair of {@link Tokens}.
+ * The pair of tokens that we care about in OIDC flow.
  *
+ * @param idToken     the ID token (JWT) containing user identity claims.
+ * @param accessToken the access token for accessing UserInfo endpoint and protected resources.
+ *
+ * @author Nikita Kirillov
  * @author Mikhail Polivakha
  */
-public interface OidcRoleExtractor {
-
-    /**
-     * Determine the {@link Role} of the user identified by the {@link Tokens provided tokens pair}.
-     *
-     * @param tokens the pair of tokens.
-     * @return the role that is extracted. Never {@code null}.
-     */
-    Role extractRole(Tokens tokens);
-}
+public record Tokens(String idToken, String accessToken) {}

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/package-info.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package com.axelixlabs.axelix.master.service.auth.oauth;
+
+import org.jspecify.annotations.NullMarked;

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/OAuth2CallbackControllerTest.java
@@ -40,6 +40,7 @@ import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
 import com.axelixlabs.axelix.master.api.external.endpoint.OAuth2CallbackController;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
 import com.axelixlabs.axelix.master.service.auth.CookieService;
+import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,13 +60,14 @@ import static org.mockito.Mockito.when;
             "axelix.master.auth.options.oauth2.issuer-uri=http://placeholder.will.be.overridden",
             "axelix.master.auth.options.oauth2.client-id=test-client",
             "axelix.master.auth.options.oauth2.client-secret=test-secret",
-            "axelix.master.auth.options.oauth2.redirect-uri=http://localhost:3000/api/external/oauth2/callback"
+            "axelix.master.auth.options.oauth2.base-url=http://localhost:3000",
+            "axelix.master.auth.options.oauth2.role-attribute-path=\"$.roles[*]\""
         })
-@TestPropertySource(properties = "axelix.master.auth.static-admin.enabled=true")
 class OAuth2CallbackControllerTest {
 
     private static final String CODE = "test-code";
     private static final String ID_TOKEN = "test-id-token";
+    private static final String ACCESS_TOKEN = "test-access-token";
     private static final String USERNAME = "test-user";
     private static final String OUR_JWT_TOKEN = "our-jwt-token";
     private static final String AUTHORITIES = "authorities_of_role";
@@ -86,7 +88,7 @@ class OAuth2CallbackControllerTest {
 
     @BeforeEach
     void prepare() {
-        ResponseCookie authCookie = ResponseCookie.from("auth-token", OUR_JWT_TOKEN)
+        ResponseCookie authCookie = ResponseCookie.from("auth_token", OUR_JWT_TOKEN)
                 .path("/")
                 .httpOnly(true)
                 .build();
@@ -96,8 +98,8 @@ class OAuth2CallbackControllerTest {
 
         restTemplate = new TestRestTemplate(new RestTemplateBuilder().redirects(HttpRedirects.DONT_FOLLOW));
 
-        when(oidcClient.exchangeCodeForIdToken(CODE)).thenReturn(ID_TOKEN);
-        when(oidcClient.validateOAuth2JwtTokenAndExtractUsername(ID_TOKEN)).thenReturn(USERNAME);
+        when(oidcClient.exchangeCodeForTokens(CODE)).thenReturn(new DefaultOidcClient.Tokens(ID_TOKEN, ACCESS_TOKEN));
+        when(oidcClient.validateIdTokenAndExtractUsername(ID_TOKEN)).thenReturn(USERNAME);
         when(jwtEncoderService.generateToken(any())).thenReturn(OUR_JWT_TOKEN);
         when(cookieService.buildAuthCookie(OUR_JWT_TOKEN)).thenReturn(authCookie);
         when(cookieService.buildAuthoritiesMetadataCookie(any(Set.class))).thenReturn(authoritiesMetadataCookie);
@@ -112,7 +114,7 @@ class OAuth2CallbackControllerTest {
         assertThat(response.getHeaders().getLocation()).hasToString("/wallboard");
 
         List<String> cookies = response.getHeaders().get(HttpHeaders.SET_COOKIE);
-        assertThat(cookies).anyMatch(c -> c.contains("auth-token=" + OUR_JWT_TOKEN));
+        assertThat(cookies).anyMatch(c -> c.contains("auth_token=" + OUR_JWT_TOKEN));
         assertThat(cookies).anyMatch(c -> c.contains("authorities=" + AUTHORITIES));
     }
 
@@ -126,7 +128,7 @@ class OAuth2CallbackControllerTest {
 
     @Test
     void shouldReturn401WhenCodeExchangeFails() {
-        when(oidcClient.exchangeCodeForIdToken(CODE)).thenThrow(new OidcTokenExchangeException("exchange failed"));
+        when(oidcClient.exchangeCodeForTokens(CODE)).thenThrow(new OidcTokenExchangeException("exchange failed"));
 
         ResponseEntity<Void> response = restTemplate.getForEntity(
                 "http://localhost:" + port + "/api/external/oauth2/callback?code=" + CODE, Void.class);
@@ -136,7 +138,7 @@ class OAuth2CallbackControllerTest {
 
     @Test
     void shouldReturn401WhenTokenValidationFails() {
-        when(oidcClient.validateOAuth2JwtTokenAndExtractUsername(ID_TOKEN))
+        when(oidcClient.validateIdTokenAndExtractUsername(ID_TOKEN))
                 .thenThrow(new InvalidJwtTokenException("invalid token"));
 
         ResponseEntity<Void> response = restTemplate.getForEntity(

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/OAuth2CallbackControllerTest.java
@@ -20,7 +20,6 @@ package com.axelixlabs.axelix.master.api;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.axelixlabs.axelix.master.service.auth.oauth.OidcRoleExtractor;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,8 +44,8 @@ import com.axelixlabs.axelix.common.auth.exception.InvalidJwtTokenException;
 import com.axelixlabs.axelix.common.auth.service.JwtDecoderService;
 import com.axelixlabs.axelix.master.api.external.endpoint.OAuth2CallbackController;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
-import com.axelixlabs.axelix.master.service.auth.oauth.JmesPathOidcRoleExtractor;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
+import com.axelixlabs.axelix.master.service.auth.oauth.OidcRoleExtractor;
 import com.axelixlabs.axelix.master.service.auth.oauth.Tokens;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/OAuth2CallbackControllerTest.java
@@ -18,11 +18,13 @@
 package com.axelixlabs.axelix.master.api;
 
 import java.util.List;
-import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.http.client.HttpRedirects;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -30,21 +32,23 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import com.axelixlabs.axelix.common.auth.core.Authority;
+import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
+import com.axelixlabs.axelix.common.auth.core.DefaultRole;
+import com.axelixlabs.axelix.common.auth.core.PasswordlessUser;
 import com.axelixlabs.axelix.common.auth.exception.InvalidJwtTokenException;
-import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
+import com.axelixlabs.axelix.common.auth.service.JwtDecoderService;
 import com.axelixlabs.axelix.master.api.external.endpoint.OAuth2CallbackController;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
-import com.axelixlabs.axelix.master.service.auth.CookieService;
-import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient;
+import com.axelixlabs.axelix.master.service.auth.oauth.JmesPathOidcRoleExtractor;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
+import com.axelixlabs.axelix.master.service.auth.oauth.Tokens;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**
@@ -52,6 +56,7 @@ import static org.mockito.Mockito.when;
  *
  * @since 06.03.2026
  * @author Nikita Kirillov
+ * @author Mikhail Polivakha
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(
@@ -67,10 +72,6 @@ class OAuth2CallbackControllerTest {
 
     private static final String CODE = "test-code";
     private static final String ID_TOKEN = "test-id-token";
-    private static final String ACCESS_TOKEN = "test-access-token";
-    private static final String USERNAME = "test-user";
-    private static final String OUR_JWT_TOKEN = "our-jwt-token";
-    private static final String AUTHORITIES = "authorities_of_role";
 
     @LocalServerPort
     private int port;
@@ -81,45 +82,65 @@ class OAuth2CallbackControllerTest {
     private OidcClient oidcClient;
 
     @MockitoBean
-    private CookieService cookieService;
+    private JmesPathOidcRoleExtractor oidcRoleExtractor;
 
-    @MockitoBean
-    private JwtEncoderService jwtEncoderService;
+    @Autowired
+    private JwtDecoderService jwtDecoderService;
 
     @BeforeEach
     void prepare() {
-        ResponseCookie authCookie = ResponseCookie.from("auth_token", OUR_JWT_TOKEN)
-                .path("/")
-                .httpOnly(true)
-                .build();
-
-        ResponseCookie authoritiesMetadataCookie =
-                ResponseCookie.from("authorities", AUTHORITIES).path("/").build();
-
         restTemplate = new TestRestTemplate(new RestTemplateBuilder().redirects(HttpRedirects.DONT_FOLLOW));
-
-        when(oidcClient.exchangeCodeForTokens(CODE)).thenReturn(new DefaultOidcClient.Tokens(ID_TOKEN, ACCESS_TOKEN));
-        when(oidcClient.validateIdTokenAndExtractUsername(ID_TOKEN)).thenReturn(USERNAME);
-        when(jwtEncoderService.generateToken(any())).thenReturn(OUR_JWT_TOKEN);
-        when(cookieService.buildAuthCookie(OUR_JWT_TOKEN)).thenReturn(authCookie);
-        when(cookieService.buildAuthoritiesMetadataCookie(any(Set.class))).thenReturn(authoritiesMetadataCookie);
     }
 
     @Test
-    void shouldRedirectToWallboardWithCookieOnSuccess() {
+    void happyPath() {
+        // given.
+        String username = "test-user";
+        var tokens = new Tokens(ID_TOKEN, "access-token");
+
+        // and.
+        when(oidcClient.exchangeCodeForTokens(CODE)).thenReturn(tokens);
+        when(oidcClient.validateIdTokenAndExtractUsername(ID_TOKEN)).thenReturn(username);
+        when(oidcRoleExtractor.extractRole(tokens)).thenReturn(DefaultRole.EDITOR);
+
+        // when.
         ResponseEntity<Void> response = restTemplate.getForEntity(
                 "http://localhost:" + port + "/api/external/oauth2/callback?code=" + CODE, Void.class);
 
+        // then.
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
         assertThat(response.getHeaders().getLocation()).hasToString("/wallboard");
 
         List<String> cookies = response.getHeaders().get(HttpHeaders.SET_COOKIE);
-        assertThat(cookies).anyMatch(c -> c.contains("auth_token=" + OUR_JWT_TOKEN));
-        assertThat(cookies).anyMatch(c -> c.contains("authorities=" + AUTHORITIES));
+
+        String authTokenCookie = findCookie(cookies, "auth_token");
+        String authoritiesCookie = findCookie(cookies, "authorities");
+
+        PasswordlessUser decodedTokenToUser = jwtDecoderService.decodeTokenToUser(
+                // trying to extract an actual token from the cookie value
+                authTokenCookie.substring(authTokenCookie.indexOf("=") + 1, authTokenCookie.indexOf(";")));
+
+        assertThat(decodedTokenToUser.getUsername()).isEqualTo(username);
+        assertThat(decodedTokenToUser.getRoles()).hasSize(1).first().isEqualTo(DefaultRole.EDITOR);
+
+        assertThat(
+                        // trying to extract an actual token from the cookie value
+                        authoritiesCookie.substring(authoritiesCookie.indexOf("=") + 1, authoritiesCookie.indexOf(";")))
+                .isBase64()
+                .asBase64Decoded()
+                .asString()
+                .contains(DefaultRole.EDITOR.getAuthorities().stream()
+                        .map(Authority::getName)
+                        .collect(Collectors.toSet()));
+
+        assertThat(authoritiesCookie)
+                .doesNotContain(
+                        DefaultAuthority.ENV_VALUES_READ.getName(),
+                        DefaultAuthority.CONFIG_PROPS_VALUES_READ.getName());
     }
 
     @Test
-    void shouldReturn500WhenCodeParamMissing() {
+    void shouldReturn400WhenCodeParamMissing() {
         ResponseEntity<Void> response =
                 restTemplate.getForEntity("http://localhost:" + port + "/api/external/oauth2/callback", Void.class);
 
@@ -137,7 +158,8 @@ class OAuth2CallbackControllerTest {
     }
 
     @Test
-    void shouldReturn401WhenTokenValidationFails() {
+    void shouldReturn401WhenIdTokenValidationFails() {
+        when(oidcClient.exchangeCodeForTokens(CODE)).thenReturn(new Tokens(ID_TOKEN, "access-token"));
         when(oidcClient.validateIdTokenAndExtractUsername(ID_TOKEN))
                 .thenThrow(new InvalidJwtTokenException("invalid token"));
 
@@ -145,5 +167,9 @@ class OAuth2CallbackControllerTest {
                 "http://localhost:" + port + "/api/external/oauth2/callback?code=" + CODE, Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    private static @NonNull String findCookie(List<String> cookies, String s) {
+        return cookies.stream().filter(it -> it.contains(s)).findFirst().orElseThrow();
     }
 }

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/OAuth2CallbackControllerTest.java
@@ -18,7 +18,6 @@
 package com.axelixlabs.axelix.master.api;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,7 +65,7 @@ import static org.mockito.Mockito.when;
             "axelix.master.auth.options.oauth2.client-id=test-client",
             "axelix.master.auth.options.oauth2.client-secret=test-secret",
             "axelix.master.auth.options.oauth2.base-url=http://localhost:3000",
-            "axelix.master.auth.options.oauth2.role-attribute-path=\"$.roles[*]\""
+            "axelix.master.auth.options.oauth2.role-attribute-path=roles[0]"
         })
 class OAuth2CallbackControllerTest {
 
@@ -123,15 +122,17 @@ class OAuth2CallbackControllerTest {
         assertThat(decodedTokenToUser.getUsername()).isEqualTo(username);
         assertThat(decodedTokenToUser.getRoles()).hasSize(1).first().isEqualTo(DefaultRole.EDITOR);
 
-        assertThat(
+        String decodedAuthorities = assertThat(
                         // trying to extract an actual token from the cookie value
                         authoritiesCookie.substring(authoritiesCookie.indexOf("=") + 1, authoritiesCookie.indexOf(";")))
                 .isBase64()
                 .asBase64Decoded()
                 .asString()
-                .contains(DefaultRole.EDITOR.getAuthorities().stream()
-                        .map(Authority::getName)
-                        .collect(Collectors.toSet()));
+                .actual();
+
+        DefaultRole.EDITOR.getAuthorities().stream()
+                .map(Authority::getName)
+                .forEach(name -> assertThat(decodedAuthorities).contains(name));
 
         assertThat(authoritiesCookie)
                 .doesNotContain(

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/OAuth2CallbackControllerTest.java
@@ -20,6 +20,7 @@ package com.axelixlabs.axelix.master.api;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.axelixlabs.axelix.master.service.auth.oauth.OidcRoleExtractor;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -82,7 +83,7 @@ class OAuth2CallbackControllerTest {
     private OidcClient oidcClient;
 
     @MockitoBean
-    private JmesPathOidcRoleExtractor oidcRoleExtractor;
+    private OidcRoleExtractor oidcRoleExtractor;
 
     @Autowired
     private JwtDecoderService jwtDecoderService;

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/SettingsApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/SettingsApiTest.java
@@ -109,7 +109,7 @@ class SettingsApiTest {
                 "axelix.master.auth.options.oauth2.issuer-uri=http://placeholder.will.be.overridden",
                 "axelix.master.auth.options.oauth2.client-id=test-client",
                 "axelix.master.auth.options.oauth2.client-secret=test-secret",
-                "axelix.master.auth.options.oauth2.redirect-uri=http://localhost:3000/api/external/oauth2/callback"
+                "axelix.master.auth.options.oauth2.base-url=http://localhost:3000"
             })
     @Nested
     class WhenOAuth2Enabled {
@@ -164,7 +164,7 @@ class SettingsApiTest {
                 "axelix.master.auth.options.oauth2.issuer-uri=http://placeholder.will.be.overridden",
                 "axelix.master.auth.options.oauth2.client-id=test-client",
                 "axelix.master.auth.options.oauth2.client-secret=test-secret",
-                "axelix.master.auth.options.oauth2.redirect-uri=http://localhost:3000/api/external/oauth2/callback"
+                "axelix.master.auth.options.oauth2.base-url=http://localhost:3000"
             })
     @Nested
     class WhenStaticAdminAndOAuth2Enabled {

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClientTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClientTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.Curve;
@@ -60,6 +61,7 @@ import com.axelixlabs.axelix.common.auth.exception.InvalidJwtTokenException;
 import com.axelixlabs.axelix.common.auth.exception.JwtParsingException;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.properties.OAuth2Properties;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
+import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient.Tokens;
 import com.axelixlabs.axelix.master.utils.TestResourceReader;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -105,14 +107,15 @@ class DefaultOidcClientTest {
 
     @BeforeEach
     void prepare() {
-        String baseUrl = mockWebServer.url("").toString();
+        String issuerUri = mockWebServer.url("").toString();
 
         OAuth2Properties oAuth2Properties =
-                new OAuth2Properties(baseUrl, CLIENT_ID, CLIENT_SECRET, baseUrl + "/oauth2/callback", null, null);
+                new OAuth2Properties(issuerUri, CLIENT_ID, CLIENT_SECRET, issuerUri, null, null, null, null);
 
         OidcMetadataProvider oidcMetadataProvider = mock(OidcMetadataProvider.class);
-        when(oidcMetadataProvider.getTokenEndpoint()).thenReturn(baseUrl + "/token");
-        when(oidcMetadataProvider.getJwksUri()).thenReturn(baseUrl + "/certs");
+        when(oidcMetadataProvider.getTokenEndpoint()).thenReturn(issuerUri + "/token");
+        when(oidcMetadataProvider.getJwksUri()).thenReturn(issuerUri + "/certs");
+        when(oidcMetadataProvider.getUserInfoEndpoint()).thenReturn(issuerUri + "/userinfo");
 
         oidcClient = new DefaultOidcClient(
                 RestClient.builder().build(), oAuth2Properties, oidcMetadataProvider, new ObjectMapper());
@@ -137,17 +140,22 @@ class DefaultOidcClientTest {
         });
 
         // when.
-        String data = oidcClient.exchangeCodeForIdToken(AUTH_CODE);
+        Tokens data = oidcClient.exchangeCodeForTokens(AUTH_CODE);
 
         // then.
         String idToken =
                 new ObjectMapper().readTree(jsonResponse).get("id_token").asString();
-        assertThat(data).isEqualTo(idToken);
+        assertThat(data.idToken()).isEqualTo(idToken);
+
+        // and then.
+        String accessToken =
+                new ObjectMapper().readTree(jsonResponse).get("access_token").asString();
+        assertThat(data.accessToken()).isEqualTo(accessToken);
 
         // and then.
         RecordedRequest tokenRequest = mockWebServer.takeRequest();
         Map<String, String> formParams = parseFormBody(tokenRequest.getBody().readUtf8());
-        String expectedRedirectUri = mockWebServer.url("") + "/oauth2/callback";
+        String expectedRedirectUri = mockWebServer.url("") + "/api/external/oauth2/callback";
 
         assertThat(formParams)
                 .containsEntry("grant_type", "authorization_code")
@@ -178,7 +186,7 @@ class DefaultOidcClientTest {
         });
 
         // when/then
-        assertThatThrownBy(() -> oidcClient.exchangeCodeForIdToken(AUTH_CODE))
+        assertThatThrownBy(() -> oidcClient.exchangeCodeForTokens(AUTH_CODE))
                 .isInstanceOf(OidcTokenExchangeException.class);
     }
 
@@ -190,7 +198,7 @@ class DefaultOidcClientTest {
             setupJwksDispatcher();
             String token = buildIdToken(RSA_KEY_ID, rsaKey.toPrivateKey(), "preferred-user", null);
 
-            String result = oidcClient.validateOAuth2JwtTokenAndExtractUsername(token);
+            String result = oidcClient.validateIdTokenAndExtractUsername(token);
 
             assertThat(result).isEqualTo("preferred-user");
         }
@@ -200,7 +208,7 @@ class DefaultOidcClientTest {
             setupJwksDispatcher();
             String token = buildIdToken(EC_KEY_ID, ecKey.toPrivateKey(), "ec-user", null);
 
-            String result = oidcClient.validateOAuth2JwtTokenAndExtractUsername(token);
+            String result = oidcClient.validateIdTokenAndExtractUsername(token);
 
             assertThat(result).isEqualTo("ec-user");
         }
@@ -211,7 +219,7 @@ class DefaultOidcClientTest {
             String subject = UUID.randomUUID().toString();
             String token = buildIdToken(RSA_KEY_ID, rsaKey.toPrivateKey(), null, subject);
 
-            String result = oidcClient.validateOAuth2JwtTokenAndExtractUsername(token);
+            String result = oidcClient.validateIdTokenAndExtractUsername(token);
 
             assertThat(result).isEqualTo(subject);
         }
@@ -221,7 +229,7 @@ class DefaultOidcClientTest {
             setupJwksDispatcher();
             String token = buildExpiredToken();
 
-            assertThatThrownBy(() -> oidcClient.validateOAuth2JwtTokenAndExtractUsername(token))
+            assertThatThrownBy(() -> oidcClient.validateIdTokenAndExtractUsername(token))
                     .isInstanceOf(ExpiredJwtTokenException.class);
         }
 
@@ -233,7 +241,7 @@ class DefaultOidcClientTest {
             String token = buildIdToken(RSA_KEY_ID, differentRsaKey.toPrivateKey(), "user", null);
 
             // when/then.
-            assertThatThrownBy(() -> oidcClient.validateOAuth2JwtTokenAndExtractUsername(token))
+            assertThatThrownBy(() -> oidcClient.validateIdTokenAndExtractUsername(token))
                     .isInstanceOf(InvalidJwtTokenException.class);
         }
 
@@ -244,7 +252,7 @@ class DefaultOidcClientTest {
             String token = buildIdToken("unknown-key-id", rsaKey.toPrivateKey(), "user", null);
 
             // when/then.
-            assertThatThrownBy(() -> oidcClient.validateOAuth2JwtTokenAndExtractUsername(token))
+            assertThatThrownBy(() -> oidcClient.validateIdTokenAndExtractUsername(token))
                     .isInstanceOf(JwtParsingException.class);
         }
 
@@ -304,6 +312,65 @@ class DefaultOidcClientTest {
                     .expiration(Date.from(past.plus(Duration.ofMinutes(1))))
                     .signWith(rsaKey.toPrivateKey())
                     .compact();
+        }
+    }
+
+    @Nested
+    class AccessTokenValidation {
+
+        @BeforeEach
+        void drainStaleRecordedRequests() throws InterruptedException {
+            while (mockWebServer.takeRequest(1, TimeUnit.MILLISECONDS) != null) {
+                // Clear recorded requests.
+                // Other test do not always consume MockWebServer's recorded requests.
+            }
+        }
+
+        @Test
+        void shouldCompleteWhenUserInfoReturnsOk() throws Exception {
+            String accessToken = "test-access-token";
+
+            String jsonResponse = TestResourceReader.readResource("other/user-info-response.json");
+
+            mockWebServer.setDispatcher(new Dispatcher() {
+                @Override
+                public @NonNull MockResponse dispatch(@NonNull RecordedRequest request) {
+                    if ("/userinfo".equals(request.getPath()) && "GET".equals(request.getMethod())) {
+                        String auth = request.getHeader(HttpHeaders.AUTHORIZATION);
+                        if (("Bearer " + accessToken).equals(auth)) {
+                            return new MockResponse()
+                                    .setBody(jsonResponse)
+                                    .addHeader("Content-Type", APPLICATION_JSON_VALUE)
+                                    .setResponseCode(200);
+                        }
+                    }
+                    return new MockResponse().setResponseCode(404);
+                }
+            });
+
+            String userInfoJson = oidcClient.validateAccessTokenAndExtractUserInfo(accessToken);
+
+            assertThat(userInfoJson).isEqualTo(jsonResponse);
+            RecordedRequest userInfoRequest = mockWebServer.takeRequest();
+            assertThat(userInfoRequest.getPath()).isEqualTo("/userinfo");
+            assertThat(userInfoRequest.getMethod()).isEqualTo("GET");
+            assertThat(userInfoRequest.getHeader(HttpHeaders.AUTHORIZATION)).isEqualTo("Bearer " + accessToken);
+        }
+
+        @Test
+        void shouldThrowWhenUserInfoReturnsUnauthorized() {
+            mockWebServer.setDispatcher(new Dispatcher() {
+                @Override
+                public @NonNull MockResponse dispatch(@NonNull RecordedRequest request) {
+                    if ("/userinfo".equals(request.getPath()) && "GET".equals(request.getMethod())) {
+                        return new MockResponse().setResponseCode(401);
+                    }
+                    return new MockResponse().setResponseCode(404);
+                }
+            });
+
+            assertThatThrownBy(() -> oidcClient.validateAccessTokenAndExtractUserInfo("invalid-token"))
+                    .isInstanceOf(OidcTokenExchangeException.class);
         }
     }
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClientTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClientTest.java
@@ -110,7 +110,7 @@ class DefaultOidcClientTest {
         String issuerUri = mockWebServer.url("").toString();
 
         OAuth2Properties oAuth2Properties =
-                new OAuth2Properties(issuerUri, CLIENT_ID, CLIENT_SECRET, issuerUri, null, null, null, null);
+                new OAuth2Properties(issuerUri, CLIENT_ID, CLIENT_SECRET, issuerUri, null, null, null);
 
         OidcMetadataProvider oidcMetadataProvider = mock(OidcMetadataProvider.class);
         when(oidcMetadataProvider.getTokenEndpoint()).thenReturn(issuerUri + "/token");

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClientTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClientTest.java
@@ -60,8 +60,8 @@ import com.axelixlabs.axelix.common.auth.exception.ExpiredJwtTokenException;
 import com.axelixlabs.axelix.common.auth.exception.InvalidJwtTokenException;
 import com.axelixlabs.axelix.common.auth.exception.JwtParsingException;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.properties.OAuth2Properties;
+import com.axelixlabs.axelix.master.exception.auth.OidcMetadataUnavailableException;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
-import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient.Tokens;
 import com.axelixlabs.axelix.master.utils.TestResourceReader;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -358,7 +358,7 @@ class DefaultOidcClientTest {
         }
 
         @Test
-        void shouldThrowWhenUserInfoReturnsUnauthorized() {
+        void shouldThrowTokenExchangeExceptionWhenUserInfoReturnsUnauthorized() {
             mockWebServer.setDispatcher(new Dispatcher() {
                 @Override
                 public @NonNull MockResponse dispatch(@NonNull RecordedRequest request) {
@@ -371,6 +371,20 @@ class DefaultOidcClientTest {
 
             assertThatThrownBy(() -> oidcClient.validateAccessTokenAndExtractUserInfo("invalid-token"))
                     .isInstanceOf(OidcTokenExchangeException.class);
+        }
+
+        @Test
+        void shouldThrowOidcMetadataUnavailableExceptionWhenUserInfoReturnsUnauthorized() {
+
+            mockWebServer.setDispatcher(new Dispatcher() {
+                @Override
+                public @NonNull MockResponse dispatch(@NonNull RecordedRequest request) {
+                    return new MockResponse().setResponseCode(404);
+                }
+            });
+
+            assertThatThrownBy(() -> oidcClient.validateAccessTokenAndExtractUserInfo("invalid-token"))
+                    .isInstanceOf(OidcMetadataUnavailableException.class);
         }
     }
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClientTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClientTest.java
@@ -374,7 +374,7 @@ class DefaultOidcClientTest {
         }
 
         @Test
-        void shouldThrowOidcMetadataUnavailableExceptionWhenUserInfoReturnsUnauthorized() {
+        void shouldThrowOidcMetadataUnavailableExceptionWhenUserInfoReturnsNotFound() {
 
             mockWebServer.setDispatcher(new Dispatcher() {
                 @Override

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractorTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractorTest.java
@@ -17,18 +17,14 @@
  */
 package com.axelixlabs.axelix.master.service.auth.oauth;
 
-import java.lang.reflect.Method;
 import java.util.Base64;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.Role;
@@ -36,6 +32,7 @@ import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
 import com.axelixlabs.axelix.master.utils.TestResourceReader;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.of;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -49,340 +46,136 @@ import static org.mockito.Mockito.when;
  */
 class JmesPathOidcRoleExtractorTest {
 
-    private OidcClient MOCK_OIDC_CLIENT;
+    private OidcClient oidcClient;
 
     @BeforeEach
     void setUp() {
-        MOCK_OIDC_CLIENT = mock(OidcClient.class);
+        oidcClient = mock(OidcClient.class);
     }
 
-    @Nested
-    class ExtractRoleIntegrationTest {
-
-        private static final String ID_TOKEN =
-                "header." + Base64.getUrlEncoder().encodeToString("""
+    @Test
+    void shouldExtractRoleFromIdTokenWhenPresent() {
+        // given.
+        Tokens tokens = tokens("""
         {
             "roles": ["admin", "offline_access"]
         }
-        """.getBytes()) + ".signature";
+        """);
+        JmesPathOidcRoleExtractor extractor = new JmesPathOidcRoleExtractor(oidcClient, "roles[0]");
 
-        private static final String ACCESS_TOKEN = "test-access-token";
-        private static final String USER_INFO_JSON = TestResourceReader.readResource("other/user-info-response.json");
+        // when.
+        Role role = extractor.extractRole(tokens);
 
-        private JmesPathOidcRoleExtractor extractor;
-
-        @Test
-        void shouldExtractRoleFromIdTokenWhenPresent() {
-            Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
-
-            Role role = extractor.extractRole(tokens);
-
-            assertThat(role).isEqualTo(DefaultRole.ADMIN);
-            verify(MOCK_OIDC_CLIENT, never()).validateAccessTokenAndExtractUserInfo(anyString());
-        }
-
-        @Test
-        void shouldFallbackToUserInfoWhenIdTokenHasNoRole() {
-            String idTokenWithoutRoles = "header."
-                    + Base64.getUrlEncoder().encodeToString("{\"sub\": \"user123\"}".getBytes()) + ".signature";
-            Tokens tokens = new Tokens(idTokenWithoutRoles, ACCESS_TOKEN);
-
-            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
-                    .thenReturn(USER_INFO_JSON);
-
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
-
-            Role role = extractor.extractRole(tokens);
-
-            assertThat(role).isEqualTo(DefaultRole.ADMIN);
-            verify(MOCK_OIDC_CLIENT).validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN);
-        }
-
-        @Test
-        void shouldFallbackToUserInfoWhenIdTokenExtractionFails() {
-            String invalidIdToken = "invalid.token.format";
-            Tokens tokens = new Tokens(invalidIdToken, ACCESS_TOKEN);
-
-            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
-                    .thenReturn(USER_INFO_JSON);
-
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
-
-            Role role = extractor.extractRole(tokens);
-
-            assertThat(role).isEqualTo(DefaultRole.ADMIN);
-            verify(MOCK_OIDC_CLIENT).validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN);
-        }
-
-        @Test
-        void shouldReturnViewerWhenBothSourcesFail() {
-            String invalidIdToken = "invalid.token.format";
-            Tokens tokens = new Tokens(invalidIdToken, ACCESS_TOKEN);
-
-            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
-                    .thenThrow(new OidcTokenExchangeException("UserInfo endpoint failed"));
-
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
-
-            Role role = extractor.extractRole(tokens);
-
-            assertThat(role).isEqualTo(DefaultRole.VIEWER);
-        }
-
-        @Test
-        void shouldReturnViewerWhenNoRoleFoundInBothSources() {
-            String idTokenWithoutRoles = "header."
-                    + Base64.getUrlEncoder().encodeToString("{\"sub\": \"user123\"}".getBytes()) + ".signature";
-            String userInfoWithoutRoles = """
-            {
-                "sub": "user123",
-                "name": "Test User"
-            }
-            """;
-
-            Tokens tokens = new Tokens(idTokenWithoutRoles, ACCESS_TOKEN);
-
-            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
-                    .thenReturn(userInfoWithoutRoles);
-
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
-
-            Role role = extractor.extractRole(tokens);
-
-            assertThat(role).isEqualTo(DefaultRole.VIEWER);
-        }
-
-        @Test
-        void shouldExtractEditorRoleFromUserInfo() {
-            String idTokenWithoutRoles =
-                    "header." + Base64.getUrlEncoder().encodeToString("{}".getBytes()) + ".signature";
-            String userInfoWithEditor = """
-            {
-                "roles": ["editor", "viewer"]
-            }
-            """;
-
-            Tokens tokens = new Tokens(idTokenWithoutRoles, ACCESS_TOKEN);
-
-            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
-                    .thenReturn(userInfoWithEditor);
-
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
-
-            Role role = extractor.extractRole(tokens);
-
-            assertThat(role).isEqualTo(DefaultRole.EDITOR);
-        }
-
-        @Test
-        void shouldReturnViewerWhenRoleAttributePathIsBlank() {
-            Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
-
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "");
-
-            Role role = extractor.extractRole(tokens);
-
-            assertThat(role).isEqualTo(DefaultRole.VIEWER);
-            verify(MOCK_OIDC_CLIENT, never()).validateAccessTokenAndExtractUserInfo(anyString());
-        }
-
-        @Test
-        void shouldReturnViewerWhenRoleAttributePathIsNull() {
-            Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
-
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, null);
-
-            Role role = extractor.extractRole(tokens);
-
-            assertThat(role).isEqualTo(DefaultRole.VIEWER);
-            verify(MOCK_OIDC_CLIENT, never()).validateAccessTokenAndExtractUserInfo(anyString());
-        }
-
-        @Test
-        void shouldExtractFromUserInfoWhenIdTokenHasNullRole() {
-            String idTokenWithNullRole =
-                    "header." + Base64.getUrlEncoder().encodeToString("{\"roles\": null}".getBytes()) + ".signature";
-            Tokens tokens = new Tokens(idTokenWithNullRole, ACCESS_TOKEN);
-
-            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
-                    .thenReturn(USER_INFO_JSON);
-
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
-
-            Role role = extractor.extractRole(tokens);
-
-            assertThat(role).isEqualTo(DefaultRole.ADMIN);
-            verify(MOCK_OIDC_CLIENT).validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN);
-        }
-
-        @Test
-        void shouldUseFirstMatchingRoleFromArray() {
-            String idTokenWithMultipleRoles = "header."
-                    + Base64.getUrlEncoder()
-                            .encodeToString("{\"roles\": [\"viewer\", \"editor\", \"admin\"]}".getBytes())
-                    + ".signature";
-            Tokens tokens = new Tokens(idTokenWithMultipleRoles, ACCESS_TOKEN);
-
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
-
-            Role role = extractor.extractRole(tokens);
-
-            assertThat(role).isEqualTo(DefaultRole.VIEWER);
-        }
+        // then.
+        assertThat(role).isEqualTo(DefaultRole.ADMIN);
+        verify(oidcClient, never()).validateAccessTokenAndExtractUserInfo(anyString());
     }
 
-    /**
-     * Unit tests for {@link JmesPathOidcRoleExtractor#extractRoleFromJson(String json)}
-     *
-     * @author Nikita Kirillov
-     */
-    @Nested
-    class ExtractRoleFromJsonPrivateMethodTest {
+    @Test
+    void shouldFallbackToUserInfoWhenRoleMissingInIdToken() {
+        // given.
+        Tokens tokens = tokens("""
+            { "sub" : "user123" }
+            """);
+        String userInfoJson = TestResourceReader.readResource("other/user-info-response.json");
+        when(oidcClient.validateAccessTokenAndExtractUserInfo(tokens.accessToken()))
+                .thenReturn(userInfoJson);
+        JmesPathOidcRoleExtractor extractor = new JmesPathOidcRoleExtractor(oidcClient, "roles[0]");
 
-        private Method extractRoleFromJsonMethod;
-        private JmesPathOidcRoleExtractor extractor;
+        // when.
+        Role role = extractor.extractRole(tokens);
 
-        @BeforeEach
-        void setUp() throws NoSuchMethodException {
-            extractRoleFromJsonMethod =
-                    JmesPathOidcRoleExtractor.class.getDeclaredMethod("extractRoleFromJson", String.class);
-            extractRoleFromJsonMethod.setAccessible(true);
-        }
+        // then.
+        assertThat(role).isEqualTo(DefaultRole.ADMIN);
+        verify(oidcClient).validateAccessTokenAndExtractUserInfo(tokens.accessToken());
+    }
 
-        @ParameterizedTest
-        @NullAndEmptySource
-        @ValueSource(strings = {"", "   ", "\t", "\n", "  \t  "})
-        void shouldReturnNullWhenRoleAttributePathIsBlank(String path) throws Exception {
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, path);
+    @MethodSource(value = "absentRoleAttributePath")
+    @ParameterizedTest
+    void shouldReturnViewerWhenExpressionIsNotSpecified(String roleAttributePath) {
+        // given.
+        Tokens tokens = tokens("""
+            { "roles" : ["admin"] }
+            """);
+        JmesPathOidcRoleExtractor extractor = new JmesPathOidcRoleExtractor(oidcClient, roleAttributePath);
 
-            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"admin\"}");
+        // when.
+        Role role = extractor.extractRole(tokens);
 
-            assertThat(role).isNull();
-        }
+        // then.
+        assertThat(role).isEqualTo(DefaultRole.VIEWER);
+        verify(oidcClient, never()).validateAccessTokenAndExtractUserInfo(anyString());
+    }
 
-        @ParameterizedTest
-        @MethodSource("provideJsonAndExpectedRole")
-        void shouldExtractCorrectRoleFromJson(String json, String roleAttributePath, DefaultRole expectedRole)
-                throws Exception {
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, roleAttributePath);
+    @Test
+    void shouldReturnViewerWhenBothSourcesDoNotProvideRole() {
+        // given.
+        Tokens tokens = tokens("""
+            { "sub" : "user123" }
+            """);
+        when(oidcClient.validateAccessTokenAndExtractUserInfo(tokens.accessToken()))
+                .thenReturn("""
+            { "name" : "Test" }
+            """);
+        JmesPathOidcRoleExtractor extractor = new JmesPathOidcRoleExtractor(oidcClient, "roles[0]");
 
-            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
+        // when.
+        Role role = extractor.extractRole(tokens);
 
-            assertThat(role).as("JSON: %s, Path: %s", json, roleAttributePath).isEqualTo(expectedRole);
-        }
+        // then.
+        assertThat(role).isEqualTo(DefaultRole.VIEWER);
+    }
 
-        private static Stream<Arguments> provideJsonAndExpectedRole() {
-            return Stream.of(
-                    // Basic role extraction
-                    Arguments.of("{\"role\": \"admin\"}", "role", DefaultRole.ADMIN),
-                    Arguments.of("{\"role\": \"editor\"}", "role", DefaultRole.EDITOR),
-                    Arguments.of("{\"role\": \"viewer\"}", "role", null),
-                    Arguments.of("{\"role\": \"unknown\"}", "role", null),
+    @Test
+    void shouldExtractEditorFromUserInfo() {
+        // given.
+        Tokens tokens = tokens("{}");
+        when(oidcClient.validateAccessTokenAndExtractUserInfo(tokens.accessToken()))
+                .thenReturn(
+                        // language=json
+                        """
+                    {
+                        "data": [
+                            {
+                                "roles": ["viewer", "editor"]
+                            }
+                        ]
+                    }""");
+        JmesPathOidcRoleExtractor extractor = new JmesPathOidcRoleExtractor(oidcClient, "data[0].roles[1]");
 
-                    // Nested paths
-                    Arguments.of("{\"user\": {\"access\": \"admin\"}}", "user.access", DefaultRole.ADMIN),
-                    Arguments.of(
-                            "{\"data\": {\"info\": {\"level\": \"editor\"}}}", "data.info.level", DefaultRole.EDITOR),
+        // when.
+        Role role = extractor.extractRole(tokens);
 
-                    // Array handling
-                    Arguments.of("{\"roles\": [\"admin\", \"user\"]}", "roles[0]", DefaultRole.ADMIN),
-                    Arguments.of("{\"roles\": [\"viewer\", \"editor\"]}", "roles[1]", DefaultRole.EDITOR),
-                    Arguments.of("{\"roles\": [\"guest\", \"user\"]}", "roles[0]", null),
-                    Arguments.of("{\"roles\": [\"editor\"]}", "roles[0]", DefaultRole.EDITOR),
+        // then.
+        assertThat(role).isEqualTo(DefaultRole.EDITOR);
+    }
 
-                    // Case insensitivity
-                    Arguments.of("{\"role\": \"ADMIN\"}", "role", DefaultRole.ADMIN),
-                    Arguments.of("{\"role\": \"Admin\"}", "role", DefaultRole.ADMIN),
-                    Arguments.of("{\"role\": \"EDITOR\"}", "role", DefaultRole.EDITOR),
-                    Arguments.of("{\"role\": \"EdItOr\"}", "role", DefaultRole.EDITOR),
-                    Arguments.of("{\"role\": \"ViEwEr\"}", "role", null));
-        }
+    @Test
+    void shouldReturnViewerWhenUserInfoRequestFails() {
+        // given.
+        Tokens tokens = new Tokens("invalid.token.format", "test-access-token");
 
-        @ParameterizedTest
-        @MethodSource("provideEdgeCaseJson")
-        void shouldHandleEdgeCasesGracefully(String json, String path, DefaultRole expectedRole) throws Exception {
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, path);
+        when(oidcClient.validateAccessTokenAndExtractUserInfo(tokens.accessToken()))
+                .thenThrow(new OidcTokenExchangeException("userinfo failed"));
 
-            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
+        JmesPathOidcRoleExtractor extractor = new JmesPathOidcRoleExtractor(oidcClient, "roles[0]");
 
-            assertThat(role).as("JSON: %s, Path: %s", json, path).isEqualTo(expectedRole);
-        }
+        // when.
+        Role role = extractor.extractRole(tokens);
 
-        private static Stream<Arguments> provideEdgeCaseJson() {
-            return Stream.of(
-                    Arguments.of("{}", "role", null),
-                    Arguments.of("{\"role\": null}", "role", null),
-                    Arguments.of("{\"role\": 1}", "role", null),
-                    Arguments.of("{\"role\": true}", "role", null),
-                    Arguments.of("{\"roles\": []}", "roles[0]", null),
-                    Arguments.of("{invalid json}", "role", null),
-                    Arguments.of("plain string", "role", null),
-                    Arguments.of("{\"user\": \"admin\"}", "role", null),
-                    Arguments.of("{\"data\": {\"value\": \"admin\"}}", "role", null));
-        }
+        // then.
+        assertThat(role).isEqualTo(DefaultRole.VIEWER);
+    }
 
-        @Test
-        void shouldHandleDeeplyNestedArrays() throws Exception {
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "data[0].users[1].roles[0]");
+    private Tokens tokens(String idTokenPayloadJson) {
+        // header and signature are also supposed to be base64 encoded, but we're not really interested in them in this
+        // test clas
+        String idToken =
+                "header." + Base64.getUrlEncoder().encodeToString(idTokenPayloadJson.getBytes()) + ".signature";
+        return new Tokens(idToken, "test-access-token");
+    }
 
-            String json = """
-                {
-                    "data": [
-                        {
-                            "users": [
-                                {"name": "user1", "roles": ["viewer"]},
-                                {"name": "user2", "roles": ["admin", "editor"]}
-                            ]
-                        }
-                    ]
-                }
-                """;
-
-            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
-            assertThat(role).isEqualTo(DefaultRole.ADMIN);
-        }
-
-        @ParameterizedTest
-        @MethodSource("provideDifferentPathFormats")
-        void shouldHandleDifferentJmesPathFormats(String path, String json, DefaultRole expectedRole) throws Exception {
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, path);
-
-            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
-
-            assertThat(role).as("Path: %s should extract correct role", path).isEqualTo(expectedRole);
-        }
-
-        private static Stream<Arguments> provideDifferentPathFormats() {
-            return Stream.of(
-                    Arguments.of("data.role", "{\"data\": {\"role\": \"admin\"}}", DefaultRole.ADMIN),
-                    Arguments.of("roles[0]", "{\"roles\": [\"admin\", \"editor\"]}", DefaultRole.ADMIN),
-                    Arguments.of("roles[1]", "{\"roles\": [\"admin\", \"editor\"]}", DefaultRole.EDITOR),
-                    Arguments.of("roles | [0]", "{\"roles\": [\"editor\", \"admin\"]}", DefaultRole.EDITOR),
-                    Arguments.of(
-                            "user.info.role", "{\"user\": {\"info\": {\"role\": \"editor\"}}}", DefaultRole.EDITOR),
-                    Arguments.of(
-                            "data[0].roles[1]",
-                            "{\"data\": [{\"roles\": [\"viewer\", \"admin\"]}]}",
-                            DefaultRole.ADMIN));
-        }
-
-        @Test
-        void shouldReturnNullWhenPathDoesNotExist() throws Exception {
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "nonexistent");
-
-            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"admin\"}");
-
-            assertThat(role).isNull();
-        }
-
-        @Test
-        void shouldReturnNullWhenJsonIsNull() throws Exception {
-            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "role");
-
-            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, (Object) null);
-
-            assertThat(role).isNull();
-        }
+    static Stream<Arguments> absentRoleAttributePath() {
+        return Stream.of(of(new Object[] {null}), of(""));
     }
 }

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractorTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractorTest.java
@@ -169,7 +169,7 @@ class JmesPathOidcRoleExtractorTest {
 
     private Tokens tokens(String idTokenPayloadJson) {
         // header and signature are also supposed to be base64 encoded, but we're not really interested in them in this
-        // test clas
+        // test class
         String idToken =
                 "header." + Base64.getUrlEncoder().encodeToString(idTokenPayloadJson.getBytes()) + ".signature";
         return new Tokens(idToken, "test-access-token");

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractorTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractorTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
-import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient.Tokens;
 import com.axelixlabs.axelix.master.utils.TestResourceReader;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,11 +43,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for {@link OidcRoleExtractor}
+ * Tests for {@link JmesPathOidcRoleExtractor}
  *
  * @author Nikita Kirillov
  */
-class OidcRoleExtractorTest {
+class JmesPathOidcRoleExtractorTest {
 
     private OidcClient MOCK_OIDC_CLIENT;
 
@@ -70,12 +69,12 @@ class OidcRoleExtractorTest {
         private static final String ACCESS_TOKEN = "test-access-token";
         private static final String USER_INFO_JSON = TestResourceReader.readResource("other/user-info-response.json");
 
-        private OidcRoleExtractor extractor;
+        private JmesPathOidcRoleExtractor extractor;
 
         @Test
         void shouldExtractRoleFromIdTokenWhenPresent() {
             Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -92,7 +91,7 @@ class OidcRoleExtractorTest {
             when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                     .thenReturn(USER_INFO_JSON);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -108,7 +107,7 @@ class OidcRoleExtractorTest {
             when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                     .thenReturn(USER_INFO_JSON);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -124,7 +123,7 @@ class OidcRoleExtractorTest {
             when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                     .thenThrow(new OidcTokenExchangeException("UserInfo endpoint failed"));
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -147,7 +146,7 @@ class OidcRoleExtractorTest {
             when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                     .thenReturn(userInfoWithoutRoles);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -169,7 +168,7 @@ class OidcRoleExtractorTest {
             when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                     .thenReturn(userInfoWithEditor);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -180,7 +179,7 @@ class OidcRoleExtractorTest {
         void shouldReturnViewerWhenRoleAttributePathIsBlank() {
             Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "");
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "");
 
             Role role = extractor.extractRole(tokens);
 
@@ -192,7 +191,7 @@ class OidcRoleExtractorTest {
         void shouldReturnViewerWhenRoleAttributePathIsNull() {
             Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, null);
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, null);
 
             Role role = extractor.extractRole(tokens);
 
@@ -209,7 +208,7 @@ class OidcRoleExtractorTest {
             when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                     .thenReturn(USER_INFO_JSON);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -225,7 +224,7 @@ class OidcRoleExtractorTest {
                     + ".signature";
             Tokens tokens = new Tokens(idTokenWithMultipleRoles, ACCESS_TOKEN);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -234,7 +233,7 @@ class OidcRoleExtractorTest {
     }
 
     /**
-     * Unit tests for {@link OidcRoleExtractor#extractRoleFromJson(String json)}
+     * Unit tests for {@link JmesPathOidcRoleExtractor#extractRoleFromJson(String json)}
      *
      * @author Nikita Kirillov
      */
@@ -242,11 +241,12 @@ class OidcRoleExtractorTest {
     class ExtractRoleFromJsonPrivateMethodTest {
 
         private Method extractRoleFromJsonMethod;
-        private OidcRoleExtractor extractor;
+        private JmesPathOidcRoleExtractor extractor;
 
         @BeforeEach
         void setUp() throws NoSuchMethodException {
-            extractRoleFromJsonMethod = OidcRoleExtractor.class.getDeclaredMethod("extractRoleFromJson", String.class);
+            extractRoleFromJsonMethod =
+                    JmesPathOidcRoleExtractor.class.getDeclaredMethod("extractRoleFromJson", String.class);
             extractRoleFromJsonMethod.setAccessible(true);
         }
 
@@ -254,7 +254,7 @@ class OidcRoleExtractorTest {
         @NullAndEmptySource
         @ValueSource(strings = {"", "   ", "\t", "\n", "  \t  "})
         void shouldReturnNullWhenRoleAttributePathIsBlank(String path) throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, path);
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, path);
 
             Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"admin\"}");
 
@@ -265,7 +265,7 @@ class OidcRoleExtractorTest {
         @MethodSource("provideJsonAndExpectedRole")
         void shouldExtractCorrectRoleFromJson(String json, String roleAttributePath, DefaultRole expectedRole)
                 throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, roleAttributePath);
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, roleAttributePath);
 
             Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
 
@@ -283,9 +283,7 @@ class OidcRoleExtractorTest {
                     // Nested paths
                     Arguments.of("{\"user\": {\"access\": \"admin\"}}", "user.access", DefaultRole.ADMIN),
                     Arguments.of(
-                            "{\"data\": {\"info\": {\"level\": \"editor\"}}}",
-                            "data.info.level",
-                            DefaultRole.EDITOR),
+                            "{\"data\": {\"info\": {\"level\": \"editor\"}}}", "data.info.level", DefaultRole.EDITOR),
 
                     // Array handling
                     Arguments.of("{\"roles\": [\"admin\", \"user\"]}", "roles[0]", DefaultRole.ADMIN),
@@ -304,7 +302,7 @@ class OidcRoleExtractorTest {
         @ParameterizedTest
         @MethodSource("provideEdgeCaseJson")
         void shouldHandleEdgeCasesGracefully(String json, String path, DefaultRole expectedRole) throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, path);
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, path);
 
             Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
 
@@ -326,7 +324,7 @@ class OidcRoleExtractorTest {
 
         @Test
         void shouldHandleDeeplyNestedArrays() throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "data[0].users[1].roles[0]");
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "data[0].users[1].roles[0]");
 
             String json = """
                 {
@@ -348,7 +346,7 @@ class OidcRoleExtractorTest {
         @ParameterizedTest
         @MethodSource("provideDifferentPathFormats")
         void shouldHandleDifferentJmesPathFormats(String path, String json, DefaultRole expectedRole) throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, path);
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, path);
 
             Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
 
@@ -371,7 +369,7 @@ class OidcRoleExtractorTest {
 
         @Test
         void shouldReturnNullWhenPathDoesNotExist() throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "nonexistent");
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "nonexistent");
 
             Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"admin\"}");
 
@@ -380,7 +378,7 @@ class OidcRoleExtractorTest {
 
         @Test
         void shouldReturnNullWhenJsonIsNull() throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "role");
+            extractor = new JmesPathOidcRoleExtractor(MOCK_OIDC_CLIENT, "role");
 
             Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, (Object) null);
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcRoleExtractorTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcRoleExtractorTest.java
@@ -19,8 +19,6 @@ package com.axelixlabs.axelix.master.service.auth.oauth;
 
 import java.lang.reflect.Method;
 import java.util.Base64;
-import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -77,7 +75,7 @@ class OidcRoleExtractorTest {
         @Test
         void shouldExtractRoleFromIdTokenWhenPresent() {
             Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -94,7 +92,7 @@ class OidcRoleExtractorTest {
             when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                     .thenReturn(USER_INFO_JSON);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -110,7 +108,7 @@ class OidcRoleExtractorTest {
             when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                     .thenReturn(USER_INFO_JSON);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -126,7 +124,7 @@ class OidcRoleExtractorTest {
             when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                     .thenThrow(new OidcTokenExchangeException("UserInfo endpoint failed"));
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -149,48 +147,11 @@ class OidcRoleExtractorTest {
             when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                     .thenReturn(userInfoWithoutRoles);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
             assertThat(role).isEqualTo(DefaultRole.VIEWER);
-        }
-
-        @Test
-        void shouldApplyRoleMappingFromIdToken() {
-            Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
-            Map<String, List<String>> roleMapping = Map.of(
-                    "admin", List.of("super_admin", "root"),
-                    "editor", List.of("writer"));
-
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", roleMapping);
-
-            Role role = extractor.extractRole(tokens);
-
-            assertThat(role).isEqualTo(DefaultRole.ADMIN);
-        }
-
-        @Test
-        void shouldApplyRoleMappingFromUserInfoWhenIdTokenHasNoRole() {
-            String idTokenWithoutRoles = "header."
-                    + Base64.getUrlEncoder().encodeToString("{\"sub\": \"user123\"}".getBytes()) + ".signature";
-            String userInfoWithMappedRole = """
-            {
-                "role": "super_admin"
-            }
-            """;
-
-            Tokens tokens = new Tokens(idTokenWithoutRoles, ACCESS_TOKEN);
-
-            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
-                    .thenReturn(userInfoWithMappedRole);
-
-            Map<String, List<String>> roleMapping = Map.of("admin", List.of("super_admin", "root"));
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.role", roleMapping);
-
-            Role role = extractor.extractRole(tokens);
-
-            assertThat(role).isEqualTo(DefaultRole.ADMIN);
         }
 
         @Test
@@ -208,7 +169,7 @@ class OidcRoleExtractorTest {
             when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                     .thenReturn(userInfoWithEditor);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -219,7 +180,7 @@ class OidcRoleExtractorTest {
         void shouldReturnViewerWhenRoleAttributePathIsBlank() {
             Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "", Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "");
 
             Role role = extractor.extractRole(tokens);
 
@@ -231,7 +192,7 @@ class OidcRoleExtractorTest {
         void shouldReturnViewerWhenRoleAttributePathIsNull() {
             Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, null, Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, null);
 
             Role role = extractor.extractRole(tokens);
 
@@ -248,7 +209,7 @@ class OidcRoleExtractorTest {
             when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                     .thenReturn(USER_INFO_JSON);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -264,7 +225,7 @@ class OidcRoleExtractorTest {
                     + ".signature";
             Tokens tokens = new Tokens(idTokenWithMultipleRoles, ACCESS_TOKEN);
 
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles[0]", Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "roles[0]");
 
             Role role = extractor.extractRole(tokens);
 
@@ -293,7 +254,7 @@ class OidcRoleExtractorTest {
         @NullAndEmptySource
         @ValueSource(strings = {"", "   ", "\t", "\n", "  \t  "})
         void shouldReturnNullWhenRoleAttributePathIsBlank(String path) throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, path, Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, path);
 
             Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"admin\"}");
 
@@ -302,10 +263,9 @@ class OidcRoleExtractorTest {
 
         @ParameterizedTest
         @MethodSource("provideJsonAndExpectedRole")
-        void shouldExtractCorrectRoleFromJson(
-                String json, String roleAttributePath, Map<String, List<String>> roleMapping, DefaultRole expectedRole)
+        void shouldExtractCorrectRoleFromJson(String json, String roleAttributePath, DefaultRole expectedRole)
                 throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, roleAttributePath, roleMapping);
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, roleAttributePath);
 
             Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
 
@@ -315,85 +275,36 @@ class OidcRoleExtractorTest {
         private static Stream<Arguments> provideJsonAndExpectedRole() {
             return Stream.of(
                     // Basic role extraction
-                    Arguments.of("{\"role\": \"admin\"}", "$.role", Map.of(), DefaultRole.ADMIN),
-                    Arguments.of("{\"role\": \"editor\"}", "$.role", Map.of(), DefaultRole.EDITOR),
-                    Arguments.of("{\"role\": \"viewer\"}", "$.role", Map.of(), null),
-                    Arguments.of("{\"role\": \"unknown\"}", "$.role", Map.of(), null),
+                    Arguments.of("{\"role\": \"admin\"}", "role", DefaultRole.ADMIN),
+                    Arguments.of("{\"role\": \"editor\"}", "role", DefaultRole.EDITOR),
+                    Arguments.of("{\"role\": \"viewer\"}", "role", null),
+                    Arguments.of("{\"role\": \"unknown\"}", "role", null),
 
                     // Nested paths
-                    Arguments.of("{\"user\": {\"access\": \"admin\"}}", "$.user.access", Map.of(), DefaultRole.ADMIN),
+                    Arguments.of("{\"user\": {\"access\": \"admin\"}}", "user.access", DefaultRole.ADMIN),
                     Arguments.of(
                             "{\"data\": {\"info\": {\"level\": \"editor\"}}}",
-                            "$.data.info.level",
-                            Map.of(),
+                            "data.info.level",
                             DefaultRole.EDITOR),
 
                     // Array handling
-                    Arguments.of("{\"roles\": [\"admin\", \"user\"]}", "$.roles", Map.of(), DefaultRole.ADMIN),
-                    Arguments.of("{\"roles\": [\"viewer\", \"editor\"]}", "$.roles", Map.of(), DefaultRole.EDITOR),
-                    Arguments.of("{\"roles\": [\"guest\", \"user\"]}", "$.roles", Map.of(), null),
-                    Arguments.of("{\"roles\": [\"editor\"]}", "$.roles", Map.of(), DefaultRole.EDITOR),
+                    Arguments.of("{\"roles\": [\"admin\", \"user\"]}", "roles[0]", DefaultRole.ADMIN),
+                    Arguments.of("{\"roles\": [\"viewer\", \"editor\"]}", "roles[1]", DefaultRole.EDITOR),
+                    Arguments.of("{\"roles\": [\"guest\", \"user\"]}", "roles[0]", null),
+                    Arguments.of("{\"roles\": [\"editor\"]}", "roles[0]", DefaultRole.EDITOR),
 
                     // Case insensitivity
-                    Arguments.of("{\"role\": \"ADMIN\"}", "$.role", Map.of(), DefaultRole.ADMIN),
-                    Arguments.of("{\"role\": \"Admin\"}", "$.role", Map.of(), DefaultRole.ADMIN),
-                    Arguments.of("{\"role\": \"EDITOR\"}", "$.role", Map.of(), DefaultRole.EDITOR),
-                    Arguments.of("{\"role\": \"EdItOr\"}", "$.role", Map.of(), DefaultRole.EDITOR),
-                    Arguments.of("{\"role\": \"ViEwEr\"}", "$.role", Map.of(), null),
-
-                    // Role mapping
-                    Arguments.of(
-                            "{\"role\": \"superuser\"}",
-                            "$.role",
-                            Map.of("admin", List.of("superuser", "root")),
-                            DefaultRole.ADMIN),
-                    Arguments.of(
-                            "{\"role\": \"power_user\"}",
-                            "$.role",
-                            Map.of("editor", List.of("power_user", "content_creator")),
-                            DefaultRole.EDITOR),
-                    Arguments.of(
-                            "{\"role\": \"SUPERUSER\"}",
-                            "$.role",
-                            Map.of("admin", List.of("superuser", "root")),
-                            DefaultRole.ADMIN),
-                    Arguments.of("{\"role\": \"unknown\"}", "$.role", Map.of("admin", List.of("superuser")), null),
-                    Arguments.of(
-                            "{\"role\": \"editor\"}",
-                            "$.role",
-                            Map.of("admin", List.of("superuser")),
-                            DefaultRole.EDITOR));
-        }
-
-        @ParameterizedTest
-        @MethodSource("provideRoleMappingWithMultipleValues")
-        void shouldApplyRoleMappingWithMultipleValues(
-                String json, Map<String, List<String>> roleMapping, DefaultRole expectedRole) throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.role", roleMapping);
-
-            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
-
-            assertThat(role).isEqualTo(expectedRole);
-        }
-
-        private static Stream<Arguments> provideRoleMappingWithMultipleValues() {
-            Map<String, List<String>> roleMapping = Map.of(
-                    "admin", List.of("super_admin", "root", "sysadmin"),
-                    "editor", List.of("content_editor", "blog_writer"));
-
-            return Stream.of(
-                    Arguments.of("{\"role\": \"super_admin\"}", roleMapping, DefaultRole.ADMIN),
-                    Arguments.of("{\"role\": \"root\"}", roleMapping, DefaultRole.ADMIN),
-                    Arguments.of("{\"role\": \"sysadmin\"}", roleMapping, DefaultRole.ADMIN),
-                    Arguments.of("{\"role\": \"content_editor\"}", roleMapping, DefaultRole.EDITOR),
-                    Arguments.of("{\"role\": \"blog_writer\"}", roleMapping, DefaultRole.EDITOR),
-                    Arguments.of("{\"role\": \"unknown\"}", roleMapping, null));
+                    Arguments.of("{\"role\": \"ADMIN\"}", "role", DefaultRole.ADMIN),
+                    Arguments.of("{\"role\": \"Admin\"}", "role", DefaultRole.ADMIN),
+                    Arguments.of("{\"role\": \"EDITOR\"}", "role", DefaultRole.EDITOR),
+                    Arguments.of("{\"role\": \"EdItOr\"}", "role", DefaultRole.EDITOR),
+                    Arguments.of("{\"role\": \"ViEwEr\"}", "role", null));
         }
 
         @ParameterizedTest
         @MethodSource("provideEdgeCaseJson")
         void shouldHandleEdgeCasesGracefully(String json, String path, DefaultRole expectedRole) throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, path, Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, path);
 
             Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
 
@@ -402,24 +313,20 @@ class OidcRoleExtractorTest {
 
         private static Stream<Arguments> provideEdgeCaseJson() {
             return Stream.of(
-                    Arguments.of("{}", "$.role", null),
-                    Arguments.of("{\"role\": null}", "$.role", null),
-                    Arguments.of("{\"role\": 1}", "$.role", null),
-                    Arguments.of("{\"role\": 123}", "$.role", null),
-                    Arguments.of("{\"role\": 0}", "$.role", null),
-                    Arguments.of("{\"role\": true}", "$.role", null),
-                    Arguments.of("{\"role\": false}", "$.role", null),
-                    Arguments.of("{\"roles\": []}", "$.roles", null),
-                    Arguments.of("{invalid json}", "$.role", null),
-                    Arguments.of("plain string", "$.role", null),
-                    Arguments.of("12345", "$.role", null),
-                    Arguments.of("{\"user\": \"admin\"}", "$.role", null),
-                    Arguments.of("{\"data\": {\"value\": \"admin\"}}", "$.role", null));
+                    Arguments.of("{}", "role", null),
+                    Arguments.of("{\"role\": null}", "role", null),
+                    Arguments.of("{\"role\": 1}", "role", null),
+                    Arguments.of("{\"role\": true}", "role", null),
+                    Arguments.of("{\"roles\": []}", "roles[0]", null),
+                    Arguments.of("{invalid json}", "role", null),
+                    Arguments.of("plain string", "role", null),
+                    Arguments.of("{\"user\": \"admin\"}", "role", null),
+                    Arguments.of("{\"data\": {\"value\": \"admin\"}}", "role", null));
         }
 
         @Test
         void shouldHandleDeeplyNestedArrays() throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.data[0].users[1].roles[0]", Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "data[0].users[1].roles[0]");
 
             String json = """
                 {
@@ -438,29 +345,10 @@ class OidcRoleExtractorTest {
             assertThat(role).isEqualTo(DefaultRole.ADMIN);
         }
 
-        @Test
-        void shouldHandleCaseInsensitiveInRoleMapping() throws Exception {
-            Map<String, List<String>> roleMapping = Map.of(
-                    "admin", List.of("SuperAdmin", "ROOT"),
-                    "editor", List.of("ContentEditor"));
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.role", roleMapping);
-
-            assertThat((Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"superadmin\"}"))
-                    .isEqualTo(DefaultRole.ADMIN);
-            assertThat((Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"root\"}"))
-                    .isEqualTo(DefaultRole.ADMIN);
-            assertThat((Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"ROOT\"}"))
-                    .isEqualTo(DefaultRole.ADMIN);
-            assertThat((Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"contenteditor\"}"))
-                    .isEqualTo(DefaultRole.EDITOR);
-            assertThat((Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"ContentEditor\"}"))
-                    .isEqualTo(DefaultRole.EDITOR);
-        }
-
         @ParameterizedTest
         @MethodSource("provideDifferentPathFormats")
-        void shouldHandleDifferentJsonPathFormats(String path, String json, DefaultRole expectedRole) throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, path, Map.of());
+        void shouldHandleDifferentJmesPathFormats(String path, String json, DefaultRole expectedRole) throws Exception {
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, path);
 
             Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
 
@@ -469,21 +357,21 @@ class OidcRoleExtractorTest {
 
         private static Stream<Arguments> provideDifferentPathFormats() {
             return Stream.of(
-                    Arguments.of("$.data.role", "{\"data\": {\"role\": \"admin\"}}", DefaultRole.ADMIN),
-                    Arguments.of("$.roles[0]", "{\"roles\": [\"admin\", \"editor\"]}", DefaultRole.ADMIN),
-                    Arguments.of("$.roles[1]", "{\"roles\": [\"admin\", \"editor\"]}", DefaultRole.EDITOR),
-                    Arguments.of("$.roles[*]", "{\"roles\": [\"editor\", \"admin\"]}", DefaultRole.EDITOR),
+                    Arguments.of("data.role", "{\"data\": {\"role\": \"admin\"}}", DefaultRole.ADMIN),
+                    Arguments.of("roles[0]", "{\"roles\": [\"admin\", \"editor\"]}", DefaultRole.ADMIN),
+                    Arguments.of("roles[1]", "{\"roles\": [\"admin\", \"editor\"]}", DefaultRole.EDITOR),
+                    Arguments.of("roles | [0]", "{\"roles\": [\"editor\", \"admin\"]}", DefaultRole.EDITOR),
                     Arguments.of(
-                            "$.user.info.role", "{\"user\": {\"info\": {\"role\": \"editor\"}}}", DefaultRole.EDITOR),
+                            "user.info.role", "{\"user\": {\"info\": {\"role\": \"editor\"}}}", DefaultRole.EDITOR),
                     Arguments.of(
-                            "$.data[0].roles[1]",
+                            "data[0].roles[1]",
                             "{\"data\": [{\"roles\": [\"viewer\", \"admin\"]}]}",
                             DefaultRole.ADMIN));
         }
 
         @Test
         void shouldReturnNullWhenPathDoesNotExist() throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.nonexistent", Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "nonexistent");
 
             Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"admin\"}");
 
@@ -492,7 +380,7 @@ class OidcRoleExtractorTest {
 
         @Test
         void shouldReturnNullWhenJsonIsNull() throws Exception {
-            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.role", Map.of());
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "role");
 
             Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, (Object) null);
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcRoleExtractorTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcRoleExtractorTest.java
@@ -1,0 +1,502 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.service.auth.oauth;
+
+import java.lang.reflect.Method;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.axelixlabs.axelix.common.auth.core.DefaultRole;
+import com.axelixlabs.axelix.common.auth.core.Role;
+import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
+import com.axelixlabs.axelix.master.service.auth.oauth.DefaultOidcClient.Tokens;
+import com.axelixlabs.axelix.master.utils.TestResourceReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link OidcRoleExtractor}
+ *
+ * @author Nikita Kirillov
+ */
+class OidcRoleExtractorTest {
+
+    private OidcClient MOCK_OIDC_CLIENT;
+
+    @BeforeEach
+    void setUp() {
+        MOCK_OIDC_CLIENT = mock(OidcClient.class);
+    }
+
+    @Nested
+    class ExtractRoleIntegrationTest {
+
+        private static final String ID_TOKEN =
+                "header." + Base64.getUrlEncoder().encodeToString("""
+        {
+            "roles": ["admin", "offline_access"]
+        }
+        """.getBytes()) + ".signature";
+
+        private static final String ACCESS_TOKEN = "test-access-token";
+        private static final String USER_INFO_JSON = TestResourceReader.readResource("other/user-info-response.json");
+
+        private OidcRoleExtractor extractor;
+
+        @Test
+        void shouldExtractRoleFromIdTokenWhenPresent() {
+            Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+
+            Role role = extractor.extractRole(tokens);
+
+            assertThat(role).isEqualTo(DefaultRole.ADMIN);
+            verify(MOCK_OIDC_CLIENT, never()).validateAccessTokenAndExtractUserInfo(anyString());
+        }
+
+        @Test
+        void shouldFallbackToUserInfoWhenIdTokenHasNoRole() {
+            String idTokenWithoutRoles = "header."
+                    + Base64.getUrlEncoder().encodeToString("{\"sub\": \"user123\"}".getBytes()) + ".signature";
+            Tokens tokens = new Tokens(idTokenWithoutRoles, ACCESS_TOKEN);
+
+            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
+                    .thenReturn(USER_INFO_JSON);
+
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+
+            Role role = extractor.extractRole(tokens);
+
+            assertThat(role).isEqualTo(DefaultRole.ADMIN);
+            verify(MOCK_OIDC_CLIENT).validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN);
+        }
+
+        @Test
+        void shouldFallbackToUserInfoWhenIdTokenExtractionFails() {
+            String invalidIdToken = "invalid.token.format";
+            Tokens tokens = new Tokens(invalidIdToken, ACCESS_TOKEN);
+
+            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
+                    .thenReturn(USER_INFO_JSON);
+
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+
+            Role role = extractor.extractRole(tokens);
+
+            assertThat(role).isEqualTo(DefaultRole.ADMIN);
+            verify(MOCK_OIDC_CLIENT).validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN);
+        }
+
+        @Test
+        void shouldReturnViewerWhenBothSourcesFail() {
+            String invalidIdToken = "invalid.token.format";
+            Tokens tokens = new Tokens(invalidIdToken, ACCESS_TOKEN);
+
+            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
+                    .thenThrow(new OidcTokenExchangeException("UserInfo endpoint failed"));
+
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+
+            Role role = extractor.extractRole(tokens);
+
+            assertThat(role).isEqualTo(DefaultRole.VIEWER);
+        }
+
+        @Test
+        void shouldReturnViewerWhenNoRoleFoundInBothSources() {
+            String idTokenWithoutRoles = "header."
+                    + Base64.getUrlEncoder().encodeToString("{\"sub\": \"user123\"}".getBytes()) + ".signature";
+            String userInfoWithoutRoles = """
+            {
+                "sub": "user123",
+                "name": "Test User"
+            }
+            """;
+
+            Tokens tokens = new Tokens(idTokenWithoutRoles, ACCESS_TOKEN);
+
+            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
+                    .thenReturn(userInfoWithoutRoles);
+
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+
+            Role role = extractor.extractRole(tokens);
+
+            assertThat(role).isEqualTo(DefaultRole.VIEWER);
+        }
+
+        @Test
+        void shouldApplyRoleMappingFromIdToken() {
+            Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
+            Map<String, List<String>> roleMapping = Map.of(
+                    "admin", List.of("super_admin", "root"),
+                    "editor", List.of("writer"));
+
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", roleMapping);
+
+            Role role = extractor.extractRole(tokens);
+
+            assertThat(role).isEqualTo(DefaultRole.ADMIN);
+        }
+
+        @Test
+        void shouldApplyRoleMappingFromUserInfoWhenIdTokenHasNoRole() {
+            String idTokenWithoutRoles = "header."
+                    + Base64.getUrlEncoder().encodeToString("{\"sub\": \"user123\"}".getBytes()) + ".signature";
+            String userInfoWithMappedRole = """
+            {
+                "role": "super_admin"
+            }
+            """;
+
+            Tokens tokens = new Tokens(idTokenWithoutRoles, ACCESS_TOKEN);
+
+            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
+                    .thenReturn(userInfoWithMappedRole);
+
+            Map<String, List<String>> roleMapping = Map.of("admin", List.of("super_admin", "root"));
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.role", roleMapping);
+
+            Role role = extractor.extractRole(tokens);
+
+            assertThat(role).isEqualTo(DefaultRole.ADMIN);
+        }
+
+        @Test
+        void shouldExtractEditorRoleFromUserInfo() {
+            String idTokenWithoutRoles =
+                    "header." + Base64.getUrlEncoder().encodeToString("{}".getBytes()) + ".signature";
+            String userInfoWithEditor = """
+            {
+                "roles": ["editor", "viewer"]
+            }
+            """;
+
+            Tokens tokens = new Tokens(idTokenWithoutRoles, ACCESS_TOKEN);
+
+            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
+                    .thenReturn(userInfoWithEditor);
+
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+
+            Role role = extractor.extractRole(tokens);
+
+            assertThat(role).isEqualTo(DefaultRole.EDITOR);
+        }
+
+        @Test
+        void shouldReturnViewerWhenRoleAttributePathIsBlank() {
+            Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
+
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "", Map.of());
+
+            Role role = extractor.extractRole(tokens);
+
+            assertThat(role).isEqualTo(DefaultRole.VIEWER);
+            verify(MOCK_OIDC_CLIENT, never()).validateAccessTokenAndExtractUserInfo(anyString());
+        }
+
+        @Test
+        void shouldReturnViewerWhenRoleAttributePathIsNull() {
+            Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
+
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, null, Map.of());
+
+            Role role = extractor.extractRole(tokens);
+
+            assertThat(role).isEqualTo(DefaultRole.VIEWER);
+            verify(MOCK_OIDC_CLIENT, never()).validateAccessTokenAndExtractUserInfo(anyString());
+        }
+
+        @Test
+        void shouldExtractFromUserInfoWhenIdTokenHasNullRole() {
+            String idTokenWithNullRole =
+                    "header." + Base64.getUrlEncoder().encodeToString("{\"roles\": null}".getBytes()) + ".signature";
+            Tokens tokens = new Tokens(idTokenWithNullRole, ACCESS_TOKEN);
+
+            when(MOCK_OIDC_CLIENT.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
+                    .thenReturn(USER_INFO_JSON);
+
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles", Map.of());
+
+            Role role = extractor.extractRole(tokens);
+
+            assertThat(role).isEqualTo(DefaultRole.ADMIN);
+            verify(MOCK_OIDC_CLIENT).validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN);
+        }
+
+        @Test
+        void shouldUseFirstMatchingRoleFromArray() {
+            String idTokenWithMultipleRoles = "header."
+                    + Base64.getUrlEncoder()
+                            .encodeToString("{\"roles\": [\"viewer\", \"editor\", \"admin\"]}".getBytes())
+                    + ".signature";
+            Tokens tokens = new Tokens(idTokenWithMultipleRoles, ACCESS_TOKEN);
+
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.roles[0]", Map.of());
+
+            Role role = extractor.extractRole(tokens);
+
+            assertThat(role).isEqualTo(DefaultRole.VIEWER);
+        }
+    }
+
+    /**
+     * Unit tests for {@link OidcRoleExtractor#extractRoleFromJson(String json)}
+     *
+     * @author Nikita Kirillov
+     */
+    @Nested
+    class ExtractRoleFromJsonPrivateMethodTest {
+
+        private Method extractRoleFromJsonMethod;
+        private OidcRoleExtractor extractor;
+
+        @BeforeEach
+        void setUp() throws NoSuchMethodException {
+            extractRoleFromJsonMethod = OidcRoleExtractor.class.getDeclaredMethod("extractRoleFromJson", String.class);
+            extractRoleFromJsonMethod.setAccessible(true);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"", "   ", "\t", "\n", "  \t  "})
+        void shouldReturnNullWhenRoleAttributePathIsBlank(String path) throws Exception {
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, path, Map.of());
+
+            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"admin\"}");
+
+            assertThat(role).isNull();
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideJsonAndExpectedRole")
+        void shouldExtractCorrectRoleFromJson(
+                String json, String roleAttributePath, Map<String, List<String>> roleMapping, DefaultRole expectedRole)
+                throws Exception {
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, roleAttributePath, roleMapping);
+
+            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
+
+            assertThat(role).as("JSON: %s, Path: %s", json, roleAttributePath).isEqualTo(expectedRole);
+        }
+
+        private static Stream<Arguments> provideJsonAndExpectedRole() {
+            return Stream.of(
+                    // Basic role extraction
+                    Arguments.of("{\"role\": \"admin\"}", "$.role", Map.of(), DefaultRole.ADMIN),
+                    Arguments.of("{\"role\": \"editor\"}", "$.role", Map.of(), DefaultRole.EDITOR),
+                    Arguments.of("{\"role\": \"viewer\"}", "$.role", Map.of(), null),
+                    Arguments.of("{\"role\": \"unknown\"}", "$.role", Map.of(), null),
+
+                    // Nested paths
+                    Arguments.of("{\"user\": {\"access\": \"admin\"}}", "$.user.access", Map.of(), DefaultRole.ADMIN),
+                    Arguments.of(
+                            "{\"data\": {\"info\": {\"level\": \"editor\"}}}",
+                            "$.data.info.level",
+                            Map.of(),
+                            DefaultRole.EDITOR),
+
+                    // Array handling
+                    Arguments.of("{\"roles\": [\"admin\", \"user\"]}", "$.roles", Map.of(), DefaultRole.ADMIN),
+                    Arguments.of("{\"roles\": [\"viewer\", \"editor\"]}", "$.roles", Map.of(), DefaultRole.EDITOR),
+                    Arguments.of("{\"roles\": [\"guest\", \"user\"]}", "$.roles", Map.of(), null),
+                    Arguments.of("{\"roles\": [\"editor\"]}", "$.roles", Map.of(), DefaultRole.EDITOR),
+
+                    // Case insensitivity
+                    Arguments.of("{\"role\": \"ADMIN\"}", "$.role", Map.of(), DefaultRole.ADMIN),
+                    Arguments.of("{\"role\": \"Admin\"}", "$.role", Map.of(), DefaultRole.ADMIN),
+                    Arguments.of("{\"role\": \"EDITOR\"}", "$.role", Map.of(), DefaultRole.EDITOR),
+                    Arguments.of("{\"role\": \"EdItOr\"}", "$.role", Map.of(), DefaultRole.EDITOR),
+                    Arguments.of("{\"role\": \"ViEwEr\"}", "$.role", Map.of(), null),
+
+                    // Role mapping
+                    Arguments.of(
+                            "{\"role\": \"superuser\"}",
+                            "$.role",
+                            Map.of("admin", List.of("superuser", "root")),
+                            DefaultRole.ADMIN),
+                    Arguments.of(
+                            "{\"role\": \"power_user\"}",
+                            "$.role",
+                            Map.of("editor", List.of("power_user", "content_creator")),
+                            DefaultRole.EDITOR),
+                    Arguments.of(
+                            "{\"role\": \"SUPERUSER\"}",
+                            "$.role",
+                            Map.of("admin", List.of("superuser", "root")),
+                            DefaultRole.ADMIN),
+                    Arguments.of("{\"role\": \"unknown\"}", "$.role", Map.of("admin", List.of("superuser")), null),
+                    Arguments.of(
+                            "{\"role\": \"editor\"}",
+                            "$.role",
+                            Map.of("admin", List.of("superuser")),
+                            DefaultRole.EDITOR));
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideRoleMappingWithMultipleValues")
+        void shouldApplyRoleMappingWithMultipleValues(
+                String json, Map<String, List<String>> roleMapping, DefaultRole expectedRole) throws Exception {
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.role", roleMapping);
+
+            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
+
+            assertThat(role).isEqualTo(expectedRole);
+        }
+
+        private static Stream<Arguments> provideRoleMappingWithMultipleValues() {
+            Map<String, List<String>> roleMapping = Map.of(
+                    "admin", List.of("super_admin", "root", "sysadmin"),
+                    "editor", List.of("content_editor", "blog_writer"));
+
+            return Stream.of(
+                    Arguments.of("{\"role\": \"super_admin\"}", roleMapping, DefaultRole.ADMIN),
+                    Arguments.of("{\"role\": \"root\"}", roleMapping, DefaultRole.ADMIN),
+                    Arguments.of("{\"role\": \"sysadmin\"}", roleMapping, DefaultRole.ADMIN),
+                    Arguments.of("{\"role\": \"content_editor\"}", roleMapping, DefaultRole.EDITOR),
+                    Arguments.of("{\"role\": \"blog_writer\"}", roleMapping, DefaultRole.EDITOR),
+                    Arguments.of("{\"role\": \"unknown\"}", roleMapping, null));
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideEdgeCaseJson")
+        void shouldHandleEdgeCasesGracefully(String json, String path, DefaultRole expectedRole) throws Exception {
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, path, Map.of());
+
+            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
+
+            assertThat(role).as("JSON: %s, Path: %s", json, path).isEqualTo(expectedRole);
+        }
+
+        private static Stream<Arguments> provideEdgeCaseJson() {
+            return Stream.of(
+                    Arguments.of("{}", "$.role", null),
+                    Arguments.of("{\"role\": null}", "$.role", null),
+                    Arguments.of("{\"role\": 1}", "$.role", null),
+                    Arguments.of("{\"role\": 123}", "$.role", null),
+                    Arguments.of("{\"role\": 0}", "$.role", null),
+                    Arguments.of("{\"role\": true}", "$.role", null),
+                    Arguments.of("{\"role\": false}", "$.role", null),
+                    Arguments.of("{\"roles\": []}", "$.roles", null),
+                    Arguments.of("{invalid json}", "$.role", null),
+                    Arguments.of("plain string", "$.role", null),
+                    Arguments.of("12345", "$.role", null),
+                    Arguments.of("{\"user\": \"admin\"}", "$.role", null),
+                    Arguments.of("{\"data\": {\"value\": \"admin\"}}", "$.role", null));
+        }
+
+        @Test
+        void shouldHandleDeeplyNestedArrays() throws Exception {
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.data[0].users[1].roles[0]", Map.of());
+
+            String json = """
+                {
+                    "data": [
+                        {
+                            "users": [
+                                {"name": "user1", "roles": ["viewer"]},
+                                {"name": "user2", "roles": ["admin", "editor"]}
+                            ]
+                        }
+                    ]
+                }
+                """;
+
+            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
+            assertThat(role).isEqualTo(DefaultRole.ADMIN);
+        }
+
+        @Test
+        void shouldHandleCaseInsensitiveInRoleMapping() throws Exception {
+            Map<String, List<String>> roleMapping = Map.of(
+                    "admin", List.of("SuperAdmin", "ROOT"),
+                    "editor", List.of("ContentEditor"));
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.role", roleMapping);
+
+            assertThat((Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"superadmin\"}"))
+                    .isEqualTo(DefaultRole.ADMIN);
+            assertThat((Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"root\"}"))
+                    .isEqualTo(DefaultRole.ADMIN);
+            assertThat((Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"ROOT\"}"))
+                    .isEqualTo(DefaultRole.ADMIN);
+            assertThat((Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"contenteditor\"}"))
+                    .isEqualTo(DefaultRole.EDITOR);
+            assertThat((Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"ContentEditor\"}"))
+                    .isEqualTo(DefaultRole.EDITOR);
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideDifferentPathFormats")
+        void shouldHandleDifferentJsonPathFormats(String path, String json, DefaultRole expectedRole) throws Exception {
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, path, Map.of());
+
+            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, json);
+
+            assertThat(role).as("Path: %s should extract correct role", path).isEqualTo(expectedRole);
+        }
+
+        private static Stream<Arguments> provideDifferentPathFormats() {
+            return Stream.of(
+                    Arguments.of("$.data.role", "{\"data\": {\"role\": \"admin\"}}", DefaultRole.ADMIN),
+                    Arguments.of("$.roles[0]", "{\"roles\": [\"admin\", \"editor\"]}", DefaultRole.ADMIN),
+                    Arguments.of("$.roles[1]", "{\"roles\": [\"admin\", \"editor\"]}", DefaultRole.EDITOR),
+                    Arguments.of("$.roles[*]", "{\"roles\": [\"editor\", \"admin\"]}", DefaultRole.EDITOR),
+                    Arguments.of(
+                            "$.user.info.role", "{\"user\": {\"info\": {\"role\": \"editor\"}}}", DefaultRole.EDITOR),
+                    Arguments.of(
+                            "$.data[0].roles[1]",
+                            "{\"data\": [{\"roles\": [\"viewer\", \"admin\"]}]}",
+                            DefaultRole.ADMIN));
+        }
+
+        @Test
+        void shouldReturnNullWhenPathDoesNotExist() throws Exception {
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.nonexistent", Map.of());
+
+            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, "{\"role\": \"admin\"}");
+
+            assertThat(role).isNull();
+        }
+
+        @Test
+        void shouldReturnNullWhenJsonIsNull() throws Exception {
+            extractor = new OidcRoleExtractor(MOCK_OIDC_CLIENT, "$.role", Map.of());
+
+            Role role = (Role) extractRoleFromJsonMethod.invoke(extractor, (Object) null);
+
+            assertThat(role).isNull();
+        }
+    }
+}

--- a/master/src/test/resources/other/user-info-response.json
+++ b/master/src/test/resources/other/user-info-response.json
@@ -1,0 +1,12 @@
+{
+  "sub": "2d23e6c3-dec0-4b2a-b5d2-ba1cee156b03",
+  "email_verified": true,
+  "roles": [
+    "admin"
+  ],
+  "name": "John Doe",
+  "preferred_username": "user",
+  "given_name": "John",
+  "family_name": "Doe",
+  "email": "example@mail.com"
+}


### PR DESCRIPTION
close #918 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic role assignment from OAuth2 tokens using configurable JMESPath expressions; falls back to user-info when needed.
  * OAuth2 flow now handles both ID and access tokens to improve identity and role resolution.
  * Extracted role strings map to admin/editor/viewer with a safe default of viewer.

* **Configuration Changes**
  * OAuth2 property `redirectUri` replaced by `baseUrl` (redirect is now derived).
  * Added optional `roleAttributePath` to configure role extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->