### PR TITLE
GH-967 Fix role extraction logic in JmesPathOidcRoleExtractor, throw exception when fails.

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractor.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractor.java
@@ -64,10 +64,10 @@ public class JmesPathOidcRoleExtractor implements OidcRoleExtractor {
      * First tries to evaluate the configured JMESPath expression against ID token claims,
      * then evaluates it against the userInfo endpoint response if needed.
      *
-     * @return extracted role, or DefaultRole.VIEWER (fallback).
+     * @return extracted role, or {@link DefaultRole#VIEWER} if JMES path expression is not configured
      */
     @Override
-    public Role extractRole(Tokens tokens) {
+    public Role extractRole(Tokens tokens) throws OidcTokenExchangeException {
         if (jmesPathExpression == null) {
             return DefaultRole.VIEWER;
         }
@@ -78,7 +78,13 @@ public class JmesPathOidcRoleExtractor implements OidcRoleExtractor {
             role = extractRoleFromUserInfo(tokens.accessToken());
         }
 
-        return role != null ? role : DefaultRole.VIEWER;
+        if (role == null) {
+            throw new OidcTokenExchangeException(String.format(
+                    "Failed to extract role from tokens. JMES path expression: '%s' - role not found in ID token nor UserInfo endpoint",
+                    jmesPathExpression));
+        }
+
+        return role;
     }
 
     @Nullable

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractor.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractor.java
@@ -60,12 +60,6 @@ public class JmesPathOidcRoleExtractor implements OidcRoleExtractor {
         }
     }
 
-    /**
-     * First tries to evaluate the configured JMESPath expression against ID token claims,
-     * then evaluates it against the userInfo endpoint response if needed.
-     *
-     * @return extracted role, or {@link DefaultRole#VIEWER} if JMES path expression is not configured
-     */
     @Override
     public Role extractRole(Tokens tokens) throws OidcTokenExchangeException {
         if (jmesPathExpression == null) {

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcRoleExtractor.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcRoleExtractor.java
@@ -18,6 +18,7 @@
 package com.axelixlabs.axelix.master.service.auth.oauth;
 
 import com.axelixlabs.axelix.common.auth.core.Role;
+import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
 
 /**
  * The component that is capable to extract the role that belongs to current user based on the pair of {@link Tokens}.
@@ -31,6 +32,8 @@ public interface OidcRoleExtractor {
      *
      * @param tokens the pair of tokens.
      * @return the role that is extracted. Never {@code null}.
+     * @throws OidcTokenExchangeException if the role cannot be extracted from neither
+     *                                    the ID token nor the UserInfo endpoint
      */
-    Role extractRole(Tokens tokens);
+    Role extractRole(Tokens tokens) throws OidcTokenExchangeException;
 }

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractorTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractorTest.java
@@ -32,6 +32,7 @@ import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
 import com.axelixlabs.axelix.master.utils.TestResourceReader;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.of;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -119,11 +120,8 @@ class JmesPathOidcRoleExtractorTest {
             """);
         JmesPathOidcRoleExtractor extractor = new JmesPathOidcRoleExtractor(oidcClient, "roles[0]");
 
-        // when.
-        Role role = extractor.extractRole(tokens);
-
-        // then.
-        assertThat(role).isEqualTo(DefaultRole.VIEWER);
+        // when & then.
+        assertThatThrownBy(() -> extractor.extractRole(tokens)).isInstanceOf(OidcTokenExchangeException.class);
     }
 
     @Test
@@ -160,11 +158,8 @@ class JmesPathOidcRoleExtractorTest {
 
         JmesPathOidcRoleExtractor extractor = new JmesPathOidcRoleExtractor(oidcClient, "roles[0]");
 
-        // when.
-        Role role = extractor.extractRole(tokens);
-
-        // then.
-        assertThat(role).isEqualTo(DefaultRole.VIEWER);
+        // when & then.
+        assertThatThrownBy(() -> extractor.extractRole(tokens)).isInstanceOf(OidcTokenExchangeException.class);
     }
 
     private Tokens tokens(String idTokenPayloadJson) {

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractorTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractorTest.java
@@ -109,7 +109,7 @@ class JmesPathOidcRoleExtractorTest {
     }
 
     @Test
-    void shouldReturnViewerWhenBothSourcesDoNotProvideRole() {
+    void shouldThrowWhenBothSourcesDoNotProvideRole() {
         // given.
         Tokens tokens = tokens("""
             { "sub" : "user123" }
@@ -149,7 +149,7 @@ class JmesPathOidcRoleExtractorTest {
     }
 
     @Test
-    void shouldReturnViewerWhenUserInfoRequestFails() {
+    void shouldThrowWhenUserInfoRequestFails() {
         // given.
         Tokens tokens = new Tokens("invalid.token.format", "test-access-token");
 


### PR DESCRIPTION
close #967 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OpenID Connect role extraction now fails explicitly when a role cannot be determined from the authentication provider instead of silently falling back to a default role, surfacing an error for unresolved role extraction.

* **Tests**
  * Updated tests to assert that role extraction reports failures when role information is missing or unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->