### PR TITLE
GH-955 Implement a mechanism to remove self-registered instances from InstanceRegistry on the Master side

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/domain/Instance.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/domain/Instance.java
@@ -39,7 +39,7 @@ import org.springframework.data.relational.core.mapping.Table;
  * @param jdkVendor               Vendor of JDK distribution used inside the service.
  * @param commitShaShort          Short git commit hash from which this instance's {@link #serviceVersion version} was build
  * @param deployedAt              Timestamp when the service was deployed
- * @param latestHearthBeat        Stores the instance last registration time for self-registered instance, and {@code null} in other cases
+ * @param latestHeartBeat         Stores the instance last registration time for self-registered instance, and {@code null} in other cases
  * @param status                  The status of the given instance from the Master standpoint.
  * @param memoryUsage             Memory usage of the given instance
  * @param actuatorUrl             The URL of the actuator root, e.g. {@code https://my-app:6061/actuator}
@@ -57,7 +57,7 @@ public record Instance(
         String jdkVendor,
         String commitShaShort,
         @Nullable Instant deployedAt,
-        @Nullable Instant latestHearthBeat,
+        @Nullable Instant latestHeartBeat,
         InstanceStatus status,
         @Embedded.Empty MemoryUsage memoryUsage,
         String actuatorUrl,
@@ -99,7 +99,7 @@ public record Instance(
                 this.jdkVendor,
                 this.commitShaShort,
                 this.deployedAt,
-                this.latestHearthBeat,
+                this.latestHeartBeat,
                 instanceStatus,
                 this.memoryUsage,
                 this.actuatorUrl,

--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/InstanceRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/InstanceRepository.java
@@ -17,6 +17,7 @@
  */
 package com.axelixlabs.axelix.master.repository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
@@ -49,6 +50,10 @@ public interface InstanceRepository extends ListCrudRepository<Instance, Instanc
     Set<Instance> findByNameLikeIgnoreCase(@Param("query") String query);
 
     @Modifying
-    @Query("DELETE FROM instances WHERE latest_hearth_beat IS NULL")
+    @Query("DELETE FROM instances WHERE latest_heart_beat IS NOT NULL AND latest_heart_beat < :threshold")
+    int deleteWhereHeartbeatOlderThan(@Param("threshold") Instant threshold);
+
+    @Modifying
+    @Query("DELETE FROM instances WHERE latest_heart_beat IS NULL")
     void deleteAllWithoutHeartbeat();
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/DefaultInstanceFactory.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/DefaultInstanceFactory.java
@@ -53,7 +53,7 @@ public class DefaultInstanceFactory implements InstanceFactory {
             String instanceId,
             String instanceName,
             String deploymentAt,
-            @Nullable Instant latestHearthBeat,
+            @Nullable Instant latestHeartBeat,
             String instanceActuatorUrl,
             BasicDiscoveryMetadata metadata) {
         return new Instance(
@@ -67,7 +67,7 @@ public class DefaultInstanceFactory implements InstanceFactory {
                 metadata.getJdkVendor(),
                 metadata.getCommitShortSha(),
                 extractDeployTimestamp(deploymentAt, instanceId, instanceName),
-                latestHearthBeat,
+                latestHeartBeat,
                 convertServiceStatus(metadata.getHealthStatus()),
                 new MemoryUsage(metadata.getMemoryDetails().getHeap()),
                 instanceActuatorUrl,

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/InstanceFactory.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/InstanceFactory.java
@@ -48,7 +48,7 @@ public interface InstanceFactory {
             String instanceId,
             String instanceName,
             String deploymentAt,
-            @Nullable Instant latestHearthBeat,
+            @Nullable Instant latestHeartBeat,
             String instanceActuatorUrl,
             BasicDiscoveryMetadata metadata);
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/SelfRegistrationInstanceEvictionScheduler.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/SelfRegistrationInstanceEvictionScheduler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.service.discovery;
+
+import java.time.Instant;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.axelixlabs.axelix.master.repository.InstanceRepository;
+
+/**
+ * Evicts self-registered instances that haven't sent a heartbeat within the timeout period.
+ *
+ * @author Nikita Kirillov
+ */
+@Service
+public class SelfRegistrationInstanceEvictionScheduler {
+
+    private static final Logger logger = LoggerFactory.getLogger(SelfRegistrationInstanceEvictionScheduler.class);
+
+    private final InstanceRepository instanceRepository;
+
+    /**
+     * Maximum time in seconds without a heartbeat before a self-registered instance
+     * is considered stale and eligible for eviction. Default: 45 seconds
+     */
+    @Value("${axelix.master.discovery.self.eviction.heartbeat-timeout:45000}")
+    private long heartbeatTimeout;
+
+    public SelfRegistrationInstanceEvictionScheduler(InstanceRepository instanceRepository) {
+        this.instanceRepository = instanceRepository;
+    }
+
+    @Scheduled(
+            fixedDelayString = "${axelix.master.discovery.self.eviction.interval:60000}",
+            initialDelayString = "${axelix.master.discovery.self.eviction.interval:60000}")
+    public void evictStaleInstances() {
+        Instant threshold = Instant.now().minusMillis(heartbeatTimeout);
+        int evictedCount = instanceRepository.deleteWhereHeartbeatOlderThan(threshold);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Evicted {} stale instances.", evictedCount);
+        }
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/SelfRegistrationInstanceEvictionScheduler.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/SelfRegistrationInstanceEvictionScheduler.java
@@ -44,18 +44,16 @@ public class SelfRegistrationInstanceEvictionScheduler {
      * Maximum time in seconds without a heartbeat before a self-registered instance
      * is considered stale and eligible for eviction. Default: 45 seconds
      */
-    @Value("${axelix.master.discovery.self-registration.eviction.heartbeat-timeout:45000}")
+    @Value("${axelix.master.discovery.self-registration.eviction.heartbeat-timeout:45}")
     private long heartbeatTimeout;
 
     public SelfRegistrationInstanceEvictionScheduler(InstanceRepository instanceRepository) {
         this.instanceRepository = instanceRepository;
     }
 
-    @Scheduled(
-            fixedDelayString = "${axelix.master.discovery.self-registration.eviction.interval:60000}",
-            initialDelayString = "${axelix.master.discovery.self-registration.eviction.interval:60000}")
+    @Scheduled(cron = "${axelix.master.discovery.self-registration.eviction.interval}")
     public void evictStaleInstances() {
-        Instant threshold = Instant.now().minusMillis(heartbeatTimeout);
+        Instant threshold = Instant.now().minusSeconds(heartbeatTimeout);
         int evictedCount = instanceRepository.deleteWhereHeartbeatOlderThan(threshold);
 
         logger.debug("Evicted {} stale instances.", evictedCount);

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/SelfRegistrationInstanceEvictionScheduler.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/SelfRegistrationInstanceEvictionScheduler.java
@@ -17,6 +17,7 @@
  */
 package com.axelixlabs.axelix.master.service.discovery;
 
+import java.time.Duration;
 import java.time.Instant;
 
 import org.slf4j.Logger;
@@ -44,16 +45,17 @@ public class SelfRegistrationInstanceEvictionScheduler {
      * Maximum time in seconds without a heartbeat before a self-registered instance
      * is considered stale and eligible for eviction. Default: 45 seconds
      */
-    @Value("${axelix.master.discovery.self-registration.eviction.heartbeat-timeout:45}")
-    private long heartbeatTimeout;
+    @SuppressWarnings("NullAway.Init")
+    @Value("${axelix.master.discovery.self-registration.eviction.heartbeat-timeout}")
+    private Duration heartbeatTimeout;
 
     public SelfRegistrationInstanceEvictionScheduler(InstanceRepository instanceRepository) {
         this.instanceRepository = instanceRepository;
     }
 
-    @Scheduled(cron = "${axelix.master.discovery.self-registration.eviction.interval}")
+    @Scheduled(cron = "${axelix.master.discovery.self-registration.eviction.schedule}")
     public void evictStaleInstances() {
-        Instant threshold = Instant.now().minusSeconds(heartbeatTimeout);
+        Instant threshold = Instant.now().minus(heartbeatTimeout);
         int evictedCount = instanceRepository.deleteWhereHeartbeatOlderThan(threshold);
 
         logger.debug("Evicted {} stale instances.", evictedCount);

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/SelfRegistrationInstanceEvictionScheduler.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/SelfRegistrationInstanceEvictionScheduler.java
@@ -44,7 +44,7 @@ public class SelfRegistrationInstanceEvictionScheduler {
      * Maximum time in seconds without a heartbeat before a self-registered instance
      * is considered stale and eligible for eviction. Default: 45 seconds
      */
-    @Value("${axelix.master.discovery.self.eviction.heartbeat-timeout:45000}")
+    @Value("${axelix.master.discovery.self-registration.eviction.heartbeat-timeout:45000}")
     private long heartbeatTimeout;
 
     public SelfRegistrationInstanceEvictionScheduler(InstanceRepository instanceRepository) {
@@ -52,14 +52,12 @@ public class SelfRegistrationInstanceEvictionScheduler {
     }
 
     @Scheduled(
-            fixedDelayString = "${axelix.master.discovery.self.eviction.interval:60000}",
-            initialDelayString = "${axelix.master.discovery.self.eviction.interval:60000}")
+            fixedDelayString = "${axelix.master.discovery.self-registration.eviction.interval:60000}",
+            initialDelayString = "${axelix.master.discovery.self-registration.eviction.interval:60000}")
     public void evictStaleInstances() {
         Instant threshold = Instant.now().minusMillis(heartbeatTimeout);
         int evictedCount = instanceRepository.deleteWhereHeartbeatOlderThan(threshold);
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Evicted {} stale instances.", evictedCount);
-        }
+        logger.debug("Evicted {} stale instances.", evictedCount);
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/ShortPollingInstanceDiscoveryScheduler.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/ShortPollingInstanceDiscoveryScheduler.java
@@ -62,7 +62,7 @@ public class ShortPollingInstanceDiscoveryScheduler {
         this.securityContextExecutor = securityContextExecutor;
     }
 
-    @Scheduled(fixedDelayString = "${axelix.master.discovery.auto.broadcast.interval}")
+    @Scheduled(cron = "${axelix.master.discovery.auto.broadcast.interval}")
     public void performDiscovery() {
 
         String token = jwtEncoderService.generateToken(TECH_USER, Duration.ofSeconds(300));

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/ShortPollingInstanceDiscoveryScheduler.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/ShortPollingInstanceDiscoveryScheduler.java
@@ -62,7 +62,7 @@ public class ShortPollingInstanceDiscoveryScheduler {
         this.securityContextExecutor = securityContextExecutor;
     }
 
-    @Scheduled(cron = "${axelix.master.discovery.auto.broadcast.interval}")
+    @Scheduled(cron = "${axelix.master.discovery.auto.broadcast.schedule}")
     public void performDiscovery() {
 
         String token = jwtEncoderService.generateToken(TECH_USER, Duration.ofSeconds(300));

--- a/master/src/main/resources/application-local.yaml
+++ b/master/src/main/resources/application-local.yaml
@@ -5,7 +5,7 @@ axelix:
       static-resources:
         location: /application/dist/
     discovery:
-      self:
+      self-registration:
         eviction:
           interval: 60000
       auto:

--- a/master/src/main/resources/application-local.yaml
+++ b/master/src/main/resources/application-local.yaml
@@ -7,11 +7,12 @@ axelix:
     discovery:
       self-registration:
         eviction:
-          interval: "0 * * * * *"
+          heartbeat-timeout: 45s
+          schedule: "0 * * * * *"
       auto:
         enabled: true
         broadcast:
-          interval: "0 * * * * *"
+          schedule: "0 * * * * *"
         platform: kubernetes
         kubernetes:
           # Should be provided by the local-launch configuration

--- a/master/src/main/resources/application-local.yaml
+++ b/master/src/main/resources/application-local.yaml
@@ -7,11 +7,11 @@ axelix:
     discovery:
       self-registration:
         eviction:
-          interval: 60000
+          interval: "0 * * * * *"
       auto:
         enabled: true
         broadcast:
-          interval: 60000
+          interval: "0 * * * * *"
         platform: kubernetes
         kubernetes:
           # Should be provided by the local-launch configuration

--- a/master/src/main/resources/application-local.yaml
+++ b/master/src/main/resources/application-local.yaml
@@ -5,6 +5,9 @@ axelix:
       static-resources:
         location: /application/dist/
     discovery:
+      self:
+        eviction:
+          interval: 60000
       auto:
         enabled: true
         broadcast:

--- a/master/src/main/resources/application.yaml
+++ b/master/src/main/resources/application.yaml
@@ -34,11 +34,11 @@ axelix:
     discovery:
       self-registration:
         eviction:
-          interval: 60000
+          interval: "0 * * * * *"
       auto:
         enabled: true
         broadcast:
-          interval: 60000
+          interval: "0 * * * * *"
         platform: kubernetes
         kubernetes:
           kube-apiserver-url: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}

--- a/master/src/main/resources/application.yaml
+++ b/master/src/main/resources/application.yaml
@@ -32,7 +32,7 @@ management:
 axelix:
   master:
     discovery:
-      self:
+      self-registration:
         eviction:
           interval: 60000
       auto:

--- a/master/src/main/resources/application.yaml
+++ b/master/src/main/resources/application.yaml
@@ -34,11 +34,12 @@ axelix:
     discovery:
       self-registration:
         eviction:
-          interval: "0 * * * * *"
+          heartbeat-timeout: 45s
+          schedule: "0 * * * * *"
       auto:
         enabled: true
         broadcast:
-          interval: "0 * * * * *"
+          schedule: "0 * * * * *"
         platform: kubernetes
         kubernetes:
           kube-apiserver-url: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}

--- a/master/src/main/resources/application.yaml
+++ b/master/src/main/resources/application.yaml
@@ -32,6 +32,9 @@ management:
 axelix:
   master:
     discovery:
+      self:
+        eviction:
+          interval: 60000
       auto:
         enabled: true
         broadcast:

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.0.0-create-instances-table.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.0.0-create-instances-table.xml
@@ -44,7 +44,7 @@
       <column name="deployed_at" type="DATETIME">
         <constraints nullable="true"/>
       </column>
-      <column name="latest_hearth_beat" type="DATETIME">
+      <column name="latest_heart_beat" type="DATETIME">
          <constraints nullable="true"/>
       </column>
       <column name="status" type="VARCHAR(1000)">

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.0.0-create-instances-table.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.0.0-create-instances-table.xml
@@ -44,7 +44,7 @@
       <column name="deployed_at" type="TIMESTAMP WITH TIME ZONE">
         <constraints nullable="true"/>
       </column>
-      <column name="latest_hearth_beat" type="TIMESTAMP WITH TIME ZONE">
+      <column name="latest_heart_beat" type="TIMESTAMP WITH TIME ZONE">
         <constraints nullable="true"/>
       </column>
       <column name="status" type="TEXT">

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.0.0-create-instances-table.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.0.0-create-instances-table.xml
@@ -44,7 +44,7 @@
       <column name="deployed_at" type="TEXT">
         <constraints nullable="true"/>
       </column>
-      <column name="latest_hearth_beat" type="TEXT">
+      <column name="latest_heart_beat" type="TEXT">
         <constraints nullable="true"/>
       </column>
       <column name="status" type="TEXT">

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/DefaultInstanceFactoryTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/DefaultInstanceFactoryTest.java
@@ -59,7 +59,7 @@ public class DefaultInstanceFactoryTest {
         assertThat(instance.jdkVendor()).isEqualTo("BellSoft");
         assertThat(instance.commitShaShort()).isEqualTo("a8b0929");
         assertThat(instance.deployedAt()).isEqualTo("2025-02-03T13:29:29Z");
-        assertThat(instance.latestHearthBeat().toString()).isEqualTo("2025-04-03T13:29:29Z");
+        assertThat(instance.latestHeartBeat().toString()).isEqualTo("2025-04-03T13:29:29Z");
         assertThat(instance.status()).isEqualTo(Instance.InstanceStatus.UP);
         assertThat(instance.memoryUsage().heap()).isEqualTo(12000.0);
         assertThat(instance.actuatorUrl()).isEqualTo("http://localhost:8080/actuator");

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/discovery/SelfRegistrationInstanceEvictionSchedulerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/discovery/SelfRegistrationInstanceEvictionSchedulerTest.java
@@ -30,6 +30,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import com.axelixlabs.axelix.master.domain.Instance;
 import com.axelixlabs.axelix.master.domain.InstanceId;
+import com.axelixlabs.axelix.master.repository.InstanceRepository;
 import com.axelixlabs.axelix.master.service.state.InstanceRegistry;
 
 import static com.axelixlabs.axelix.master.utils.TestObjectFactory.createInstance;
@@ -49,9 +50,12 @@ class SelfRegistrationInstanceEvictionSchedulerTest {
     @Autowired
     private SelfRegistrationInstanceEvictionScheduler selfRegistrationInstanceEvictionScheduler;
 
+    @Autowired
+    private InstanceRepository instanceRepository;
+
     @BeforeEach
     void setUp() {
-        instanceRegistry.deRegisterAll(instanceRegistry.getAllIds());
+        instanceRepository.deleteAll();
     }
 
     @Test

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/discovery/SelfRegistrationInstanceEvictionSchedulerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/discovery/SelfRegistrationInstanceEvictionSchedulerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.service.discovery;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.axelixlabs.axelix.master.domain.Instance;
+import com.axelixlabs.axelix.master.domain.InstanceId;
+import com.axelixlabs.axelix.master.service.state.InstanceRegistry;
+
+import static com.axelixlabs.axelix.master.utils.TestObjectFactory.createInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link SelfRegistrationInstanceEvictionScheduler}
+ *
+ * @author Nikita Kirillov
+ */
+@SpringBootTest(properties = "axelix.master.discovery.self.eviction.interval=60000000")
+class SelfRegistrationInstanceEvictionSchedulerTest {
+
+    @Autowired
+    private InstanceRegistry instanceRegistry;
+
+    @Autowired
+    private SelfRegistrationInstanceEvictionScheduler selfRegistrationInstanceEvictionScheduler;
+
+    @BeforeEach
+    void setUp() {
+        instanceRegistry.deRegisterAll(instanceRegistry.getAllIds());
+    }
+
+    @Test
+    void shouldEvictInstance() {
+        // given
+        String instanceId = UUID.randomUUID().toString();
+        Instant latestHeartBeat = Instant.now().minusSeconds(60000);
+        registerInstance(instanceId, latestHeartBeat);
+
+        // when
+        selfRegistrationInstanceEvictionScheduler.evictStaleInstances();
+
+        // then
+        assertThat(instanceRegistry.get(InstanceId.of(instanceId))).isEmpty();
+    }
+
+    @Test
+    void shouldNotEvictInstanceWithoutHeartbeat() {
+        // given
+        String staleInstanceId = UUID.randomUUID().toString();
+        Instant staleHeartbeat = Instant.now().minusSeconds(60000);
+        registerInstance(staleInstanceId, staleHeartbeat);
+
+        String noHeartbeatInstanceId = UUID.randomUUID().toString();
+        registerInstance(noHeartbeatInstanceId, null);
+
+        // when
+        selfRegistrationInstanceEvictionScheduler.evictStaleInstances();
+
+        // then
+        assertThat(instanceRegistry.get(InstanceId.of(staleInstanceId))).isEmpty();
+        assertThat(instanceRegistry.get(InstanceId.of(noHeartbeatInstanceId))).isNotEmpty();
+    }
+
+    @Test
+    void shouldEvictMultipleStaleInstances() {
+        // given
+        Set<String> staleIds = new HashSet<>();
+        for (int i = 0; i < 3; i++) {
+            String id = UUID.randomUUID().toString();
+            registerInstance(id, Instant.now().minusSeconds(60000));
+            staleIds.add(id);
+        }
+
+        Set<String> freshIds = new HashSet<>();
+        for (int i = 0; i < 2; i++) {
+            String id = UUID.randomUUID().toString();
+            registerInstance(id, Instant.now());
+            freshIds.add(id);
+        }
+
+        // when
+        selfRegistrationInstanceEvictionScheduler.evictStaleInstances();
+
+        // then
+        assertThat(staleIds).allSatisfy(instanceId -> assertThat(instanceRegistry.get(InstanceId.of(instanceId)))
+                .isEmpty());
+        assertThat(freshIds).allSatisfy(instanceId -> assertThat(instanceRegistry.get(InstanceId.of(instanceId)))
+                .isNotEmpty());
+    }
+
+    private void registerInstance(String instanceId, Instant latestHeartBeat) {
+        Instance instance = createInstance(instanceId, latestHeartBeat);
+        instanceRegistry.register(instance);
+    }
+}

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/discovery/ShortPollingInstanceDiscoverySchedulerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/discovery/ShortPollingInstanceDiscoverySchedulerTest.java
@@ -69,11 +69,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = {
-            "axelix.master.discovery.auto.enabled=true",
-            "axelix.master.discovery.auto.platform=kubernetes",
-            "axelix.master.discovery.auto.broadcast.interval=1000"
-        })
+        properties = {"axelix.master.discovery.auto.enabled=true", "axelix.master.discovery.auto.platform=kubernetes"})
 class ShortPollingInstanceDiscoverySchedulerTest {
 
     private static MockWebServer mockWebServer;

--- a/master/src/test/java/com/axelixlabs/axelix/master/utils/TestObjectFactory.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/utils/TestObjectFactory.java
@@ -47,6 +47,10 @@ public final class TestObjectFactory {
         return withUrl(id, DEFAULT_URL);
     }
 
+    public static Instance createInstance(String id, @Nullable Instant instant) {
+        return createInstanceWithHeartbeat(id, instant);
+    }
+
     public static Instance withName(String id, String name) {
         return createInstance(
                 id,
@@ -158,6 +162,25 @@ public final class TestObjectFactory {
                 Instance.VmFeatures.of(Arrays.stream(vmFeatures).collect(Collectors.toSet())));
     }
 
+    public static Instance createInstanceWithHeartbeat(String id, @Nullable Instant instant) {
+        return new Instance(
+                InstanceId.of(id),
+                "test-object-factory-instance",
+                "1.2.3-classifer-test",
+                "25",
+                "3.5.2",
+                "6.0.2",
+                null,
+                "BellSoft",
+                "df027cf",
+                Instant.now(),
+                instant,
+                DEFAULT_STATUS,
+                new MemoryUsage(1000L),
+                DEFAULT_URL,
+                Instance.VmFeatures.empty());
+    }
+
     public static Instance createInstance(
             String id,
             String url,
@@ -180,7 +203,7 @@ public final class TestObjectFactory {
                 jdkVendor,
                 "df027cf",
                 Instant.now(),
-                Instant.now(),
+                Instant.now().minusSeconds(60),
                 status,
                 new MemoryUsage(1000L),
                 url,

--- a/master/src/test/resources/application.yaml
+++ b/master/src/test/resources/application.yaml
@@ -45,10 +45,10 @@ axelix:
     discovery:
       auto:
         broadcast:
-          interval: "-"
+          schedule: "-"
       self-registration:
         eviction:
-          interval: "-"
+          schedule: "-"
     web:
       static-resources:
         location: classpath:/spa-dist/

--- a/master/src/test/resources/application.yaml
+++ b/master/src/test/resources/application.yaml
@@ -42,10 +42,9 @@ axelix:
         role-authority-table: role_authorities
         role-components-table: role_components
   master:
-    discovery:
-      auto:
-        broadcast:
-          interval: "-"
+    self-registration:
+      eviction:
+        interval: 31536000000
     web:
       static-resources:
         location: classpath:/spa-dist/

--- a/master/src/test/resources/application.yaml
+++ b/master/src/test/resources/application.yaml
@@ -42,9 +42,13 @@ axelix:
         role-authority-table: role_authorities
         role-components-table: role_components
   master:
-    self-registration:
-      eviction:
-        interval: 31536000000
+    discovery:
+      auto:
+        broadcast:
+          interval: "-"
+      self-registration:
+        eviction:
+          interval: "-"
     web:
       static-resources:
         location: classpath:/spa-dist/

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/config/SelfRegistrationConfigurationProperties.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/config/SelfRegistrationConfigurationProperties.java
@@ -108,7 +108,7 @@ public class SelfRegistrationConfigurationProperties implements Validateable {
 
     private void validateRequiredProperty(Object value, String propertyName) {
         Assert.notNull(
-                value, String.format("Property '%s' must be set when self-registartion is enabled", propertyName));
+                value, String.format("Property '%s' must be set when self-registration is enabled", propertyName));
     }
 
     private void validateUrl(String url, String propertyName) {


### PR DESCRIPTION
close #955 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Periodic eviction of stale self-registered instances driven by a configurable cron interval.

* **Bug Fixes**
  * Consistent heartbeat field/name corrected across code, database changelogs and queries.
  * Fixed spelling in self-registration validation message.
  * Scheduler trigger switched to cron-based scheduling.

* **Tests**
  * Added integration and unit tests covering eviction behavior and heartbeat handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->