### PR TITLE
GH-977 Added PR size limit

### DIFF
--- a/.github/actions/check-pr-size/action.yaml
+++ b/.github/actions/check-pr-size/action.yaml
@@ -1,0 +1,34 @@
+name: Check PR Size
+description: Check if PR is too large
+
+inputs:
+  max-lines:
+    description: Maximum number of lines allowed
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check PR size
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const MAX_LINES = parseInt('${{ inputs.max-lines }}')
+
+          const { data: pr } = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number,
+          })
+
+          const totalLines = pr.additions + pr.deletions
+
+          if (totalLines > MAX_LINES) {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## PR is too large\n\nTotal lines: **${totalLines}**, limit: **${MAX_LINES}**.\n\nPlease split this PR into smaller parts.`
+            })
+            core.setFailed(`PR is too large: ${totalLines} lines, limit is ${MAX_LINES}`)
+          }

--- a/.github/workflows/backend_pull_requests.yaml
+++ b/.github/workflows/backend_pull_requests.yaml
@@ -17,7 +17,23 @@ jobs:
         with:
           exclude-labels: "refactoring, dependencies"
 
+  check-pr-size:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check PR size
+        uses: ./.github/actions/check-pr-size
+        with:
+          max-lines: '1500'
+
   backend-build:
+    needs: check-pr-size
     runs-on: ubuntu-latest
     env:
       NEXUS_USER: ${{ secrets.NEXUS_USER }}

--- a/.github/workflows/frontend_pull_requests.yaml
+++ b/.github/workflows/frontend_pull_requests.yaml
@@ -15,7 +15,23 @@ jobs:
         with:
           exclude-labels: "refactoring, dependencies"
 
+  check-pr-size:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check PR size
+        uses: ./.github/actions/check-pr-size
+        with:
+          max-lines: '400'
+
   frontend-build:
+    needs: check-pr-size
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Closes GH-977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added PR size checks to CI with configurable limits (frontend: 400 lines, backend: 1500 lines). PRs exceeding limits will be commented and block merging until reduced.
  * Build pipelines now wait for the PR-size check to complete before continuing.
  * CI workflows now have permission to post and update pull-request comments to enforce these checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->