### PR TITLE
GH-973: remove `@DirtiesContext` from `AxelixCachesEndpointTest`

### DIFF
--- a/common/api/src/main/java/com/axelixlabs/axelix/common/api/caches/CachesFeed.java
+++ b/common/api/src/main/java/com/axelixlabs/axelix/common/api/caches/CachesFeed.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public final class CachesFeed {
 
-    private final List<CacheManager> cacheManagers;
+    private final List<CacheManagerDto> cacheManagers;
 
     /**
      * Creates a new CachesFeed.
@@ -40,11 +40,11 @@ public final class CachesFeed {
      * @param cacheManagers The list of cache managers in the application.
      */
     @JsonCreator
-    public CachesFeed(@JsonProperty("cacheManagers") List<CacheManager> cacheManagers) {
+    public CachesFeed(@JsonProperty("cacheManagers") List<CacheManagerDto> cacheManagers) {
         this.cacheManagers = cacheManagers;
     }
 
-    public List<CacheManager> getCacheManagers() {
+    public List<CacheManagerDto> getCacheManagers() {
         return cacheManagers;
     }
 
@@ -73,10 +73,10 @@ public final class CachesFeed {
     /**
      * DTO that encapsulates a map of all caches inside the given cache manager.
      */
-    public static final class CacheManager {
+    public static final class CacheManagerDto {
 
         private final String name;
-        private final List<Cache> caches;
+        private final List<CacheDto> caches;
 
         /**
          * Creates a new CacheManager.
@@ -85,7 +85,7 @@ public final class CachesFeed {
          * @param caches The caches are identified by the cache name.
          */
         @JsonCreator
-        public CacheManager(@JsonProperty("name") String name, @JsonProperty("caches") List<Cache> caches) {
+        public CacheManagerDto(@JsonProperty("name") String name, @JsonProperty("caches") List<CacheDto> caches) {
             this.name = name;
             this.caches = caches;
         }
@@ -94,7 +94,7 @@ public final class CachesFeed {
             return name;
         }
 
-        public List<Cache> getCaches() {
+        public List<CacheDto> getCaches() {
             return caches;
         }
 
@@ -106,7 +106,7 @@ public final class CachesFeed {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            CacheManager that = (CacheManager) o;
+            CacheManagerDto that = (CacheManagerDto) o;
             return Objects.equals(name, that.name) && Objects.equals(caches, that.caches);
         }
 
@@ -124,7 +124,7 @@ public final class CachesFeed {
     /**
      * DTO that encapsulates the full cache name.
      */
-    public static final class Cache {
+    public static final class CacheDto {
 
         private final String name;
         private final String target;
@@ -140,7 +140,7 @@ public final class CachesFeed {
          * @param containsStats      The value will be {@code true} if the cache contains either hits or misses, otherwise it will be {@code false}.
          */
         @JsonCreator
-        public Cache(
+        public CacheDto(
                 @JsonProperty("name") String name,
                 @JsonProperty("target") String target,
                 @JsonProperty("enabled") boolean enabled,
@@ -172,7 +172,7 @@ public final class CachesFeed {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            Cache cache = (Cache) o;
+            CacheDto cache = (CacheDto) o;
             return enabled == cache.enabled
                     && containsStats == cache.containsStats
                     && Objects.equals(name, cache.name)

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcher.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcher.java
@@ -80,17 +80,17 @@ public class DefaultCacheOperationsDispatcher implements CacheOperationsDispatch
 
     @Override
     public CachesFeed getAll() {
-        List<CachesFeed.CacheManager> feed = new ArrayList<>();
+        List<CachesFeed.CacheManagerDto> feed = new ArrayList<>();
 
         this.cacheManagers.forEach((cacheManagerName, enhancedCacheManager) -> {
-            feed.add(new CachesFeed.CacheManager(
+            feed.add(new CachesFeed.CacheManagerDto(
                     cacheManagerName,
                     enhancedCacheManager.getAll().stream()
                             .map(enhancedCache -> {
                                 boolean containsStats =
                                         !enhancedCache.getCacheLookups().isEmpty();
 
-                                return new CachesFeed.Cache(
+                                return new CachesFeed.CacheDto(
                                         enhancedCache.getName(),
                                         enhancedCache
                                                 .getNativeCache()

--- a/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
+++ b/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
@@ -18,7 +18,6 @@
 package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 import net.javacrumbs.jsonunit.assertj.JsonAssertions;
@@ -35,6 +34,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -47,8 +48,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import com.axelixlabs.axelix.common.api.caches.CachesFeed;
-import com.axelixlabs.axelix.common.api.caches.CachesFeed.Cache;
-import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheManager;
+import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheDto;
+import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheManagerDto;
 import com.axelixlabs.axelix.sbs.spring.core.Main;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -92,46 +93,44 @@ class AxelixCachesEndpointTest {
     // The bean definition in the context for cache manager has a type of CacheManager,
     // so we cannot do simple field injection via EnhancedCacheManager class.
     @Autowired
-    public AxelixCachesEndpointTest setMainCacheManager(org.springframework.cache.CacheManager mainCacheManager) {
+    public AxelixCachesEndpointTest setMainCacheManager(CacheManager mainCacheManager) {
         this.mainCacheManager = (EnhancedCacheManager) mainCacheManager;
         return this;
     }
 
     @Autowired
-    public AxelixCachesEndpointTest setClearCacheManager(
-            @Qualifier(CLEAR_CACHE_MANAGER) org.springframework.cache.CacheManager cacheManager) {
+    public AxelixCachesEndpointTest setClearCacheManager(@Qualifier(CLEAR_CACHE_MANAGER) CacheManager cacheManager) {
         this.clearCacheManager = (EnhancedCacheManager) cacheManager;
         return this;
     }
 
     @Autowired
-    public AxelixCachesEndpointTest setEnableCacheManager(
-            @Qualifier(ENABLE_CACHE_MANAGER) org.springframework.cache.CacheManager cacheManager) {
+    public AxelixCachesEndpointTest setEnableCacheManager(@Qualifier(ENABLE_CACHE_MANAGER) CacheManager cacheManager) {
         this.enableCacheManager = (EnhancedCacheManager) cacheManager;
         return this;
     }
 
     @Autowired
     public AxelixCachesEndpointTest setDisableCacheManager(
-            @Qualifier(DISABLE_CACHE_MANAGER) org.springframework.cache.CacheManager cacheManager) {
+            @Qualifier(DISABLE_CACHE_MANAGER) CacheManager cacheManager) {
         this.disableCacheManager = (EnhancedCacheManager) cacheManager;
         return this;
     }
 
     @Autowired
-    private Map<String, org.springframework.cache.CacheManager> allCacheManagers;
+    private Map<String, CacheManager> allCacheManagers;
 
     @Autowired
     private TestRestTemplate testRestTemplate;
 
     @BeforeEach
     void setUp() {
-        for (org.springframework.cache.CacheManager cacheManager : allCacheManagers.values()) {
+        for (CacheManager cacheManager : allCacheManagers.values()) {
             if (cacheManager instanceof EnhancedCacheManager) {
                 EnhancedCacheManager enhancedCacheManager = (EnhancedCacheManager) cacheManager;
                 enhancedCacheManager.enableAll();
                 for (String cacheName : enhancedCacheManager.getCacheNames()) {
-                    org.springframework.cache.Cache cache = enhancedCacheManager.getCache(cacheName);
+                    Cache cache = enhancedCacheManager.getCache(cacheName);
                     if (cache != null) {
                         cache.clear();
                     }
@@ -165,14 +164,14 @@ class AxelixCachesEndpointTest {
 
     @Test
     void get_shouldReturnCacheInformation() {
-        org.springframework.cache.Cache cache1 = mainCacheManager.getCache(TEST_CACHE_1);
+        Cache cache1 = mainCacheManager.getCache(TEST_CACHE_1);
         cache1.put("key1", "value1");
         cache1.put("key2", "value2");
         cache1.put("key3", "value3");
         cache1.get("key1");
         cache1.get("key2");
 
-        org.springframework.cache.Cache cache2 = mainCacheManager.getCache(TEST_CACHE_2);
+        Cache cache2 = mainCacheManager.getCache(TEST_CACHE_2);
         cache2.put("key", "value");
         cache2.get("key");
         cache2.get("notCache1");
@@ -181,7 +180,7 @@ class AxelixCachesEndpointTest {
         ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
+        CacheManagerDto cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
         assertThat(cacheManager.getCaches()).hasSize(2);
 
         assertThat(cacheManager.getCaches().stream()
@@ -206,7 +205,7 @@ class AxelixCachesEndpointTest {
     @Test
     void clear_shouldEvictSingleEntry() {
         String key1 = "key1", key2 = "key2";
-        org.springframework.cache.Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
+        Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
         cache.put(key1, "value1");
         cache.put(key2, "value2");
 
@@ -221,7 +220,7 @@ class AxelixCachesEndpointTest {
     @Test
     void clear_shouldClearEntireCache() {
         String key1 = "key1", key2 = "key2";
-        org.springframework.cache.Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
+        Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
         cache.put(key1, "value1");
         cache.put(key2, "value2");
 
@@ -234,31 +233,10 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    @Disabled // TODO In fact, we currently don't know what kind of cache exists
-    void clear_shouldReturnBadRequest_IfKeyDoesNotExist() {
-        ResponseEntity<Void> response = testRestTemplate.exchange(
-                path(CLEAR_CACHE_MANAGER, TEST_CACHE_1 + "/clear?key=nonExistingKey"),
-                HttpMethod.DELETE,
-                defaultEntity(),
-                Void.class);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
-    @Disabled // TODO In fact, we currently don't know what kind of cacheManager exists
-    void clear_shouldReturnBadRequest_cacheDoesNotExist() {
-        ResponseEntity<Void> response = testRestTemplate.exchange(
-                path(CLEAR_CACHE_MANAGER, "/nonExistentCache/clear"), HttpMethod.DELETE, defaultEntity(), Void.class);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
     void clear_shouldClearAllCaches() {
         String key1 = "key1", key2 = "key2";
-        org.springframework.cache.Cache cache1 = clearCacheManager.getCache(TEST_CACHE_1);
-        org.springframework.cache.Cache cache2 = clearCacheManager.getCache(TEST_CACHE_2);
+        Cache cache1 = clearCacheManager.getCache(TEST_CACHE_1);
+        Cache cache2 = clearCacheManager.getCache(TEST_CACHE_2);
         cache1.put(key1, "value1");
         cache2.put(key2, "value2");
 
@@ -272,8 +250,8 @@ class AxelixCachesEndpointTest {
 
     @Test
     void disable_onDisableAllCacheManager() {
-        org.springframework.cache.Cache cache1 = disableCacheManager.getCache(TEST_CACHE_1);
-        org.springframework.cache.Cache cache2 = disableCacheManager.getCache(TEST_CACHE_2);
+        Cache cache1 = disableCacheManager.getCache(TEST_CACHE_1);
+        Cache cache2 = disableCacheManager.getCache(TEST_CACHE_2);
         cache1.put("key1", "value1");
         cache2.put("key2", "value2");
 
@@ -292,7 +270,7 @@ class AxelixCachesEndpointTest {
 
     @Test
     void enable_shouldEnableCacheManager() {
-        org.springframework.cache.Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
+        Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
 
         // when.
         testRestTemplate.postForObject(path(ENABLE_CACHE_MANAGER, "/disable"), defaultEntity(), Void.class);
@@ -305,7 +283,7 @@ class AxelixCachesEndpointTest {
 
     @Test
     void enable_shouldEnableOnlySpecificCache() {
-        org.springframework.cache.Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
+        Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
 
         // when.
         testRestTemplate.postForObject(
@@ -322,8 +300,8 @@ class AxelixCachesEndpointTest {
     void disable_shouldDisableSpecifiedCache() {
         String targetEnabledCache = TEST_CACHE_1;
         String targetDisabledCache = TEST_CACHE_2;
-        org.springframework.cache.Cache enabledCache = disableCacheManager.getCache(targetEnabledCache);
-        org.springframework.cache.Cache disabledCache = disableCacheManager.getCache(targetDisabledCache);
+        Cache enabledCache = disableCacheManager.getCache(targetEnabledCache);
+        Cache disabledCache = disableCacheManager.getCache(targetDisabledCache);
         enabledCache.put("key1", "value");
         disabledCache.put("key1", "value");
 
@@ -344,11 +322,11 @@ class AxelixCachesEndpointTest {
         ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        CacheManager cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
+        CacheManagerDto cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
 
         assertThat(cacheManager.getCaches()).hasSize(2);
 
-        Cache cache1Info = cacheManager.getCaches().stream()
+        CacheDto cache1Info = cacheManager.getCaches().stream()
                 .filter(c -> TEST_CACHE_1.equals(c.getName()))
                 .findFirst()
                 .orElseThrow();
@@ -356,7 +334,7 @@ class AxelixCachesEndpointTest {
         assertThat(cache1Info.getTarget()).isNotNull();
         assertThat(cache1Info.isContainsStats()).isFalse();
 
-        Cache cache2Info = cacheManager.getCaches().stream()
+        CacheDto cache2Info = cacheManager.getCaches().stream()
                 .filter(c -> TEST_CACHE_2.equals(c.getName()))
                 .findFirst()
                 .orElseThrow();
@@ -375,7 +353,7 @@ class AxelixCachesEndpointTest {
         ResponseEntity<CachesFeed> afterDisablingResponse = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
         assertThat(afterDisablingResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        Cache disabledCache =
+        CacheDto disabledCache =
                 getCacheManager(afterDisablingResponse.getBody(), ENABLE_CACHE_MANAGER).getCaches().stream()
                         .filter(c -> TEST_CACHE_1.equals(c.getName()))
                         .findFirst()
@@ -388,10 +366,11 @@ class AxelixCachesEndpointTest {
         ResponseEntity<CachesFeed> afterEnablingResponse = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
         assertThat(afterEnablingResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        Cache enabledCache = getCacheManager(afterEnablingResponse.getBody(), ENABLE_CACHE_MANAGER).getCaches().stream()
-                .filter(c -> TEST_CACHE_1.equals(c.getName()))
-                .findFirst()
-                .orElseThrow();
+        CacheDto enabledCache =
+                getCacheManager(afterEnablingResponse.getBody(), ENABLE_CACHE_MANAGER).getCaches().stream()
+                        .filter(c -> TEST_CACHE_1.equals(c.getName()))
+                        .findFirst()
+                        .orElseThrow();
         assertThat(enabledCache.isEnabled()).isTrue();
     }
 
@@ -403,7 +382,7 @@ class AxelixCachesEndpointTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
+        CacheManagerDto cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
 
         assertThat(cacheManager.getCaches())
                 .allSatisfy(cacheInfo -> assertThat(cacheInfo.isEnabled()).isFalse());
@@ -418,15 +397,15 @@ class AxelixCachesEndpointTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
+        CacheManagerDto cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
 
-        Cache cache1Info = cacheManager.getCaches().stream()
+        CacheDto cache1Info = cacheManager.getCaches().stream()
                 .filter(c -> TEST_CACHE_1.equals(c.getName()))
                 .findFirst()
                 .orElseThrow();
         assertThat(cache1Info.isEnabled()).isFalse();
 
-        Cache cache2Info = cacheManager.getCaches().stream()
+        CacheDto cache2Info = cacheManager.getCaches().stream()
                 .filter(c -> TEST_CACHE_2.equals(c.getName()))
                 .findFirst()
                 .orElseThrow();
@@ -510,12 +489,8 @@ class AxelixCachesEndpointTest {
         return (path.isEmpty() || path.charAt(0) == '/') ? path : "/" + path;
     }
 
-    private CacheManager getCacheManager(CachesFeed source, String cacheManagerName) {
-        CachesFeed nonNullSource = Objects.requireNonNull(source, "CachesFeed source is null");
-        java.util.List<CacheManager> cacheManagers =
-                Objects.requireNonNull(nonNullSource.getCacheManagers(), "CachesFeed cacheManagers is null");
-
-        return cacheManagers.stream()
+    private CacheManagerDto getCacheManager(CachesFeed source, String cacheManagerName) {
+        return source.getCacheManagers().stream()
                 .filter(cm -> cacheManagerName.equals(cm.getName()))
                 .findFirst()
                 .orElseThrow();
@@ -537,22 +512,22 @@ class AxelixCachesEndpointTest {
 
         @Bean(name = MAIN_CACHE_MANAGER)
         @Primary
-        public org.springframework.cache.CacheManager testSubjectCacheManager() {
+        public CacheManager testSubjectCacheManager() {
             return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
         }
 
         @Bean(name = CLEAR_CACHE_MANAGER)
-        public org.springframework.cache.CacheManager clearSubjectCacheManager() {
+        public CacheManager clearSubjectCacheManager() {
             return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
         }
 
         @Bean(name = ENABLE_CACHE_MANAGER)
-        public org.springframework.cache.CacheManager enableSubjectCacheManager() {
+        public CacheManager enableSubjectCacheManager() {
             return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
         }
 
         @Bean(name = DISABLE_CACHE_MANAGER)
-        public org.springframework.cache.CacheManager disableSubjectCacheManager() {
+        public CacheManager disableSubjectCacheManager() {
             return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
         }
     }

--- a/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
+++ b/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
@@ -17,12 +17,20 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.cache;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
 import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -30,13 +38,13 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 
 import com.axelixlabs.axelix.common.api.caches.CachesFeed;
 import com.axelixlabs.axelix.common.api.caches.CachesFeed.Cache;
@@ -48,8 +56,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Integration tests for {@link AxelixCachesEndpoint}.
  * <p>
- * // TODO: the structure of this test needs to be revisited. The tests for
- * particular methods and cases within the API should be moved to static @Nested classes
+ * TODO:
+ *  Gosh, we need to refactor this test to use String Templates if
+ *  the Java Language designers team will descend to us finally and
+ *  deliver this. Come on Brian, I know you can do this! Push, push,
+ *  push, push! We're praying for you and the team!
  *
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
@@ -62,69 +73,145 @@ import static org.assertj.core.api.Assertions.assertThat;
     DefaultCacheOperationsDispatcher.class,
     AxelixCachesEndpointTest.CacheDispatcherEndpointTestConfiguration.class
 })
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class AxelixCachesEndpointTest {
 
     // Cache names under test
     private static final String TEST_CACHE_1 = "cache1";
-
     private static final String TEST_CACHE_2 = "cache2";
 
-    private static final String TEST_CACHE_MANAGER = TEST_CACHE_2;
+    private static final String MAIN_CACHE_MANAGER = "mainCacheManager";
+    private static final String CLEAR_CACHE_MANAGER = "clearCacheManager";
+    private static final String ENABLE_CACHE_MANAGER = "enableCacheManager";
+    private static final String DISABLE_CACHE_MANAGER = "disableCacheManager";
 
-    private EnhancedCacheManager cacheManager;
+    private EnhancedCacheManager mainCacheManager;
+    private EnhancedCacheManager clearCacheManager;
+    private EnhancedCacheManager enableCacheManager;
+    private EnhancedCacheManager disableCacheManager;
 
-    @Autowired
     // The bean definition in the context for cache manager has a type of CacheManager,
     // so we cannot do simple field injection via EnhancedCacheManager class.
-    public AxelixCachesEndpointTest setCacheManager(org.springframework.cache.CacheManager cacheManager) {
-        this.cacheManager = (EnhancedCacheManager) cacheManager;
+    @Autowired
+    public AxelixCachesEndpointTest setMainCacheManager(org.springframework.cache.CacheManager mainCacheManager) {
+        this.mainCacheManager = (EnhancedCacheManager) mainCacheManager;
         return this;
     }
+
+    @Autowired
+    public AxelixCachesEndpointTest setClearCacheManager(
+            @Qualifier(CLEAR_CACHE_MANAGER) org.springframework.cache.CacheManager cacheManager) {
+        this.clearCacheManager = (EnhancedCacheManager) cacheManager;
+        return this;
+    }
+
+    @Autowired
+    public AxelixCachesEndpointTest setEnableCacheManager(
+            @Qualifier(ENABLE_CACHE_MANAGER) org.springframework.cache.CacheManager cacheManager) {
+        this.enableCacheManager = (EnhancedCacheManager) cacheManager;
+        return this;
+    }
+
+    @Autowired
+    public AxelixCachesEndpointTest setDisableCacheManager(
+            @Qualifier(DISABLE_CACHE_MANAGER) org.springframework.cache.CacheManager cacheManager) {
+        this.disableCacheManager = (EnhancedCacheManager) cacheManager;
+        return this;
+    }
+
+    @Autowired
+    private Map<String, org.springframework.cache.CacheManager> allCacheManagers;
 
     @Autowired
     private TestRestTemplate testRestTemplate;
 
     @BeforeEach
     void setUp() {
-        cacheManager.enableAll();
-
-        for (String cacheName : cacheManager.getCacheNames()) {
-            cacheManager.getCache(cacheName).invalidate();
+        for (org.springframework.cache.CacheManager cacheManager : allCacheManagers.values()) {
+            if (cacheManager instanceof EnhancedCacheManager) {
+                EnhancedCacheManager enhancedCacheManager = (EnhancedCacheManager) cacheManager;
+                enhancedCacheManager.enableAll();
+                for (String cacheName : enhancedCacheManager.getCacheNames()) {
+                    org.springframework.cache.Cache cache = enhancedCacheManager.getCache(cacheName);
+                    if (cache != null) {
+                        cache.clear();
+                    }
+                }
+            }
         }
     }
 
     @Test
-    void shouldGetSingleCacheByName() {
-
+    void get_shouldReturnSingleCacheByName() {
         // when.
-        ResponseEntity<String> response = testRestTemplate.getForEntity(path(TEST_CACHE_1), String.class);
+        ResponseEntity<String> response =
+                testRestTemplate.getForEntity(path(MAIN_CACHE_MANAGER, TEST_CACHE_1), String.class);
 
         // then.
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         JsonAssertions.assertThatJson(response.getBody())
-                .isEqualTo("{\n" + "    \"cacheManager\" : \"cache2\",\n"
-                        + "    \"name\" : \"cache1\",\n"
-                        + "    \"target\" : \"java.util.concurrent.ConcurrentHashMap\",\n"
-                        + "    \"enabled\" : true,\n"
-                        + "    \"estimatedEntrySize\" : 0,\n"
-                        + "    \"lookupHistory\" : []\n"
-                        + "}");
+                .isEqualTo(
+                        // language=json
+                        String.format(
+                                "{\n"
+                                        + "    \"cacheManager\" : \"%s\",\n"
+                                        + "    \"name\" : \"%s\",\n"
+                                        + "    \"target\" : \"java.util.concurrent.ConcurrentHashMap\",\n"
+                                        + "    \"enabled\" : true,\n"
+                                        + "    \"estimatedEntrySize\" : 0,\n"
+                                        + "    \"lookupHistory\" : []\n"
+                                        + "}\n",
+                                MAIN_CACHE_MANAGER, TEST_CACHE_1));
     }
 
     @Test
-    void clearKey_shouldEvictSingleEntry() {
-        String key1 = "key1", key2 = "key2";
-        org.springframework.cache.Cache cache = cacheManager.getCache(TEST_CACHE_1);
-        assertThat(cache).isNotNull();
+    void get_shouldReturnCacheInformation() {
+        org.springframework.cache.Cache cache1 = mainCacheManager.getCache(TEST_CACHE_1);
+        cache1.put("key1", "value1");
+        cache1.put("key2", "value2");
+        cache1.put("key3", "value3");
+        cache1.get("key1");
+        cache1.get("key2");
 
+        org.springframework.cache.Cache cache2 = mainCacheManager.getCache(TEST_CACHE_2);
+        cache2.put("key", "value");
+        cache2.get("key");
+        cache2.get("notCache1");
+        cache2.get("notCache2");
+
+        ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        CacheManager cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
+        assertThat(cacheManager.getCaches()).hasSize(2);
+
+        assertThat(cacheManager.getCaches().stream()
+                        .filter(c -> TEST_CACHE_1.equals(c.getName()))
+                        .findFirst())
+                .hasValueSatisfying(c -> {
+                    assertThat(c.isEnabled()).isTrue();
+                    assertThat(c.getTarget()).isNotNull();
+                    assertThat(c.isContainsStats()).isTrue();
+                });
+
+        assertThat(cacheManager.getCaches().stream()
+                        .filter(c -> TEST_CACHE_2.equals(c.getName()))
+                        .findFirst())
+                .hasValueSatisfying(c -> {
+                    assertThat(c.isEnabled()).isTrue();
+                    assertThat(c.getTarget()).isNotNull();
+                    assertThat(c.isContainsStats()).isTrue();
+                });
+    }
+
+    @Test
+    void clear_shouldEvictSingleEntry() {
+        String key1 = "key1", key2 = "key2";
+        org.springframework.cache.Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
         cache.put(key1, "value1");
         cache.put(key2, "value2");
-        assertThat(cache.get(key1)).isNotNull();
-        assertThat(cache.get(key2)).isNotNull();
 
-        ResponseEntity<Void> response =
-                testRestTemplate.exchange(path(TEST_CACHE_1 + "/clear?key=key2"), HttpMethod.DELETE, null, Void.class);
+        ResponseEntity<Void> response = testRestTemplate.exchange(
+                path(CLEAR_CACHE_MANAGER, TEST_CACHE_1 + "/clear?key=key2"), HttpMethod.DELETE, null, Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(cache.get(key2)).isNull();
@@ -134,16 +221,12 @@ class AxelixCachesEndpointTest {
     @Test
     void clear_shouldClearEntireCache() {
         String key1 = "key1", key2 = "key2";
-        org.springframework.cache.Cache cache = cacheManager.getCache(TEST_CACHE_1);
-        assertThat(cache).isNotNull();
-
+        org.springframework.cache.Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
         cache.put(key1, "value1");
         cache.put(key2, "value2");
-        assertThat(cache.get(key1)).isNotNull();
-        assertThat(cache.get(key2)).isNotNull();
 
-        ResponseEntity<Void> response =
-                testRestTemplate.exchange(path(TEST_CACHE_1 + "/clear"), HttpMethod.DELETE, null, Void.class);
+        ResponseEntity<Void> response = testRestTemplate.exchange(
+                path(CLEAR_CACHE_MANAGER, TEST_CACHE_1 + "/clear"), HttpMethod.DELETE, null, Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(cache.get(key1)).isNull();
@@ -151,36 +234,36 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    void clearKey_shouldReturnFalseIfKeyDoesNotExist() {
-        org.springframework.cache.Cache cache = cacheManager.getCache(TEST_CACHE_1);
-        assertThat(cache).isNotNull();
-        assertThat(cache.get("nonExistingKey")).isNull();
-
+    @Disabled // TODO In fact, we currently don't know what kind of cache exists
+    void clear_shouldReturnBadRequest_IfKeyDoesNotExist() {
         ResponseEntity<Void> response = testRestTemplate.exchange(
-                path(TEST_CACHE_1 + "/clear?key=nonExistingKey"), HttpMethod.DELETE, defaultEntity(), Void.class);
+                path(CLEAR_CACHE_MANAGER, TEST_CACHE_1 + "/clear?key=nonExistingKey"),
+                HttpMethod.DELETE,
+                defaultEntity(),
+                Void.class);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test
-    void clear_shouldReturnFalse_cacheDoesNotExist() {
+    @Disabled // TODO In fact, we currently don't know what kind of cacheManager exists
+    void clear_shouldReturnBadRequest_cacheDoesNotExist() {
         ResponseEntity<Void> response = testRestTemplate.exchange(
-                path("/nonExistentCache/clear"), HttpMethod.DELETE, defaultEntity(), Void.class);
+                path(CLEAR_CACHE_MANAGER, "/nonExistentCache/clear"), HttpMethod.DELETE, defaultEntity(), Void.class);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test
-    void clearAll_shouldClearAllCaches() {
+    void clear_shouldClearAllCaches() {
         String key1 = "key1", key2 = "key2";
-        org.springframework.cache.Cache cache1 = cacheManager.getCache(TEST_CACHE_1);
-        org.springframework.cache.Cache cache2 = cacheManager.getCache(TEST_CACHE_2);
-
+        org.springframework.cache.Cache cache1 = clearCacheManager.getCache(TEST_CACHE_1);
+        org.springframework.cache.Cache cache2 = clearCacheManager.getCache(TEST_CACHE_2);
         cache1.put(key1, "value1");
         cache2.put(key2, "value2");
 
         ResponseEntity<Void> response =
-                testRestTemplate.exchange(path("/clear-all"), HttpMethod.DELETE, null, Void.class);
+                testRestTemplate.exchange(path(CLEAR_CACHE_MANAGER, "/clear-all"), HttpMethod.DELETE, null, Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(cache1.get(key1)).isNull();
@@ -188,16 +271,14 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    void shouldDisableAllCaches_onDisableCacheManager() {
-        // given.
-        org.springframework.cache.Cache cache1 = cacheManager.getCache(TEST_CACHE_1);
-        org.springframework.cache.Cache cache2 = cacheManager.getCache(TEST_CACHE_2);
-
+    void disable_onDisableAllCacheManager() {
+        org.springframework.cache.Cache cache1 = disableCacheManager.getCache(TEST_CACHE_1);
+        org.springframework.cache.Cache cache2 = disableCacheManager.getCache(TEST_CACHE_2);
         cache1.put("key1", "value1");
         cache2.put("key2", "value2");
 
         // when.
-        testRestTemplate.postForObject(path("/disable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(path(DISABLE_CACHE_MANAGER, "/disable"), defaultEntity(), Void.class);
         cache1.put("key3", "value2");
         cache2.put("key4", "value2");
 
@@ -206,17 +287,16 @@ class AxelixCachesEndpointTest {
         assertThat(cache1.get("key3")).isNull();
         assertThat(cache2.get("key2")).isNull();
         assertThat(cache2.get("key4")).isNull();
-        assertThat(cacheManager.getCacheNames()).containsOnly(TEST_CACHE_1, TEST_CACHE_2);
+        assertThat(disableCacheManager.getCacheNames()).containsOnly(TEST_CACHE_1, TEST_CACHE_2);
     }
 
     @Test
-    void enableManager_shouldEnableCacheManager() {
-        // given.
-        org.springframework.cache.Cache cache = cacheManager.getCache(TEST_CACHE_1);
+    void enable_shouldEnableCacheManager() {
+        org.springframework.cache.Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
 
         // when.
-        testRestTemplate.postForObject(path("/disable"), defaultEntity(), Void.class);
-        testRestTemplate.postForObject(path("/enable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(path(ENABLE_CACHE_MANAGER, "/disable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(path(ENABLE_CACHE_MANAGER, "/enable"), defaultEntity(), Void.class);
         cache.put("key", "value");
 
         // then.
@@ -224,13 +304,14 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    void enableCache_shouldEnableOnlySpecificCache() {
-        // given.
-        org.springframework.cache.Cache cache = cacheManager.getCache(TEST_CACHE_1);
+    void enable_shouldEnableOnlySpecificCache() {
+        org.springframework.cache.Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
 
         // when.
-        testRestTemplate.postForObject(path(TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
-        testRestTemplate.postForObject(path(TEST_CACHE_1 + "/enable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(
+                path(ENABLE_CACHE_MANAGER, TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(
+                path(ENABLE_CACHE_MANAGER, TEST_CACHE_1 + "/enable"), defaultEntity(), Void.class);
 
         // then.
         cache.put("key", "value");
@@ -238,20 +319,16 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    void disableCache_shouldDisableSpecifiedCache() {
+    void disable_shouldDisableSpecifiedCache() {
         String targetEnabledCache = TEST_CACHE_1;
         String targetDisabledCache = TEST_CACHE_2;
-
-        org.springframework.cache.Cache enabledCache = cacheManager.getCache(targetEnabledCache);
-        org.springframework.cache.Cache disabledCache = cacheManager.getCache(targetDisabledCache);
-
+        org.springframework.cache.Cache enabledCache = disableCacheManager.getCache(targetEnabledCache);
+        org.springframework.cache.Cache disabledCache = disableCacheManager.getCache(targetDisabledCache);
         enabledCache.put("key1", "value");
         disabledCache.put("key1", "value");
 
-        assertThat(enabledCache.get("key1")).isNotNull();
-        assertThat(disabledCache.get("key1")).isNotNull();
-
-        testRestTemplate.postForObject(path(targetDisabledCache + "/disable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(
+                path(DISABLE_CACHE_MANAGER, targetDisabledCache + "/disable"), defaultEntity(), Void.class);
 
         enabledCache.put("key2", "value2");
         disabledCache.put("key2", "value2");
@@ -267,13 +344,7 @@ class AxelixCachesEndpointTest {
         ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-
-        CachesFeed cachesFeed = response.getBody();
-
-        CacheManager cacheManager = cachesFeed.getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
+        CacheManager cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
 
         assertThat(cacheManager.getCaches()).hasSize(2);
 
@@ -295,77 +366,29 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    void concurrentCache_shouldReturnCacheInformation() {
-        org.springframework.cache.Cache cache1 = this.cacheManager.getCache(TEST_CACHE_1);
-        cache1.put("key1", "value1");
-        cache1.put("key2", "value2");
-        cache1.put("key3", "value3");
-        cache1.get("key1");
-        cache1.get("key2");
-
-        org.springframework.cache.Cache cache2 = this.cacheManager.getCache(TEST_CACHE_2);
-        cache2.put("key", "value");
-        cache2.get("key");
-        cache2.get("notCache1");
-        cache2.get("notCache2");
-
-        ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
-
-        CacheManager cacheManager = response.getBody().getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(cacheManager.getCaches()).hasSize(2);
-
-        Cache cache1Info = cacheManager.getCaches().stream()
-                .filter(c -> TEST_CACHE_1.equals(c.getName()))
-                .findFirst()
-                .orElseThrow();
-        assertThat(cache1Info.isEnabled()).isTrue();
-        assertThat(cache1Info.getTarget()).isNotNull();
-        assertThat(cache1Info.isContainsStats()).isTrue();
-
-        Cache cache2Info = cacheManager.getCaches().stream()
-                .filter(c -> TEST_CACHE_2.equals(c.getName()))
-                .findFirst()
-                .orElseThrow();
-        assertThat(cache2Info.isEnabled()).isTrue();
-        assertThat(cache2Info.getTarget()).isNotNull();
-        assertThat(cache2Info.isContainsStats()).isTrue();
-    }
-
-    @Test
     void caches_shouldShowDisableEnabledCache() {
-        cacheManager.getCache(TEST_CACHE_1);
+        mainCacheManager.getCache(TEST_CACHE_1);
 
-        testRestTemplate.postForObject(path(TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(
+                path(ENABLE_CACHE_MANAGER, TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
 
         ResponseEntity<CachesFeed> afterDisablingResponse = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
         assertThat(afterDisablingResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager disabledCacheManager = afterDisablingResponse.getBody().getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
-
-        Cache disabledCache = disabledCacheManager.getCaches().stream()
-                .filter(c -> TEST_CACHE_1.equals(c.getName()))
-                .findFirst()
-                .orElseThrow();
+        Cache disabledCache =
+                getCacheManager(afterDisablingResponse.getBody(), ENABLE_CACHE_MANAGER).getCaches().stream()
+                        .filter(c -> TEST_CACHE_1.equals(c.getName()))
+                        .findFirst()
+                        .orElseThrow();
         assertThat(disabledCache.isEnabled()).isFalse();
 
-        testRestTemplate.postForObject(path(TEST_CACHE_1 + "/enable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(
+                path(ENABLE_CACHE_MANAGER, TEST_CACHE_1 + "/enable"), defaultEntity(), Void.class);
 
         ResponseEntity<CachesFeed> afterEnablingResponse = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
         assertThat(afterEnablingResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager enabledCacheManager = afterEnablingResponse.getBody().getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
-
-        Cache enabledCache = enabledCacheManager.getCaches().stream()
+        Cache enabledCache = getCacheManager(afterEnablingResponse.getBody(), ENABLE_CACHE_MANAGER).getCaches().stream()
                 .filter(c -> TEST_CACHE_1.equals(c.getName()))
                 .findFirst()
                 .orElseThrow();
@@ -373,34 +396,29 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    void caches_shouldShowAllCachesDisabledWhenManagerIsDisabled() {
-        testRestTemplate.postForObject(path("/disable"), defaultEntity(), Void.class);
+    void disable_shouldShowAllCachesDisabledWhenManagerIsDisabled() {
+        testRestTemplate.postForObject(path(DISABLE_CACHE_MANAGER, "/disable"), defaultEntity(), Void.class);
 
         ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager cacheManager = response.getBody().getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
+        CacheManager cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
 
         assertThat(cacheManager.getCaches())
                 .allSatisfy(cacheInfo -> assertThat(cacheInfo.isEnabled()).isFalse());
     }
 
     @Test
-    void caches_shouldShowMixedEnabledStatusWhenSomeCachesAreDisabled() {
-        testRestTemplate.postForObject(path(TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
+    void disable_shouldShowMixedEnabledStatusWhenSomeCachesAreDisabled() {
+        testRestTemplate.postForObject(
+                path(DISABLE_CACHE_MANAGER, TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
 
         ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager cacheManager = response.getBody().getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
+        CacheManager cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
 
         Cache cache1Info = cacheManager.getCaches().stream()
                 .filter(c -> TEST_CACHE_1.equals(c.getName()))
@@ -415,56 +433,36 @@ class AxelixCachesEndpointTest {
         assertThat(cache2Info.isEnabled()).isTrue();
     }
 
-    @Test
-    void caches_shouldIncludeTargetInformation() {
-        ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-
-        CacheManager cacheManager = response.getBody().getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
-
-        Cache cacheInfo = cacheManager.getCaches().stream()
-                .filter(c -> TEST_CACHE_1.equals(c.getName()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(cacheInfo.getTarget()).isNotNull().isNotEmpty().contains("ConcurrentHashMap");
-    }
-
     // TODO: I'm not sure that this return 200 OK is the correct way of handling the non existent cache
     @Test
+    @Disabled
     void enableCache_shouldHandleNonExistentCache() {
-        ResponseEntity<Void> response =
-                testRestTemplate.postForEntity(path("/nonExistentCache/enable"), defaultEntity(), Void.class);
+        ResponseEntity<Void> response = testRestTemplate.postForEntity(
+                path(ENABLE_CACHE_MANAGER, "/nonExistentCache/enable"), defaultEntity(), Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     @Test
     void disableCache_shouldHandleNonExistentCache() {
-        ResponseEntity<Void> response =
-                testRestTemplate.postForEntity(path("/nonExistentCache/disable"), defaultEntity(), Void.class);
+        ResponseEntity<Void> response = testRestTemplate.postForEntity(
+                path(DISABLE_CACHE_MANAGER, "/nonExistentCache/disable"), defaultEntity(), Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
-    @Test
-    void enableManager_shouldThrowExceptionForNonExistentManager() {
+    @ParameterizedTest
+    @MethodSource("nonExistentManagerPaths")
+    void managerOperation_shouldThrowExceptionForNonExistentManager(String cacheManagerName, String relativePath) {
         ResponseEntity<String> response =
-                testRestTemplate.postForEntity(path("nonExistentManager", "/enable"), defaultEntity(), String.class);
+                testRestTemplate.postForEntity(path(cacheManagerName, relativePath), defaultEntity(), String.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    @Test
-    void disableManager_shouldThrowExceptionForNonExistentManager() {
-        ResponseEntity<String> response =
-                testRestTemplate.postForEntity(path("/nonExistentManager", "/disable"), defaultEntity(), String.class);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    private static Stream<Arguments> nonExistentManagerPaths() {
+        return Stream.of(
+                Arguments.of("nonExistentManager", "/enable"), Arguments.of("/nonExistentManager", "/disable"));
     }
 
     @Test
@@ -476,30 +474,25 @@ class AxelixCachesEndpointTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
-    @Test
-    void enableCache_shouldThrowExceptionForNonExistentManager() {
-        ResponseEntity<String> response = testRestTemplate.postForEntity(
-                path("/nonExistentManager", "/nonExistentCache/enable"), defaultEntity(), String.class);
+    @ParameterizedTest
+    @MethodSource("nonExistentManagerAndCachePaths")
+    void cacheOperation_shouldThrowExceptionForNonExistentManager(String cacheManagerName, String relativePath) {
+        ResponseEntity<String> response =
+                testRestTemplate.postForEntity(path(cacheManagerName, relativePath), defaultEntity(), String.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    @Test
-    void disableCache_shouldThrowExceptionForNonExistentManager() {
-        ResponseEntity<String> response = testRestTemplate.postForEntity(
-                path("/nonExistentManager", "/nonExistentCache/disable"), defaultEntity(), String.class);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    private static Stream<Arguments> nonExistentManagerAndCachePaths() {
+        return Stream.of(
+                Arguments.of("/nonExistentManager", "/nonExistentCache/enable"),
+                Arguments.of("/nonExistentManager", "/nonExistentCache/disable"));
     }
 
     private HttpEntity<Void> defaultEntity() {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         return new HttpEntity<>(headers);
-    }
-
-    private String path(String relative) {
-        return path(TEST_CACHE_MANAGER, relative);
     }
 
     private String rootPath() {
@@ -517,6 +510,17 @@ class AxelixCachesEndpointTest {
         return (path.isEmpty() || path.charAt(0) == '/') ? path : "/" + path;
     }
 
+    private CacheManager getCacheManager(CachesFeed source, String cacheManagerName) {
+        CachesFeed nonNullSource = Objects.requireNonNull(source, "CachesFeed source is null");
+        java.util.List<CacheManager> cacheManagers =
+                Objects.requireNonNull(nonNullSource.getCacheManagers(), "CachesFeed cacheManagers is null");
+
+        return cacheManagers.stream()
+                .filter(cm -> cacheManagerName.equals(cm.getName()))
+                .findFirst()
+                .orElseThrow();
+    }
+
     @TestConfiguration
     public static class CacheDispatcherEndpointTestConfiguration {
 
@@ -531,8 +535,24 @@ class AxelixCachesEndpointTest {
             return new CacheManagerBeanPostProcessor();
         }
 
-        @Bean(name = TEST_CACHE_MANAGER)
+        @Bean(name = MAIN_CACHE_MANAGER)
+        @Primary
         public org.springframework.cache.CacheManager testSubjectCacheManager() {
+            return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
+        }
+
+        @Bean(name = CLEAR_CACHE_MANAGER)
+        public org.springframework.cache.CacheManager clearSubjectCacheManager() {
+            return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
+        }
+
+        @Bean(name = ENABLE_CACHE_MANAGER)
+        public org.springframework.cache.CacheManager enableSubjectCacheManager() {
+            return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
+        }
+
+        @Bean(name = DISABLE_CACHE_MANAGER)
+        public org.springframework.cache.CacheManager disableSubjectCacheManager() {
             return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
         }
     }

--- a/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
+++ b/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
@@ -239,7 +239,7 @@ class DefaultCacheOperationsDispatcherTest {
         CachesFeed cachesFeed = dispatcher.getAll();
 
         // then.
-        CachesFeed.Cache cache = cachesFeed.getCacheManagers().stream()
+        CachesFeed.CacheDto cache = cachesFeed.getCacheManagers().stream()
                 .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
                 .findFirst()
                 .orElseThrow()
@@ -262,7 +262,7 @@ class DefaultCacheOperationsDispatcherTest {
         CachesFeed cachesFeed = dispatcher.getAll();
 
         // then.
-        CachesFeed.Cache cache = cachesFeed.getCacheManagers().stream()
+        CachesFeed.CacheDto cache = cachesFeed.getCacheManagers().stream()
                 .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
                 .findFirst()
                 .orElseThrow()

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcher.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcher.java
@@ -88,17 +88,17 @@ public class DefaultCacheOperationsDispatcher implements CacheOperationsDispatch
 
     @Override
     public CachesFeed getAll() {
-        List<CachesFeed.CacheManager> feed = new ArrayList<>();
+        List<CachesFeed.CacheManagerDto> feed = new ArrayList<>();
 
         this.cacheManagers.forEach((cacheManagerName, enhancedCacheManager) -> {
-            feed.add(new CachesFeed.CacheManager(
+            feed.add(new CachesFeed.CacheManagerDto(
                     cacheManagerName,
                     enhancedCacheManager.getAll().stream()
                             .map(enhancedCache -> {
                                 boolean containsStats =
                                         !enhancedCache.getCacheLookups().isEmpty();
 
-                                return new CachesFeed.Cache(
+                                return new CachesFeed.CacheDto(
                                         enhancedCache.getName(),
                                         enhancedCache
                                                 .getNativeCache()

--- a/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
+++ b/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
@@ -34,6 +34,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -46,8 +48,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import com.axelixlabs.axelix.common.api.caches.CachesFeed;
-import com.axelixlabs.axelix.common.api.caches.CachesFeed.Cache;
-import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheManager;
+import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheDto;
+import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheManagerDto;
 import com.axelixlabs.axelix.sbs.spring.core.Main;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -91,45 +93,43 @@ class AxelixCachesEndpointTest {
     // The bean definition in the context for cache manager has a type of CacheManager,
     // so we cannot do simple field injection via EnhancedCacheManager class.
     @Autowired
-    public AxelixCachesEndpointTest setMainCacheManager(org.springframework.cache.CacheManager mainCacheManager) {
+    public AxelixCachesEndpointTest setMainCacheManager(CacheManager mainCacheManager) {
         this.mainCacheManager = (EnhancedCacheManager) mainCacheManager;
         return this;
     }
 
     @Autowired
-    public AxelixCachesEndpointTest setClearCacheManager(
-            @Qualifier(CLEAR_CACHE_MANAGER) org.springframework.cache.CacheManager cacheManager) {
+    public AxelixCachesEndpointTest setClearCacheManager(@Qualifier(CLEAR_CACHE_MANAGER) CacheManager cacheManager) {
         this.clearCacheManager = (EnhancedCacheManager) cacheManager;
         return this;
     }
 
     @Autowired
-    public AxelixCachesEndpointTest setEnableCacheManager(
-            @Qualifier(ENABLE_CACHE_MANAGER) org.springframework.cache.CacheManager cacheManager) {
+    public AxelixCachesEndpointTest setEnableCacheManager(@Qualifier(ENABLE_CACHE_MANAGER) CacheManager cacheManager) {
         this.enableCacheManager = (EnhancedCacheManager) cacheManager;
         return this;
     }
 
     @Autowired
     public AxelixCachesEndpointTest setDisableCacheManager(
-            @Qualifier(DISABLE_CACHE_MANAGER) org.springframework.cache.CacheManager cacheManager) {
+            @Qualifier(DISABLE_CACHE_MANAGER) CacheManager cacheManager) {
         this.disableCacheManager = (EnhancedCacheManager) cacheManager;
         return this;
     }
 
     @Autowired
-    private Map<String, org.springframework.cache.CacheManager> allCacheManagers;
+    private Map<String, CacheManager> allCacheManagers;
 
     @Autowired
     private TestRestTemplate testRestTemplate;
 
     @BeforeEach
     void setUp() {
-        for (org.springframework.cache.CacheManager cacheManager : allCacheManagers.values()) {
+        for (CacheManager cacheManager : allCacheManagers.values()) {
             if (cacheManager instanceof EnhancedCacheManager enhancedCacheManager) {
                 enhancedCacheManager.enableAll();
                 for (String cacheName : enhancedCacheManager.getCacheNames()) {
-                    org.springframework.cache.Cache cache = enhancedCacheManager.getCache(cacheName);
+                    Cache cache = enhancedCacheManager.getCache(cacheName);
                     if (cache != null) {
                         cache.clear();
                     }
@@ -163,14 +163,14 @@ class AxelixCachesEndpointTest {
 
     @Test
     void get_shouldReturnCacheInformation() {
-        org.springframework.cache.Cache cache1 = mainCacheManager.getCache(TEST_CACHE_1);
+        Cache cache1 = mainCacheManager.getCache(TEST_CACHE_1);
         cache1.put("key1", "value1");
         cache1.put("key2", "value2");
         cache1.put("key3", "value3");
         cache1.get("key1");
         cache1.get("key2");
 
-        org.springframework.cache.Cache cache2 = mainCacheManager.getCache(TEST_CACHE_2);
+        Cache cache2 = mainCacheManager.getCache(TEST_CACHE_2);
         cache2.put("key", "value");
         cache2.get("key");
         cache2.get("notCache1");
@@ -179,7 +179,7 @@ class AxelixCachesEndpointTest {
         ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
+        CacheManagerDto cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
         assertThat(cacheManager.getCaches()).hasSize(2);
 
         assertThat(cacheManager.getCaches().stream()
@@ -204,7 +204,7 @@ class AxelixCachesEndpointTest {
     @Test
     void clear_shouldEvictSingleEntry() {
         String key1 = "key1", key2 = "key2";
-        org.springframework.cache.Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
+        Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
         cache.put(key1, "value1");
         cache.put(key2, "value2");
 
@@ -219,7 +219,7 @@ class AxelixCachesEndpointTest {
     @Test
     void clear_shouldClearEntireCache() {
         String key1 = "key1", key2 = "key2";
-        org.springframework.cache.Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
+        Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
         cache.put(key1, "value1");
         cache.put(key2, "value2");
 
@@ -232,31 +232,10 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    @Disabled // TODO In fact, we currently don't know what kind of cache exists
-    void clear_shouldReturnBadRequest_IfKeyDoesNotExist() {
-        ResponseEntity<Void> response = testRestTemplate.exchange(
-                path(CLEAR_CACHE_MANAGER, TEST_CACHE_1 + "/clear?key=nonExistingKey"),
-                HttpMethod.DELETE,
-                defaultEntity(),
-                Void.class);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
-    @Disabled // TODO In fact, we currently don't know what kind of cacheManager exists
-    void clear_shouldReturnBadRequest_cacheDoesNotExist() {
-        ResponseEntity<Void> response = testRestTemplate.exchange(
-                path(CLEAR_CACHE_MANAGER, "/nonExistentCache/clear"), HttpMethod.DELETE, defaultEntity(), Void.class);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
     void clear_shouldClearAllCaches() {
         String key1 = "key1", key2 = "key2";
-        org.springframework.cache.Cache cache1 = clearCacheManager.getCache(TEST_CACHE_1);
-        org.springframework.cache.Cache cache2 = clearCacheManager.getCache(TEST_CACHE_2);
+        Cache cache1 = clearCacheManager.getCache(TEST_CACHE_1);
+        Cache cache2 = clearCacheManager.getCache(TEST_CACHE_2);
         cache1.put(key1, "value1");
         cache2.put(key2, "value2");
 
@@ -270,8 +249,8 @@ class AxelixCachesEndpointTest {
 
     @Test
     void disable_onDisableAllCacheManager() {
-        org.springframework.cache.Cache cache1 = disableCacheManager.getCache(TEST_CACHE_1);
-        org.springframework.cache.Cache cache2 = disableCacheManager.getCache(TEST_CACHE_2);
+        Cache cache1 = disableCacheManager.getCache(TEST_CACHE_1);
+        Cache cache2 = disableCacheManager.getCache(TEST_CACHE_2);
         cache1.put("key1", "value1");
         cache2.put("key2", "value2");
 
@@ -290,7 +269,7 @@ class AxelixCachesEndpointTest {
 
     @Test
     void enable_shouldEnableCacheManager() {
-        org.springframework.cache.Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
+        Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
 
         // when.
         testRestTemplate.postForObject(path(ENABLE_CACHE_MANAGER, "/disable"), defaultEntity(), Void.class);
@@ -303,7 +282,7 @@ class AxelixCachesEndpointTest {
 
     @Test
     void enable_shouldEnableOnlySpecificCache() {
-        org.springframework.cache.Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
+        Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
 
         // when.
         testRestTemplate.postForObject(
@@ -320,8 +299,8 @@ class AxelixCachesEndpointTest {
     void disable_shouldDisableSpecifiedCache() {
         String targetEnabledCache = TEST_CACHE_1;
         String targetDisabledCache = TEST_CACHE_2;
-        org.springframework.cache.Cache enabledCache = disableCacheManager.getCache(targetEnabledCache);
-        org.springframework.cache.Cache disabledCache = disableCacheManager.getCache(targetDisabledCache);
+        Cache enabledCache = disableCacheManager.getCache(targetEnabledCache);
+        Cache disabledCache = disableCacheManager.getCache(targetDisabledCache);
         enabledCache.put("key1", "value");
         disabledCache.put("key1", "value");
 
@@ -342,11 +321,11 @@ class AxelixCachesEndpointTest {
         ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        CacheManager cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
+        CacheManagerDto cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
 
         assertThat(cacheManager.getCaches()).hasSize(2);
 
-        Cache cache1Info = cacheManager.getCaches().stream()
+        CacheDto cache1Info = cacheManager.getCaches().stream()
                 .filter(c -> TEST_CACHE_1.equals(c.getName()))
                 .findFirst()
                 .orElseThrow();
@@ -354,7 +333,7 @@ class AxelixCachesEndpointTest {
         assertThat(cache1Info.getTarget()).isNotNull();
         assertThat(cache1Info.isContainsStats()).isFalse();
 
-        Cache cache2Info = cacheManager.getCaches().stream()
+        CacheDto cache2Info = cacheManager.getCaches().stream()
                 .filter(c -> TEST_CACHE_2.equals(c.getName()))
                 .findFirst()
                 .orElseThrow();
@@ -373,7 +352,7 @@ class AxelixCachesEndpointTest {
         ResponseEntity<CachesFeed> afterDisablingResponse = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
         assertThat(afterDisablingResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        Cache disabledCache =
+        CacheDto disabledCache =
                 getCacheManager(afterDisablingResponse.getBody(), ENABLE_CACHE_MANAGER).getCaches().stream()
                         .filter(c -> TEST_CACHE_1.equals(c.getName()))
                         .findFirst()
@@ -386,10 +365,11 @@ class AxelixCachesEndpointTest {
         ResponseEntity<CachesFeed> afterEnablingResponse = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
         assertThat(afterEnablingResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        Cache enabledCache = getCacheManager(afterEnablingResponse.getBody(), ENABLE_CACHE_MANAGER).getCaches().stream()
-                .filter(c -> TEST_CACHE_1.equals(c.getName()))
-                .findFirst()
-                .orElseThrow();
+        CacheDto enabledCache =
+                getCacheManager(afterEnablingResponse.getBody(), ENABLE_CACHE_MANAGER).getCaches().stream()
+                        .filter(c -> TEST_CACHE_1.equals(c.getName()))
+                        .findFirst()
+                        .orElseThrow();
         assertThat(enabledCache.isEnabled()).isTrue();
     }
 
@@ -401,7 +381,7 @@ class AxelixCachesEndpointTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
+        CacheManagerDto cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
 
         assertThat(cacheManager.getCaches())
                 .allSatisfy(cacheInfo -> assertThat(cacheInfo.isEnabled()).isFalse());
@@ -416,15 +396,15 @@ class AxelixCachesEndpointTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
+        CacheManagerDto cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
 
-        Cache cache1Info = cacheManager.getCaches().stream()
+        CacheDto cache1Info = cacheManager.getCaches().stream()
                 .filter(c -> TEST_CACHE_1.equals(c.getName()))
                 .findFirst()
                 .orElseThrow();
         assertThat(cache1Info.isEnabled()).isFalse();
 
-        Cache cache2Info = cacheManager.getCaches().stream()
+        CacheDto cache2Info = cacheManager.getCaches().stream()
                 .filter(c -> TEST_CACHE_2.equals(c.getName()))
                 .findFirst()
                 .orElseThrow();
@@ -508,17 +488,8 @@ class AxelixCachesEndpointTest {
         return (path.isEmpty() || path.charAt(0) == '/') ? path : "/" + path;
     }
 
-    private CacheManager getCacheManager(CachesFeed source, String cacheManagerName) {
-        if (source == null) {
-            throw new AssertionError("Expected non-null CachesFeed from response");
-        }
-
-        java.util.List<CacheManager> cacheManagers = source.getCacheManagers();
-        if (cacheManagers == null || cacheManagers.isEmpty()) {
-            throw new AssertionError("No cache managers present");
-        }
-
-        return cacheManagers.stream()
+    private CacheManagerDto getCacheManager(CachesFeed source, String cacheManagerName) {
+        return source.getCacheManagers().stream()
                 .filter(cm -> cacheManagerName.equals(cm.getName()))
                 .findFirst()
                 .orElseThrow();
@@ -540,22 +511,22 @@ class AxelixCachesEndpointTest {
 
         @Bean(name = MAIN_CACHE_MANAGER)
         @Primary
-        public org.springframework.cache.CacheManager testSubjectCacheManager() {
+        public CacheManager testSubjectCacheManager() {
             return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
         }
 
         @Bean(name = CLEAR_CACHE_MANAGER)
-        public org.springframework.cache.CacheManager clearSubjectCacheManager() {
+        public CacheManager clearSubjectCacheManager() {
             return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
         }
 
         @Bean(name = ENABLE_CACHE_MANAGER)
-        public org.springframework.cache.CacheManager enableSubjectCacheManager() {
+        public CacheManager enableSubjectCacheManager() {
             return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
         }
 
         @Bean(name = DISABLE_CACHE_MANAGER)
-        public org.springframework.cache.CacheManager disableSubjectCacheManager() {
+        public CacheManager disableSubjectCacheManager() {
             return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
         }
     }

--- a/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
+++ b/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
@@ -17,12 +17,19 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.cache;
 
+import java.util.Map;
+import java.util.stream.Stream;
+
 import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -30,13 +37,13 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.annotation.DirtiesContext;
 
 import com.axelixlabs.axelix.common.api.caches.CachesFeed;
 import com.axelixlabs.axelix.common.api.caches.CachesFeed.Cache;
@@ -65,43 +72,77 @@ import static org.assertj.core.api.Assertions.assertThat;
     DefaultCacheOperationsDispatcher.class,
     AxelixCachesEndpointTest.CacheDispatcherEndpointTestConfiguration.class
 })
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class AxelixCachesEndpointTest {
 
     // Cache names under test
     private static final String TEST_CACHE_1 = "cache1";
-
     private static final String TEST_CACHE_2 = "cache2";
 
-    private static final String TEST_CACHE_MANAGER = TEST_CACHE_2;
+    private static final String MAIN_CACHE_MANAGER = "mainCacheManager";
+    private static final String CLEAR_CACHE_MANAGER = "clearCacheManager";
+    private static final String ENABLE_CACHE_MANAGER = "enableCacheManager";
+    private static final String DISABLE_CACHE_MANAGER = "disableCacheManager";
 
-    private EnhancedCacheManager cacheManager;
+    private EnhancedCacheManager mainCacheManager;
+    private EnhancedCacheManager clearCacheManager;
+    private EnhancedCacheManager enableCacheManager;
+    private EnhancedCacheManager disableCacheManager;
 
-    @Autowired
     // The bean definition in the context for cache manager has a type of CacheManager,
     // so we cannot do simple field injection via EnhancedCacheManager class.
-    public AxelixCachesEndpointTest setCacheManager(org.springframework.cache.CacheManager cacheManager) {
-        this.cacheManager = (EnhancedCacheManager) cacheManager;
+    @Autowired
+    public AxelixCachesEndpointTest setMainCacheManager(org.springframework.cache.CacheManager mainCacheManager) {
+        this.mainCacheManager = (EnhancedCacheManager) mainCacheManager;
         return this;
     }
+
+    @Autowired
+    public AxelixCachesEndpointTest setClearCacheManager(
+            @Qualifier(CLEAR_CACHE_MANAGER) org.springframework.cache.CacheManager cacheManager) {
+        this.clearCacheManager = (EnhancedCacheManager) cacheManager;
+        return this;
+    }
+
+    @Autowired
+    public AxelixCachesEndpointTest setEnableCacheManager(
+            @Qualifier(ENABLE_CACHE_MANAGER) org.springframework.cache.CacheManager cacheManager) {
+        this.enableCacheManager = (EnhancedCacheManager) cacheManager;
+        return this;
+    }
+
+    @Autowired
+    public AxelixCachesEndpointTest setDisableCacheManager(
+            @Qualifier(DISABLE_CACHE_MANAGER) org.springframework.cache.CacheManager cacheManager) {
+        this.disableCacheManager = (EnhancedCacheManager) cacheManager;
+        return this;
+    }
+
+    @Autowired
+    private Map<String, org.springframework.cache.CacheManager> allCacheManagers;
 
     @Autowired
     private TestRestTemplate testRestTemplate;
 
     @BeforeEach
     void setUp() {
-        cacheManager.enableAll();
-
-        for (String cacheName : cacheManager.getCacheNames()) {
-            cacheManager.getCache(cacheName).invalidate();
+        for (org.springframework.cache.CacheManager cacheManager : allCacheManagers.values()) {
+            if (cacheManager instanceof EnhancedCacheManager enhancedCacheManager) {
+                enhancedCacheManager.enableAll();
+                for (String cacheName : enhancedCacheManager.getCacheNames()) {
+                    org.springframework.cache.Cache cache = enhancedCacheManager.getCache(cacheName);
+                    if (cache != null) {
+                        cache.clear();
+                    }
+                }
+            }
         }
     }
 
     @Test
-    void shouldGetSingleCacheByName() {
-
+    void get_shouldReturnSingleCacheByName() {
         // when.
-        ResponseEntity<String> response = testRestTemplate.getForEntity(path(TEST_CACHE_1), String.class);
+        ResponseEntity<String> response =
+                testRestTemplate.getForEntity(path(MAIN_CACHE_MANAGER, TEST_CACHE_1), String.class);
 
         // then.
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -110,29 +151,65 @@ class AxelixCachesEndpointTest {
                         // language=json
                         """
                 {
-                    "cacheManager" : "cache2",
-                    "name" : "cache1",
+                    "cacheManager" : "%s",
+                    "name" : "%s",
                     "target" : "java.util.concurrent.ConcurrentHashMap",
                     "enabled" : true,
                     "estimatedEntrySize" : 0,
                     "lookupHistory" : []
                 }
-                """);
+                """.formatted(MAIN_CACHE_MANAGER, TEST_CACHE_1));
     }
 
     @Test
-    void clearKey_shouldEvictSingleEntry() {
-        String key1 = "key1", key2 = "key2";
-        org.springframework.cache.Cache cache = cacheManager.getCache(TEST_CACHE_1);
-        assertThat(cache).isNotNull();
+    void get_shouldReturnCacheInformation() {
+        org.springframework.cache.Cache cache1 = mainCacheManager.getCache(TEST_CACHE_1);
+        cache1.put("key1", "value1");
+        cache1.put("key2", "value2");
+        cache1.put("key3", "value3");
+        cache1.get("key1");
+        cache1.get("key2");
 
+        org.springframework.cache.Cache cache2 = mainCacheManager.getCache(TEST_CACHE_2);
+        cache2.put("key", "value");
+        cache2.get("key");
+        cache2.get("notCache1");
+        cache2.get("notCache2");
+
+        ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        CacheManager cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
+        assertThat(cacheManager.getCaches()).hasSize(2);
+
+        assertThat(cacheManager.getCaches().stream()
+                        .filter(c -> TEST_CACHE_1.equals(c.getName()))
+                        .findFirst())
+                .hasValueSatisfying(c -> {
+                    assertThat(c.isEnabled()).isTrue();
+                    assertThat(c.getTarget()).isNotNull();
+                    assertThat(c.isContainsStats()).isTrue();
+                });
+
+        assertThat(cacheManager.getCaches().stream()
+                        .filter(c -> TEST_CACHE_2.equals(c.getName()))
+                        .findFirst())
+                .hasValueSatisfying(c -> {
+                    assertThat(c.isEnabled()).isTrue();
+                    assertThat(c.getTarget()).isNotNull();
+                    assertThat(c.isContainsStats()).isTrue();
+                });
+    }
+
+    @Test
+    void clear_shouldEvictSingleEntry() {
+        String key1 = "key1", key2 = "key2";
+        org.springframework.cache.Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
         cache.put(key1, "value1");
         cache.put(key2, "value2");
-        assertThat(cache.get(key1)).isNotNull();
-        assertThat(cache.get(key2)).isNotNull();
 
-        ResponseEntity<Void> response =
-                testRestTemplate.exchange(path(TEST_CACHE_1 + "/clear?key=key2"), HttpMethod.DELETE, null, Void.class);
+        ResponseEntity<Void> response = testRestTemplate.exchange(
+                path(CLEAR_CACHE_MANAGER, TEST_CACHE_1 + "/clear?key=key2"), HttpMethod.DELETE, null, Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(cache.get(key2)).isNull();
@@ -142,16 +219,12 @@ class AxelixCachesEndpointTest {
     @Test
     void clear_shouldClearEntireCache() {
         String key1 = "key1", key2 = "key2";
-        org.springframework.cache.Cache cache = cacheManager.getCache(TEST_CACHE_1);
-        assertThat(cache).isNotNull();
-
+        org.springframework.cache.Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
         cache.put(key1, "value1");
         cache.put(key2, "value2");
-        assertThat(cache.get(key1)).isNotNull();
-        assertThat(cache.get(key2)).isNotNull();
 
-        ResponseEntity<Void> response =
-                testRestTemplate.exchange(path(TEST_CACHE_1 + "/clear"), HttpMethod.DELETE, null, Void.class);
+        ResponseEntity<Void> response = testRestTemplate.exchange(
+                path(CLEAR_CACHE_MANAGER, TEST_CACHE_1 + "/clear"), HttpMethod.DELETE, null, Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(cache.get(key1)).isNull();
@@ -159,36 +232,36 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    void clearKey_shouldReturnFalseIfKeyDoesNotExist() {
-        org.springframework.cache.Cache cache = cacheManager.getCache(TEST_CACHE_1);
-        assertThat(cache).isNotNull();
-        assertThat(cache.get("nonExistingKey")).isNull();
-
+    @Disabled // TODO In fact, we currently don't know what kind of cache exists
+    void clear_shouldReturnBadRequest_IfKeyDoesNotExist() {
         ResponseEntity<Void> response = testRestTemplate.exchange(
-                path(TEST_CACHE_1 + "/clear?key=nonExistingKey"), HttpMethod.DELETE, defaultEntity(), Void.class);
+                path(CLEAR_CACHE_MANAGER, TEST_CACHE_1 + "/clear?key=nonExistingKey"),
+                HttpMethod.DELETE,
+                defaultEntity(),
+                Void.class);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test
-    void clear_shouldReturnFalse_cacheDoesNotExist() {
+    @Disabled // TODO In fact, we currently don't know what kind of cacheManager exists
+    void clear_shouldReturnBadRequest_cacheDoesNotExist() {
         ResponseEntity<Void> response = testRestTemplate.exchange(
-                path("/nonExistentCache/clear"), HttpMethod.DELETE, defaultEntity(), Void.class);
+                path(CLEAR_CACHE_MANAGER, "/nonExistentCache/clear"), HttpMethod.DELETE, defaultEntity(), Void.class);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test
-    void clearAll_shouldClearAllCaches() {
+    void clear_shouldClearAllCaches() {
         String key1 = "key1", key2 = "key2";
-        org.springframework.cache.Cache cache1 = cacheManager.getCache(TEST_CACHE_1);
-        org.springframework.cache.Cache cache2 = cacheManager.getCache(TEST_CACHE_2);
-
+        org.springframework.cache.Cache cache1 = clearCacheManager.getCache(TEST_CACHE_1);
+        org.springframework.cache.Cache cache2 = clearCacheManager.getCache(TEST_CACHE_2);
         cache1.put(key1, "value1");
         cache2.put(key2, "value2");
 
         ResponseEntity<Void> response =
-                testRestTemplate.exchange(path("/clear-all"), HttpMethod.DELETE, null, Void.class);
+                testRestTemplate.exchange(path(CLEAR_CACHE_MANAGER, "/clear-all"), HttpMethod.DELETE, null, Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(cache1.get(key1)).isNull();
@@ -196,16 +269,14 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    void shouldDisableAllCaches_onDisableCacheManager() {
-        // given.
-        org.springframework.cache.Cache cache1 = cacheManager.getCache(TEST_CACHE_1);
-        org.springframework.cache.Cache cache2 = cacheManager.getCache(TEST_CACHE_2);
-
+    void disable_onDisableAllCacheManager() {
+        org.springframework.cache.Cache cache1 = disableCacheManager.getCache(TEST_CACHE_1);
+        org.springframework.cache.Cache cache2 = disableCacheManager.getCache(TEST_CACHE_2);
         cache1.put("key1", "value1");
         cache2.put("key2", "value2");
 
         // when.
-        testRestTemplate.postForObject(path("/disable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(path(DISABLE_CACHE_MANAGER, "/disable"), defaultEntity(), Void.class);
         cache1.put("key3", "value2");
         cache2.put("key4", "value2");
 
@@ -214,17 +285,16 @@ class AxelixCachesEndpointTest {
         assertThat(cache1.get("key3")).isNull();
         assertThat(cache2.get("key2")).isNull();
         assertThat(cache2.get("key4")).isNull();
-        assertThat(cacheManager.getCacheNames()).containsOnly(TEST_CACHE_1, TEST_CACHE_2);
+        assertThat(disableCacheManager.getCacheNames()).containsOnly(TEST_CACHE_1, TEST_CACHE_2);
     }
 
     @Test
-    void enableManager_shouldEnableCacheManager() {
-        // given.
-        org.springframework.cache.Cache cache = cacheManager.getCache(TEST_CACHE_1);
+    void enable_shouldEnableCacheManager() {
+        org.springframework.cache.Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
 
         // when.
-        testRestTemplate.postForObject(path("/disable"), defaultEntity(), Void.class);
-        testRestTemplate.postForObject(path("/enable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(path(ENABLE_CACHE_MANAGER, "/disable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(path(ENABLE_CACHE_MANAGER, "/enable"), defaultEntity(), Void.class);
         cache.put("key", "value");
 
         // then.
@@ -232,13 +302,14 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    void enableCache_shouldEnableOnlySpecificCache() {
-        // given.
-        org.springframework.cache.Cache cache = cacheManager.getCache(TEST_CACHE_1);
+    void enable_shouldEnableOnlySpecificCache() {
+        org.springframework.cache.Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
 
         // when.
-        testRestTemplate.postForObject(path(TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
-        testRestTemplate.postForObject(path(TEST_CACHE_1 + "/enable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(
+                path(ENABLE_CACHE_MANAGER, TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(
+                path(ENABLE_CACHE_MANAGER, TEST_CACHE_1 + "/enable"), defaultEntity(), Void.class);
 
         // then.
         cache.put("key", "value");
@@ -246,20 +317,16 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    void disableCache_shouldDisableSpecifiedCache() {
+    void disable_shouldDisableSpecifiedCache() {
         String targetEnabledCache = TEST_CACHE_1;
         String targetDisabledCache = TEST_CACHE_2;
-
-        org.springframework.cache.Cache enabledCache = cacheManager.getCache(targetEnabledCache);
-        org.springframework.cache.Cache disabledCache = cacheManager.getCache(targetDisabledCache);
-
+        org.springframework.cache.Cache enabledCache = disableCacheManager.getCache(targetEnabledCache);
+        org.springframework.cache.Cache disabledCache = disableCacheManager.getCache(targetDisabledCache);
         enabledCache.put("key1", "value");
         disabledCache.put("key1", "value");
 
-        assertThat(enabledCache.get("key1")).isNotNull();
-        assertThat(disabledCache.get("key1")).isNotNull();
-
-        testRestTemplate.postForObject(path(targetDisabledCache + "/disable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(
+                path(DISABLE_CACHE_MANAGER, targetDisabledCache + "/disable"), defaultEntity(), Void.class);
 
         enabledCache.put("key2", "value2");
         disabledCache.put("key2", "value2");
@@ -275,13 +342,7 @@ class AxelixCachesEndpointTest {
         ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-
-        CachesFeed cachesFeed = response.getBody();
-
-        CacheManager cacheManager = cachesFeed.getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
+        CacheManager cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
 
         assertThat(cacheManager.getCaches()).hasSize(2);
 
@@ -303,77 +364,29 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    void concurrentCache_shouldReturnCacheInformation() {
-        org.springframework.cache.Cache cache1 = this.cacheManager.getCache(TEST_CACHE_1);
-        cache1.put("key1", "value1");
-        cache1.put("key2", "value2");
-        cache1.put("key3", "value3");
-        cache1.get("key1");
-        cache1.get("key2");
-
-        org.springframework.cache.Cache cache2 = this.cacheManager.getCache(TEST_CACHE_2);
-        cache2.put("key", "value");
-        cache2.get("key");
-        cache2.get("notCache1");
-        cache2.get("notCache2");
-
-        ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
-
-        CacheManager cacheManager = response.getBody().getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(cacheManager.getCaches()).hasSize(2);
-
-        Cache cache1Info = cacheManager.getCaches().stream()
-                .filter(c -> TEST_CACHE_1.equals(c.getName()))
-                .findFirst()
-                .orElseThrow();
-        assertThat(cache1Info.isEnabled()).isTrue();
-        assertThat(cache1Info.getTarget()).isNotNull();
-        assertThat(cache1Info.isContainsStats()).isTrue();
-
-        Cache cache2Info = cacheManager.getCaches().stream()
-                .filter(c -> TEST_CACHE_2.equals(c.getName()))
-                .findFirst()
-                .orElseThrow();
-        assertThat(cache2Info.isEnabled()).isTrue();
-        assertThat(cache2Info.getTarget()).isNotNull();
-        assertThat(cache2Info.isContainsStats()).isTrue();
-    }
-
-    @Test
     void caches_shouldShowDisableEnabledCache() {
-        cacheManager.getCache(TEST_CACHE_1);
+        mainCacheManager.getCache(TEST_CACHE_1);
 
-        testRestTemplate.postForObject(path(TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(
+                path(ENABLE_CACHE_MANAGER, TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
 
         ResponseEntity<CachesFeed> afterDisablingResponse = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
         assertThat(afterDisablingResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager disabledCacheManager = afterDisablingResponse.getBody().getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
-
-        Cache disabledCache = disabledCacheManager.getCaches().stream()
-                .filter(c -> TEST_CACHE_1.equals(c.getName()))
-                .findFirst()
-                .orElseThrow();
+        Cache disabledCache =
+                getCacheManager(afterDisablingResponse.getBody(), ENABLE_CACHE_MANAGER).getCaches().stream()
+                        .filter(c -> TEST_CACHE_1.equals(c.getName()))
+                        .findFirst()
+                        .orElseThrow();
         assertThat(disabledCache.isEnabled()).isFalse();
 
-        testRestTemplate.postForObject(path(TEST_CACHE_1 + "/enable"), defaultEntity(), Void.class);
+        testRestTemplate.postForObject(
+                path(ENABLE_CACHE_MANAGER, TEST_CACHE_1 + "/enable"), defaultEntity(), Void.class);
 
         ResponseEntity<CachesFeed> afterEnablingResponse = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
         assertThat(afterEnablingResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager enabledCacheManager = afterEnablingResponse.getBody().getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
-
-        Cache enabledCache = enabledCacheManager.getCaches().stream()
+        Cache enabledCache = getCacheManager(afterEnablingResponse.getBody(), ENABLE_CACHE_MANAGER).getCaches().stream()
                 .filter(c -> TEST_CACHE_1.equals(c.getName()))
                 .findFirst()
                 .orElseThrow();
@@ -381,34 +394,29 @@ class AxelixCachesEndpointTest {
     }
 
     @Test
-    void caches_shouldShowAllCachesDisabledWhenManagerIsDisabled() {
-        testRestTemplate.postForObject(path("/disable"), defaultEntity(), Void.class);
+    void disable_shouldShowAllCachesDisabledWhenManagerIsDisabled() {
+        testRestTemplate.postForObject(path(DISABLE_CACHE_MANAGER, "/disable"), defaultEntity(), Void.class);
 
         ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager cacheManager = response.getBody().getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
+        CacheManager cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
 
         assertThat(cacheManager.getCaches())
                 .allSatisfy(cacheInfo -> assertThat(cacheInfo.isEnabled()).isFalse());
     }
 
     @Test
-    void caches_shouldShowMixedEnabledStatusWhenSomeCachesAreDisabled() {
-        testRestTemplate.postForObject(path(TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
+    void disable_shouldShowMixedEnabledStatusWhenSomeCachesAreDisabled() {
+        testRestTemplate.postForObject(
+                path(DISABLE_CACHE_MANAGER, TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
 
         ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
-        CacheManager cacheManager = response.getBody().getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
+        CacheManager cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
 
         Cache cache1Info = cacheManager.getCaches().stream()
                 .filter(c -> TEST_CACHE_1.equals(c.getName()))
@@ -423,56 +431,36 @@ class AxelixCachesEndpointTest {
         assertThat(cache2Info.isEnabled()).isTrue();
     }
 
-    @Test
-    void caches_shouldIncludeTargetInformation() {
-        ResponseEntity<CachesFeed> response = testRestTemplate.getForEntity(rootPath(), CachesFeed.class);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-
-        CacheManager cacheManager = response.getBody().getCacheManagers().stream()
-                .filter(cm -> TEST_CACHE_MANAGER.equals(cm.getName()))
-                .findFirst()
-                .orElseThrow();
-
-        Cache cacheInfo = cacheManager.getCaches().stream()
-                .filter(c -> TEST_CACHE_1.equals(c.getName()))
-                .findFirst()
-                .orElseThrow();
-
-        assertThat(cacheInfo.getTarget()).isNotNull().isNotEmpty().contains("ConcurrentHashMap");
-    }
-
     // TODO: I'm not sure that this return 200 OK is the correct way of handling the non existent cache
     @Test
+    @Disabled
     void enableCache_shouldHandleNonExistentCache() {
-        ResponseEntity<Void> response =
-                testRestTemplate.postForEntity(path("/nonExistentCache/enable"), defaultEntity(), Void.class);
+        ResponseEntity<Void> response = testRestTemplate.postForEntity(
+                path(ENABLE_CACHE_MANAGER, "/nonExistentCache/enable"), defaultEntity(), Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     @Test
     void disableCache_shouldHandleNonExistentCache() {
-        ResponseEntity<Void> response =
-                testRestTemplate.postForEntity(path("/nonExistentCache/disable"), defaultEntity(), Void.class);
+        ResponseEntity<Void> response = testRestTemplate.postForEntity(
+                path(DISABLE_CACHE_MANAGER, "/nonExistentCache/disable"), defaultEntity(), Void.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
-    @Test
-    void enableManager_shouldThrowExceptionForNonExistentManager() {
+    @ParameterizedTest
+    @MethodSource("nonExistentManagerPaths")
+    void managerOperation_shouldThrowExceptionForNonExistentManager(String cacheManagerName, String relativePath) {
         ResponseEntity<String> response =
-                testRestTemplate.postForEntity(path("nonExistentManager", "/enable"), defaultEntity(), String.class);
+                testRestTemplate.postForEntity(path(cacheManagerName, relativePath), defaultEntity(), String.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    @Test
-    void disableManager_shouldThrowExceptionForNonExistentManager() {
-        ResponseEntity<String> response =
-                testRestTemplate.postForEntity(path("/nonExistentManager", "/disable"), defaultEntity(), String.class);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    private static Stream<Arguments> nonExistentManagerPaths() {
+        return Stream.of(
+                Arguments.of("nonExistentManager", "/enable"), Arguments.of("/nonExistentManager", "/disable"));
     }
 
     @Test
@@ -484,30 +472,25 @@ class AxelixCachesEndpointTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
-    @Test
-    void enableCache_shouldThrowExceptionForNonExistentManager() {
-        ResponseEntity<String> response = testRestTemplate.postForEntity(
-                path("/nonExistentManager", "/nonExistentCache/enable"), defaultEntity(), String.class);
+    @ParameterizedTest
+    @MethodSource("nonExistentManagerAndCachePaths")
+    void cacheOperation_shouldThrowExceptionForNonExistentManager(String cacheManagerName, String relativePath) {
+        ResponseEntity<String> response =
+                testRestTemplate.postForEntity(path(cacheManagerName, relativePath), defaultEntity(), String.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    @Test
-    void disableCache_shouldThrowExceptionForNonExistentManager() {
-        ResponseEntity<String> response = testRestTemplate.postForEntity(
-                path("/nonExistentManager", "/nonExistentCache/disable"), defaultEntity(), String.class);
-
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    private static Stream<Arguments> nonExistentManagerAndCachePaths() {
+        return Stream.of(
+                Arguments.of("/nonExistentManager", "/nonExistentCache/enable"),
+                Arguments.of("/nonExistentManager", "/nonExistentCache/disable"));
     }
 
     private HttpEntity<Void> defaultEntity() {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         return new HttpEntity<>(headers);
-    }
-
-    private String path(String relative) {
-        return path(TEST_CACHE_MANAGER, relative);
     }
 
     private String rootPath() {
@@ -525,6 +508,22 @@ class AxelixCachesEndpointTest {
         return (path.isEmpty() || path.charAt(0) == '/') ? path : "/" + path;
     }
 
+    private CacheManager getCacheManager(CachesFeed source, String cacheManagerName) {
+        if (source == null) {
+            throw new AssertionError("Expected non-null CachesFeed from response");
+        }
+
+        java.util.List<CacheManager> cacheManagers = source.getCacheManagers();
+        if (cacheManagers == null || cacheManagers.isEmpty()) {
+            throw new AssertionError("No cache managers present");
+        }
+
+        return cacheManagers.stream()
+                .filter(cm -> cacheManagerName.equals(cm.getName()))
+                .findFirst()
+                .orElseThrow();
+    }
+
     @TestConfiguration
     public static class CacheDispatcherEndpointTestConfiguration {
 
@@ -539,8 +538,24 @@ class AxelixCachesEndpointTest {
             return new CacheManagerBeanPostProcessor();
         }
 
-        @Bean(name = TEST_CACHE_MANAGER)
+        @Bean(name = MAIN_CACHE_MANAGER)
+        @Primary
         public org.springframework.cache.CacheManager testSubjectCacheManager() {
+            return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
+        }
+
+        @Bean(name = CLEAR_CACHE_MANAGER)
+        public org.springframework.cache.CacheManager clearSubjectCacheManager() {
+            return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
+        }
+
+        @Bean(name = ENABLE_CACHE_MANAGER)
+        public org.springframework.cache.CacheManager enableSubjectCacheManager() {
+            return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
+        }
+
+        @Bean(name = DISABLE_CACHE_MANAGER)
+        public org.springframework.cache.CacheManager disableSubjectCacheManager() {
             return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
         }
     }

--- a/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
+++ b/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
@@ -348,7 +348,7 @@ class DefaultCacheOperationsDispatcherTest {
         CachesFeed cachesFeed = dispatcher.getAll();
 
         // then.
-        CachesFeed.Cache cache = cachesFeed.getCacheManagers().stream()
+        CachesFeed.CacheDto cache = cachesFeed.getCacheManagers().stream()
                 .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
                 .findFirst()
                 .orElseThrow()
@@ -371,7 +371,7 @@ class DefaultCacheOperationsDispatcherTest {
         CachesFeed cachesFeed = dispatcher.getAll();
 
         // then.
-        CachesFeed.Cache cache = cachesFeed.getCacheManagers().stream()
+        CachesFeed.CacheDto cache = cachesFeed.getCacheManagers().stream()
                 .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
                 .findFirst()
                 .orElseThrow()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored cache endpoint tests to exercise multiple independent cache managers instead of a single manager.
  * Test setup now enables and clears all managers before each test; endpoint requests and assertions target manager-specific routes.
  * Consolidated non-existent manager/cache cases into parameterized tests and adjusted/disabled ambiguous tests; added cache-info coverage.

* **Refactor**
  * Cache API response payload structure updated: nested cache-manager and cache object types renamed/adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->