### PR TITLE
GH-1005: Use Spring ProxyFactory to enhance CacheManager beans

### DIFF
--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -37,7 +37,7 @@ public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
 
     @Override
     public Object postProcessAfterInitialization(@NonNull Object bean, @NonNull String beanName) throws BeansException {
-        if (!(bean instanceof CacheManager) || bean instanceof EnhancedCacheManager) {
+        if (!(bean instanceof CacheManager)) {
             return bean;
         }
 
@@ -53,12 +53,6 @@ public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
         proxyFactory.addAdvisor(new DefaultIntroductionAdvisor(
                 new EnhancedCacheManagerIntroduction(delegate), EnhancedCacheManager.class));
 
-        try {
-            return proxyFactory.getProxy();
-        } catch (Exception e) {
-           proxyFactory.setProxyTargetClass(false);
-
-            return proxyFactory.getProxy();
-        }
+        return proxyFactory.getProxy();
     }
 }

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -38,7 +38,7 @@ public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
 
     @Override
     public Object postProcessAfterInitialization(@NonNull Object bean, @NonNull String beanName) throws BeansException {
-        if (!(bean instanceof CacheManager)) {
+        if (!(bean instanceof CacheManager) || bean instanceof EnhancedCacheManager) {
             return bean;
         }
 

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -28,8 +28,7 @@ import org.springframework.cache.CacheManager;
 /**
  * BeanPostProcessor that creates an AOP proxy for every {@link CacheManager} bean to introduce
  * the {@link EnhancedCacheManager} contract while preserving the runtime type of the original
- * cache manager. The proxy is built with Spring's {@link ProxyFactory} using CGLIB so that user
- * code performing checks like {@code cacheManager instanceof CaffeineCacheManager} continues to work.
+ * cache manager.
  *
  * @since 24.11.2025
  * @author Nikita Kirillov
@@ -54,6 +53,12 @@ public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
         proxyFactory.addAdvisor(new DefaultIntroductionAdvisor(
                 new EnhancedCacheManagerIntroduction(delegate), EnhancedCacheManager.class));
 
-        return proxyFactory.getProxy();
+        try {
+            return proxyFactory.getProxy();
+        } catch (Exception e) {
+           proxyFactory.setProxyTargetClass(false);
+
+            return proxyFactory.getProxy();
+        }
     }
 }

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -32,6 +32,7 @@ import org.springframework.cache.CacheManager;
  *
  * @since 24.11.2025
  * @author Nikita Kirillov
+ * @author Artemiy Degtyarev
  */
 public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
 

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -19,31 +19,41 @@ package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import org.jspecify.annotations.NonNull;
 
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.DefaultIntroductionAdvisor;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.cache.CacheManager;
 
 /**
- * BeanPostProcessor that wraps existing CacheManager beans with EnhancedCacheManager
- * to provide additional features.
+ * BeanPostProcessor that creates an AOP proxy for every {@link CacheManager} bean to introduce
+ * the {@link EnhancedCacheManager} contract while preserving the runtime type of the original
+ * cache manager. The proxy is built with Spring's {@link ProxyFactory} using CGLIB so that user
+ * code performing checks like {@code cacheManager instanceof CaffeineCacheManager} continues to work.
  *
  * @since 24.11.2025
  * @author Nikita Kirillov
  */
 public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
 
-    // TODO:
-    //  This is a dangerous practise.
-    //  The fact is that if the end-users have stuff like "cacheManager instanceof Caffiene" or smth
-    //  like that in their code, then our bean post processor will essentially break this code.
-    //  The problem above can be solved by creating a CGLIB proxy in runtime. The question is - in this case,
-    //  we would have to be sure that the concrete CacheManager class is not a final class, so we can create an
-    //  decedent.
     @Override
     public Object postProcessAfterInitialization(@NonNull Object bean, @NonNull String beanName) throws BeansException {
-        if (bean instanceof CacheManager && !(bean instanceof EnhancedCacheManager)) {
-            return new EnhancedCacheManager(beanName, (CacheManager) bean);
+        if (!(bean instanceof CacheManager) || bean instanceof EnhancedCacheManager) {
+            return bean;
         }
-        return bean;
+
+        return createEnhancedCacheManagerProxy((CacheManager) bean, beanName);
+    }
+
+    private static Object createEnhancedCacheManagerProxy(CacheManager target, String beanName) {
+        DefaultEnhancedCacheManager delegate = new DefaultEnhancedCacheManager(beanName, target);
+
+        ProxyFactory proxyFactory = new ProxyFactory();
+        proxyFactory.setTarget(target);
+        proxyFactory.setProxyTargetClass(true);
+        proxyFactory.addAdvisor(new DefaultIntroductionAdvisor(
+                new EnhancedCacheManagerIntroduction(delegate), EnhancedCacheManager.class));
+
+        return proxyFactory.getProxy();
     }
 }

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
@@ -57,7 +57,7 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
 
     @Override
     public void clear(String cacheName) {
-        Optional.ofNullable(this.getCache(cacheName)).ifPresent(Cache::invalidate);
+        Optional.ofNullable(this.getCache(cacheName)).ifPresent(Cache::clear);
     }
 
     @Override

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
@@ -33,7 +33,7 @@ import org.springframework.cache.CacheManager;
  * {@link CacheManager} contract to an underlying manager and maintains a map of
  * {@link EnhancedCache} instances on top of the underlying caches.
  *
- * @since 24.11.2025
+ * @since 11.05.2026
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
@@ -66,6 +66,8 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
 
     @Override
     public void clearAll() {
+        this.getCacheNames().forEach(this::getCache);
+
         caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.clear());
     }
 
@@ -77,21 +79,11 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
     @Override
     @Nullable
     public EnhancedCache getCache(@NonNull String name) {
-        EnhancedCache enhancedCache = caches.computeIfAbsent(name, s -> {
+        return caches.computeIfAbsent(name, s -> {
             Cache cache = delegate.getCache(s);
 
-            if (cache != null) {
-                return new DefaultEnhancedCache(cache);
-            } else {
-                return NonExistentEnhancedCache.INSTANCE;
-            }
+            return cache != null ? new DefaultEnhancedCache(cache) : null;
         });
-
-        if (enhancedCache instanceof NonExistentEnhancedCache) {
-            return null;
-        } else {
-            return enhancedCache;
-        }
     }
 
     @Override
@@ -120,11 +112,15 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
 
     @Override
     public void enableAll() {
+        this.getCacheNames().forEach(this::getCache);
+
         this.caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.enable());
     }
 
     @Override
     public void disableAll() {
+        this.getCacheNames().forEach(this::getCache);
+
         this.caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.disable());
     }
 

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.cache;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+/**
+ * Default {@link EnhancedCacheManager} implementation that delegates the core
+ * {@link CacheManager} contract to an underlying manager and maintains a map of
+ * {@link EnhancedCache} instances on top of the underlying caches.
+ *
+ * @since 24.11.2025
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ * @author Sergey Cherkasov
+ */
+public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
+
+    private final String cacheManagerBeanName;
+    private final CacheManager delegate;
+    private final Map<String, EnhancedCache> caches = new ConcurrentHashMap<>();
+
+    public DefaultEnhancedCacheManager(String cacheManagerBeanName, CacheManager delegate) {
+        this.delegate = delegate;
+        this.cacheManagerBeanName = cacheManagerBeanName;
+    }
+
+    @Override
+    public String getUnderlyingCacheManagerBeanName() {
+        return cacheManagerBeanName;
+    }
+
+    @Override
+    public void clear(String cacheName) {
+        Optional.ofNullable(this.getCache(cacheName)).ifPresent(Cache::invalidate);
+    }
+
+    @Override
+    public void clear(String cacheName, Object key) {
+        Optional.ofNullable(this.getCache(cacheName)).ifPresent(cache -> cache.evictIfPresent(key));
+    }
+
+    @Override
+    public void clearAll() {
+        caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.clear());
+    }
+
+    @Override
+    public Collection<EnhancedCache> getAll() {
+        return caches.values();
+    }
+
+    @Override
+    @Nullable
+    public EnhancedCache getCache(@NonNull String name) {
+        EnhancedCache enhancedCache = caches.computeIfAbsent(name, s -> {
+            Cache cache = delegate.getCache(s);
+
+            if (cache != null) {
+                return new DefaultEnhancedCache(cache);
+            } else {
+                return NonExistentEnhancedCache.INSTANCE;
+            }
+        });
+
+        if (enhancedCache instanceof NonExistentEnhancedCache) {
+            return null;
+        } else {
+            return enhancedCache;
+        }
+    }
+
+    @Override
+    @NonNull
+    public Collection<String> getCacheNames() {
+        return delegate.getCacheNames();
+    }
+
+    @Override
+    public void enable(String cacheName) {
+        EnhancedCache cache = this.getCache(cacheName);
+
+        if (cache != null) {
+            cache.enable();
+        }
+    }
+
+    @Override
+    public void disable(String cacheName) {
+        EnhancedCache cache = this.getCache(cacheName);
+
+        if (cache != null) {
+            cache.disable();
+        }
+    }
+
+    @Override
+    public void enableAll() {
+        this.caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.enable());
+    }
+
+    @Override
+    public void disableAll() {
+        this.caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.disable());
+    }
+
+    @Override
+    public boolean isEnabled(String cacheName) {
+        EnhancedCache cache = this.getCache(cacheName);
+
+        if (cache != null) {
+            return cache.isEnabled();
+        }
+
+        return false;
+    }
+}

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
@@ -37,6 +37,7 @@ import org.springframework.cache.CacheManager;
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
+ * @author Artemiy Degtyarev
  */
 public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
 
@@ -64,6 +65,7 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
         Optional.ofNullable(this.getCache(cacheName)).ifPresent(cache -> cache.evictIfPresent(key));
     }
 
+    /** Best-effort with respect to caches created concurrently; late arrivals may be skipped, so callers should not rely on strong consistency. */
     @Override
     public void clearAll() {
         this.getCacheNames().forEach(this::getCache);
@@ -110,6 +112,7 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
         }
     }
 
+    /** Best-effort with respect to caches created concurrently; late arrivals may be skipped, so callers should not rely on strong consistency. */
     @Override
     public void enableAll() {
         this.getCacheNames().forEach(this::getCache);
@@ -117,6 +120,7 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
         this.caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.enable());
     }
 
+    /** Best-effort with respect to caches created concurrently; late arrivals may be skipped, so callers should not rely on strong consistency. */
     @Override
     public void disableAll() {
         this.getCacheNames().forEach(this::getCache);

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManager.java
@@ -18,144 +18,49 @@
 package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import java.util.Collection;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 
 /**
- * CacheManager implementation that provides dynamic control over cache operations.
- * <p>
- * Current implementation stores the map of {@link EnhancedCache EnhancedCache instances}.
- * All the operations, like clear, eviction by key, get by key etc. can be performed of the
- * {@link EnhancedCache}, rather than on the {@link #delegate}, since {@link EnhancedCache}
- * instance by design internally holds the reference to the exact same {@link Cache} object
- * on the heap, as the underlying {@link #delegate} does.
+ * Extension of {@link CacheManager} that exposes management operations on top of an existing
+ * {@link CacheManager}. Implementations are typically attached to user-defined {@link CacheManager}
+ * beans through an AOP proxy so that the original concrete type is preserved.
  *
- * @since 24.11.2025
- * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
  */
-public class EnhancedCacheManager implements CacheManager {
+public interface EnhancedCacheManager extends CacheManager {
 
-    private final String cacheManagerBeanName;
-    private final CacheManager delegate;
-    private final Map<String, EnhancedCache> caches = new ConcurrentHashMap<>();
-
-    public EnhancedCacheManager(String cacheManagerBeanName, CacheManager delegate) {
-        this.delegate = delegate;
-        this.cacheManagerBeanName = cacheManagerBeanName;
-    }
-
-    public String getUnderlyingCacheManagerBeanName() {
-        return cacheManagerBeanName;
-    }
-
-    public void clear(String cacheName) {
-        Optional.ofNullable(this.getCache(cacheName)).ifPresent(Cache::invalidate);
-    }
-
-    public void clear(String cacheName, Object key) {
-        Optional.ofNullable(this.getCache(cacheName)).ifPresent(cache -> cache.evictIfPresent(key));
-    }
-
-    public void clearAll() {
-        caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.clear());
-    }
-
-    public Collection<EnhancedCache> getAll() {
-        return caches.values();
-    }
+    /**
+     * @return the bean name of the underlying {@link CacheManager} that this enhanced manager wraps.
+     */
+    String getUnderlyingCacheManagerBeanName();
 
     @Override
     @Nullable
-    public EnhancedCache getCache(@NonNull String name) {
-        EnhancedCache enhancedCache = caches.computeIfAbsent(name, s -> {
-            Cache cache = delegate.getCache(s);
-
-            if (cache != null) {
-                return new DefaultEnhancedCache(cache);
-            } else {
-                return NonExistentEnhancedCache.INSTANCE;
-            }
-        });
-
-        if (enhancedCache instanceof NonExistentEnhancedCache) {
-            return null;
-        } else {
-            return enhancedCache;
-        }
-    }
-
-    @Override
-    @NonNull
-    public Collection<String> getCacheNames() {
-        return delegate.getCacheNames();
-    }
+    EnhancedCache getCache(@NonNull String name);
 
     /**
-     * Enable cache, if exists.
-     *
-     * @param cacheName cache name to enable.
+     * @return all enhanced caches that have been resolved through this manager.
      */
-    public void enable(String cacheName) {
-        Cache cache = this.getCache(cacheName);
+    Collection<EnhancedCache> getAll();
 
-        if (cache != null) {
-            ((EnhancedCache) cache).enable();
-        }
-    }
+    void clear(String cacheName);
 
-    /**
-     * Disable cache, if exists.
-     *
-     * @param cacheName cache name to enable.
-     */
-    public void disable(String cacheName) {
-        Cache cache = this.getCache(cacheName);
+    void clear(String cacheName, Object key);
 
-        if (cache != null) {
-            ((EnhancedCache) cache).disable();
-        }
-    }
+    void clearAll();
 
-    /**
-     * Enable all caches.
-     */
-    public void enableAll() {
-        this.caches.forEach((cacheManagerName, enhancedCache) -> {
-            enhancedCache.enable();
-        });
-    }
+    void enable(String cacheName);
 
-    /**
-     * Disable all caches.
-     */
-    public void disableAll() {
-        this.caches.forEach((cacheManagerName, enhancedCache) -> {
-            enhancedCache.disable();
-        });
-    }
+    void disable(String cacheName);
 
-    /**
-     * Check if a specific cache is currently enabled.
-     *
-     * @param cacheName the name of the cache to check
-     * @return {@code true} if the cache exists and is enabled, {@code false} otherwise
-     */
-    public boolean isEnabled(String cacheName) {
-        Cache cache = this.getCache(cacheName);
+    void enableAll();
 
-        if (cache != null) {
-            return ((EnhancedCache) cache).isEnabled();
-        }
+    void disableAll();
 
-        return false;
-    }
+    boolean isEnabled(String cacheName);
 }

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManager.java
@@ -29,6 +29,8 @@ import org.springframework.cache.CacheManager;
  * {@link CacheManager}. Implementations are typically attached to user-defined {@link CacheManager}
  * beans through an AOP proxy so that the original concrete type is preserved.
  *
+ * @since 24.11.2025
+ * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
  */

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManager.java
@@ -33,6 +33,7 @@ import org.springframework.cache.CacheManager;
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
+ * @author Artemiy Degtyarev
  */
 public interface EnhancedCacheManager extends CacheManager {
 

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
@@ -41,7 +41,7 @@ class EnhancedCacheManagerIntroduction implements IntroductionInterceptor {
 
     @Override
     public boolean implementsInterface(Class<?> intf) {
-        return intf.isAssignableFrom(EnhancedCacheManager.class);
+        return intf.equals(EnhancedCacheManager.class);
     }
 
     @Override
@@ -57,6 +57,9 @@ class EnhancedCacheManagerIntroduction implements IntroductionInterceptor {
 
     @Nullable
     private Method findDelegateMethod(Method invokedMethod) {
+        if (invokedMethod.getDeclaringClass().equals(Object.class))
+            return null;
+
         try {
             return EnhancedCacheManager.class.getMethod(invokedMethod.getName(), invokedMethod.getParameterTypes());
         } catch (NoSuchMethodException e) {

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
@@ -18,6 +18,9 @@
 package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.aopalliance.intercept.MethodInvocation;
 import org.jspecify.annotations.Nullable;
@@ -35,13 +38,15 @@ class EnhancedCacheManagerIntroduction implements IntroductionInterceptor {
 
     private final EnhancedCacheManager delegate;
 
+    private final Map<Method, Method> delegateMethods = new ConcurrentHashMap<>();
+
     EnhancedCacheManagerIntroduction(EnhancedCacheManager delegate) {
         this.delegate = delegate;
     }
 
     @Override
     public boolean implementsInterface(Class<?> intf) {
-        return intf.equals(EnhancedCacheManager.class);
+        return intf.isAssignableFrom(EnhancedCacheManager.class);
     }
 
     @Override
@@ -60,10 +65,12 @@ class EnhancedCacheManagerIntroduction implements IntroductionInterceptor {
         if (invokedMethod.getDeclaringClass().equals(Object.class))
             return null;
 
-        try {
-            return EnhancedCacheManager.class.getMethod(invokedMethod.getName(), invokedMethod.getParameterTypes());
-        } catch (NoSuchMethodException e) {
-            return null;
-        }
+        return delegateMethods.computeIfAbsent(invokedMethod, s -> {
+            try {
+                return EnhancedCacheManager.class.getMethod(s.getName(), s.getParameterTypes());
+            } catch (NoSuchMethodException e) {
+                return null;
+            }
+        });
     }
 }

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import java.lang.reflect.Method;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.aopalliance.intercept.MethodInvocation;
@@ -33,8 +32,11 @@ import org.springframework.aop.support.AopUtils;
  * invocations on the proxy to the supplied delegate, while letting any concrete-class-specific method
  * proceed to the proxied target. This preserves the runtime type of the original {@code CacheManager}
  * bean while exposing the enhanced management API.
+ *
+ * @since 11.05.2026
+ * @author Artemiy Degtyarev
  */
-class EnhancedCacheManagerIntroduction implements IntroductionInterceptor {
+final class EnhancedCacheManagerIntroduction implements IntroductionInterceptor {
 
     private final EnhancedCacheManager delegate;
 

--- a/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
+++ b/sbs/axelix-spring-boot-2/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.cache;
+
+import java.lang.reflect.Method;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.aop.IntroductionInterceptor;
+import org.springframework.aop.support.AopUtils;
+
+/**
+ * Routes {@link EnhancedCacheManager} (and its inherited {@link org.springframework.cache.CacheManager})
+ * invocations on the proxy to the supplied delegate, while letting any concrete-class-specific method
+ * proceed to the proxied target. This preserves the runtime type of the original {@code CacheManager}
+ * bean while exposing the enhanced management API.
+ */
+class EnhancedCacheManagerIntroduction implements IntroductionInterceptor {
+
+    private final EnhancedCacheManager delegate;
+
+    EnhancedCacheManagerIntroduction(EnhancedCacheManager delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public boolean implementsInterface(Class<?> intf) {
+        return intf.isAssignableFrom(EnhancedCacheManager.class);
+    }
+
+    @Override
+    @Nullable
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        Method delegateMethod = findDelegateMethod(invocation.getMethod());
+
+        if (delegateMethod != null)
+            return AopUtils.invokeJoinpointUsingReflection(delegate, delegateMethod, invocation.getArguments());
+
+        return invocation.proceed();
+    }
+
+    @Nullable
+    private Method findDelegateMethod(Method invokedMethod) {
+        try {
+            return EnhancedCacheManager.class.getMethod(invokedMethod.getName(), invokedMethod.getParameterTypes());
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
+++ b/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
@@ -318,8 +318,8 @@ class DefaultCacheOperationsDispatcherTest {
         dispatcher.disableCacheManager(cacheManagerName);
 
         // then.
-        assertThat(dispatcher.get(cacheManagerName, TEST_CACHE_1).isEnabled()).isTrue();
-        assertThat(dispatcher.get(cacheManagerName, TEST_CACHE_2).isEnabled()).isTrue();
+        assertThat(dispatcher.get(cacheManagerName, TEST_CACHE_1).isEnabled()).isFalse();
+        assertThat(dispatcher.get(cacheManagerName, TEST_CACHE_2).isEnabled()).isFalse();
     }
 
     @Test

--- a/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
+++ b/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
@@ -37,10 +37,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link DefaultCacheOperationsDispatcher}.
  *
- * @since 24.06.2025
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
+ * @since 24.06.2025
  */
 class DefaultCacheOperationsDispatcherTest {
 
@@ -61,9 +61,9 @@ class DefaultCacheOperationsDispatcherTest {
         Map<String, CacheManager> managers = new HashMap<>();
 
         cacheManager1 = new DefaultEnhancedCacheManager(
-                TEST_CACHE_MANAGER_1, new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2));
+            TEST_CACHE_MANAGER_1, new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2));
         cacheManager2 =
-                new DefaultEnhancedCacheManager(TEST_CACHE_MANAGER_2, new ConcurrentMapCacheManager(TEST_CACHE_2));
+            new DefaultEnhancedCacheManager(TEST_CACHE_MANAGER_2, new ConcurrentMapCacheManager(TEST_CACHE_2));
         managers.put(TEST_CACHE_MANAGER_1, cacheManager1);
         managers.put(TEST_CACHE_MANAGER_2, cacheManager2);
 
@@ -92,7 +92,7 @@ class DefaultCacheOperationsDispatcherTest {
     @Test
     void shouldNoOpOnClearingNonExistentCacheManager() {
         assertThatThrownBy(() -> dispatcher.clear("nonExistentCacheManager", "cache"))
-                .isInstanceOf(CacheManagerNotFoundException.class);
+            .isInstanceOf(CacheManagerNotFoundException.class);
     }
 
     @Test
@@ -114,7 +114,7 @@ class DefaultCacheOperationsDispatcherTest {
         // then.
         assertThat(cache.get(keyToRemove)).isNull();
         assertThat(cache.get(keyToKeep)).isNotNull().satisfies(cacheValue -> assertThat(cacheValue.get())
-                .isEqualTo("value2"));
+            .isEqualTo("value2"));
     }
 
     @Test
@@ -241,14 +241,14 @@ class DefaultCacheOperationsDispatcherTest {
 
         // then.
         CachesFeed.CacheDto cache = cachesFeed.getCacheManagers().stream()
-                .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
-                .findFirst()
-                .orElseThrow()
-                .getCaches()
-                .stream()
-                .filter(it -> TEST_CACHE_1.equals(it.getName()))
-                .findFirst()
-                .orElseThrow();
+            .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
+            .findFirst()
+            .orElseThrow()
+            .getCaches()
+            .stream()
+            .filter(it -> TEST_CACHE_1.equals(it.getName()))
+            .findFirst()
+            .orElseThrow();
 
         assertThat(cache.isContainsStats()).isTrue();
     }
@@ -264,14 +264,14 @@ class DefaultCacheOperationsDispatcherTest {
 
         // then.
         CachesFeed.CacheDto cache = cachesFeed.getCacheManagers().stream()
-                .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
-                .findFirst()
-                .orElseThrow()
-                .getCaches()
-                .stream()
-                .filter(it -> TEST_CACHE_1.equals(it.getName()))
-                .findFirst()
-                .orElseThrow();
+            .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
+            .findFirst()
+            .orElseThrow()
+            .getCaches()
+            .stream()
+            .filter(it -> TEST_CACHE_1.equals(it.getName()))
+            .findFirst()
+            .orElseThrow();
 
         assertThat(cache.isContainsStats()).isFalse();
     }
@@ -279,7 +279,7 @@ class DefaultCacheOperationsDispatcherTest {
     @Test
     void isCacheEnabled_shouldReturnTrueForEnabledCache() {
         assertThat(dispatcher.get(TEST_CACHE_MANAGER_1, TEST_CACHE_1).isEnabled())
-                .isTrue();
+            .isTrue();
     }
 
     @Test
@@ -360,11 +360,11 @@ class DefaultCacheOperationsDispatcherTest {
         // then.
         assertThat(first.getEstimatedEntrySize()).isEqualTo(2L);
         assertThat(first.getLookupHistory().stream()
-                        .filter(it -> SingleCache.LookupOutcome.MISS.equals(it.getOutcome())))
-                .hasSize(2);
+            .filter(it -> SingleCache.LookupOutcome.MISS.equals(it.getOutcome())))
+            .hasSize(2);
         assertThat(first.getLookupHistory().stream()
-                        .filter(it -> SingleCache.LookupOutcome.HIT.equals(it.getOutcome())))
-                .hasSize(2);
+            .filter(it -> SingleCache.LookupOutcome.HIT.equals(it.getOutcome())))
+            .hasSize(2);
 
         // given.
         Cache cache2 = cacheManager2.getCache(TEST_CACHE_2);
@@ -378,45 +378,45 @@ class DefaultCacheOperationsDispatcherTest {
         // then.
         assertThat(second.getEstimatedEntrySize()).isEqualTo(1L);
         assertThat(second.getLookupHistory().stream()
-                        .filter(it -> SingleCache.LookupOutcome.MISS.equals(it.getOutcome())))
-                .hasSize(1);
+            .filter(it -> SingleCache.LookupOutcome.MISS.equals(it.getOutcome())))
+            .hasSize(1);
         assertThat(second.getLookupHistory().stream()
-                        .filter(it -> SingleCache.LookupOutcome.HIT.equals(it.getOutcome())))
-                .hasSize(1);
+            .filter(it -> SingleCache.LookupOutcome.HIT.equals(it.getOutcome())))
+            .hasSize(1);
     }
 
     @Test
     void shouldReturnNull_ForNonExistentManager() {
         assertThatThrownBy(() -> dispatcher.get("nonExistentManager", TEST_CACHE_1))
-                .isInstanceOf(CacheManagerNotFoundException.class);
+            .isInstanceOf(CacheManagerNotFoundException.class);
     }
 
     @Test
     void enableCacheManager_shouldThrowExceptionForNonExistentManager() {
         assertThatThrownBy(() -> dispatcher.enableCacheManager("nonExistentManager"))
-                .isInstanceOf(CacheManagerNotFoundException.class)
-                .hasMessageContaining("nonExistentManager");
+            .isInstanceOf(CacheManagerNotFoundException.class)
+            .hasMessageContaining("nonExistentManager");
     }
 
     @Test
     void disableCacheManager_shouldThrowExceptionForNonExistentManager() {
         assertThatThrownBy(() -> dispatcher.disableCacheManager("nonExistentManager"))
-                .isInstanceOf(CacheManagerNotFoundException.class)
-                .hasMessageContaining("nonExistentManager");
+            .isInstanceOf(CacheManagerNotFoundException.class)
+            .hasMessageContaining("nonExistentManager");
     }
 
     @Test
     void enableCache_shouldThrowExceptionForNonExistentManager() {
         assertThatThrownBy(() -> dispatcher.enableCache("nonExistentManager", TEST_CACHE_1))
-                .isInstanceOf(CacheManagerNotFoundException.class)
-                .hasMessageContaining("nonExistentManager");
+            .isInstanceOf(CacheManagerNotFoundException.class)
+            .hasMessageContaining("nonExistentManager");
     }
 
     @Test
     void disableCache_shouldThrowExceptionForNonExistentManager() {
         assertThatThrownBy(() -> dispatcher.disableCache("nonExistentManager", TEST_CACHE_1))
-                .isInstanceOf(CacheManagerNotFoundException.class)
-                .hasMessageContaining("nonExistentManager");
+            .isInstanceOf(CacheManagerNotFoundException.class)
+            .hasMessageContaining("nonExistentManager");
     }
 
     @Test

--- a/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
+++ b/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
@@ -60,9 +60,10 @@ class DefaultCacheOperationsDispatcherTest {
     void setUp() {
         Map<String, CacheManager> managers = new HashMap<>();
 
-        cacheManager1 = new EnhancedCacheManager(
+        cacheManager1 = new DefaultEnhancedCacheManager(
                 TEST_CACHE_MANAGER_1, new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2));
-        cacheManager2 = new EnhancedCacheManager(TEST_CACHE_MANAGER_2, new ConcurrentMapCacheManager(TEST_CACHE_2));
+        cacheManager2 =
+                new DefaultEnhancedCacheManager(TEST_CACHE_MANAGER_2, new ConcurrentMapCacheManager(TEST_CACHE_2));
         managers.put(TEST_CACHE_MANAGER_1, cacheManager1);
         managers.put(TEST_CACHE_MANAGER_2, cacheManager2);
 

--- a/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerTest.java
+++ b/sbs/axelix-spring-boot-2/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
- * Unit tests for {@link EnhancedCacheManager}.
+ * Unit tests for {@link DefaultEnhancedCacheManager}.
  *
  * @since 23.06.2025
  * @author Nikita Kirillov
@@ -42,7 +42,7 @@ class EnhancedCacheManagerTest {
     @BeforeEach
     void setUp() {
         CacheManager cacheManager = new ConcurrentMapCacheManager();
-        subject = new EnhancedCacheManager("testCacheManagerBeanName", cacheManager);
+        subject = new DefaultEnhancedCacheManager("testCacheManagerBeanName", cacheManager);
     }
 
     @Test

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -37,7 +37,7 @@ public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
 
     @Override
     public Object postProcessAfterInitialization(@NonNull Object bean, @NonNull String beanName) throws BeansException {
-        if (!(bean instanceof CacheManager)) {
+        if (!(bean instanceof CacheManager) || bean instanceof EnhancedCacheManager) {
             return bean;
         }
         return createEnhancedCacheManagerProxy((CacheManager) bean, beanName);

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -19,6 +19,8 @@ package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import org.jspecify.annotations.NonNull;
 
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.DefaultIntroductionAdvisor;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.cache.CacheManager;
@@ -32,18 +34,23 @@ import org.springframework.cache.CacheManager;
  */
 public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
 
-    // TODO:
-    //  This is a dangerous practise.
-    //  The fact is that if the end-users have stuff like "cacheManager instanceof Caffiene" or smth
-    //  like that in their code, then our bean post processor will essentially break this code.
-    //  The problem above can be solved by creating a CGLIB proxy in runtime. The question is - in this case,
-    //  we would have to be sure that the concrete CacheManager class is not a final class, so we can create an
-    //  decedent.
     @Override
     public Object postProcessAfterInitialization(@NonNull Object bean, @NonNull String beanName) throws BeansException {
-        if (bean instanceof CacheManager && !(bean instanceof EnhancedCacheManager)) {
-            return new EnhancedCacheManager(beanName, (CacheManager) bean);
+        if (!(bean instanceof CacheManager) || bean instanceof EnhancedCacheManager) {
+            return bean;
         }
-        return bean;
+        return createEnhancedCacheManagerProxy((CacheManager) bean, beanName);
+    }
+
+    private Object createEnhancedCacheManagerProxy(CacheManager target, String beanName) {
+        DefaultEnhancedCacheManager delegate = new DefaultEnhancedCacheManager(beanName, target);
+
+        ProxyFactory proxyFactory = new ProxyFactory();
+        proxyFactory.setTarget(target);
+        proxyFactory.setProxyTargetClass(true);
+        proxyFactory.addAdvisor(new DefaultIntroductionAdvisor(new EnhancedCacheManagerIntroduction(delegate),
+            EnhancedCacheManager.class));
+
+        return proxyFactory.getProxy();
     }
 }

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -29,14 +29,14 @@ import org.springframework.cache.CacheManager;
  * BeanPostProcessor that wraps existing CacheManager beans with EnhancedCacheManager
  * to provide additional features.
  *
- * @since 24.11.2025
  * @author Nikita Kirillov
+ * @since 24.11.2025
  */
 public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
 
     @Override
     public Object postProcessAfterInitialization(@NonNull Object bean, @NonNull String beanName) throws BeansException {
-        if (!(bean instanceof CacheManager) || bean instanceof EnhancedCacheManager) {
+        if (!(bean instanceof CacheManager)) {
             return bean;
         }
         return createEnhancedCacheManagerProxy((CacheManager) bean, beanName);
@@ -51,12 +51,6 @@ public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
         proxyFactory.addAdvisor(new DefaultIntroductionAdvisor(new EnhancedCacheManagerIntroduction(delegate),
             EnhancedCacheManager.class));
 
-        try {
-            return proxyFactory.getProxy();
-        } catch (Exception e) {
-            proxyFactory.setProxyTargetClass(false);
-
-            return proxyFactory.getProxy();
-        }
+        return proxyFactory.getProxy();
     }
 }

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -51,6 +51,12 @@ public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
         proxyFactory.addAdvisor(new DefaultIntroductionAdvisor(new EnhancedCacheManagerIntroduction(delegate),
             EnhancedCacheManager.class));
 
-        return proxyFactory.getProxy();
+        try {
+            return proxyFactory.getProxy();
+        } catch (Exception e) {
+            proxyFactory.setProxyTargetClass(false);
+
+            return proxyFactory.getProxy();
+        }
     }
 }

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -29,8 +29,9 @@ import org.springframework.cache.CacheManager;
  * BeanPostProcessor that wraps existing CacheManager beans with EnhancedCacheManager
  * to provide additional features.
  *
- * @author Nikita Kirillov
  * @since 24.11.2025
+ * @author Nikita Kirillov
+ * @author Artemiy Degtyarev
  */
 public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
 

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.cache;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * CacheManager implementation that provides dynamic control over cache operations.
+ * <p>
+ * Current implementation stores the map of {@link EnhancedCache EnhancedCache instances}.
+ * All the operations, like clear, eviction by key, get by key etc. can be performed of the
+ * {@link EnhancedCache}, rather than on the {@link #delegate}, since {@link EnhancedCache}
+ * instance by design internally holds the reference to the exact same {@link Cache} object
+ * on the heap, as the underlying {@link #delegate} does.
+ *
+ * @since 24.11.2025
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ * @author Sergey Cherkasov
+ */
+public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
+
+    private final String cacheManagerBeanName;
+    private final CacheManager delegate;
+    private final Map<String, EnhancedCache> caches = new ConcurrentHashMap<>();
+
+    public DefaultEnhancedCacheManager(String cacheManagerBeanName, CacheManager delegate) {
+        this.delegate = delegate;
+        this.cacheManagerBeanName = cacheManagerBeanName;
+    }
+
+    @Override
+    public String getUnderlyingCacheManagerBeanName() {
+        return cacheManagerBeanName;
+    }
+
+    @Override
+    public void clear(String cacheName) {
+        Optional.ofNullable(this.getCache(cacheName)).ifPresent(Cache::invalidate);
+    }
+
+    @Override
+    public void clear(String cacheName, Object key) {
+        Optional.ofNullable(this.getCache(cacheName)).ifPresent(cache -> cache.evictIfPresent(key));
+    }
+
+    @Override
+    public void clearAll() {
+        caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.clear());
+    }
+
+    @Override
+    public Collection<EnhancedCache> getAll() {
+        return caches.values();
+    }
+
+    @Override
+    @Nullable
+    public EnhancedCache getCache(@NonNull String name) {
+        EnhancedCache enhancedCache = caches.computeIfAbsent(name, s -> {
+            Cache cache = delegate.getCache(s);
+
+            if (cache != null) {
+                return new DefaultEnhancedCache(cache);
+            } else {
+                return NonExistentEnhancedCache.INSTANCE;
+            }
+        });
+
+        if (enhancedCache instanceof NonExistentEnhancedCache) {
+            return null;
+        } else {
+            return enhancedCache;
+        }
+    }
+
+    @Override
+    @NonNull
+    public Collection<String> getCacheNames() {
+        return delegate.getCacheNames();
+    }
+
+    /**
+     * Enable cache, if exists.
+     *
+     * @param cacheName cache name to enable.
+     */
+    @Override
+    public void enable(String cacheName) {
+        Cache cache = this.getCache(cacheName);
+
+        if (cache != null) {
+            ((EnhancedCache) cache).enable();
+        }
+    }
+
+    /**
+     * Disable cache, if exists.
+     *
+     * @param cacheName cache name to enable.
+     */
+    @Override
+    public void disable(String cacheName) {
+        Cache cache = this.getCache(cacheName);
+
+        if (cache != null) {
+            ((EnhancedCache) cache).disable();
+        }
+    }
+
+    /**
+     * Enable all caches.
+     */
+    @Override
+    public void enableAll() {
+        this.caches.forEach((cacheManagerName, enhancedCache) -> {
+            enhancedCache.enable();
+        });
+    }
+
+    /**
+     * Disable all caches.
+     */
+    @Override
+    public void disableAll() {
+        this.caches.forEach((cacheManagerName, enhancedCache) -> {
+            enhancedCache.disable();
+        });
+    }
+
+    /**
+     * Check if a specific cache is currently enabled.
+     *
+     * @param cacheName the name of the cache to check
+     * @return {@code true} if the cache exists and is enabled, {@code false} otherwise
+     */
+    @Override
+    public boolean isEnabled(String cacheName) {
+        Cache cache = this.getCache(cacheName);
+
+        if (cache != null) {
+            return ((EnhancedCache) cache).isEnabled();
+        }
+
+        return false;
+    }
+}

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
@@ -28,15 +28,11 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * CacheManager implementation that provides dynamic control over cache operations.
- * <p>
- * Current implementation stores the map of {@link EnhancedCache EnhancedCache instances}.
- * All the operations, like clear, eviction by key, get by key etc. can be performed of the
- * {@link EnhancedCache}, rather than on the {@link #delegate}, since {@link EnhancedCache}
- * instance by design internally holds the reference to the exact same {@link Cache} object
- * on the heap, as the underlying {@link #delegate} does.
+ * Default {@link EnhancedCacheManager} implementation that delegates the core
+ * {@link CacheManager} contract to an underlying manager and maintains a map of
+ * {@link EnhancedCache} instances on top of the underlying caches.
  *
- * @since 24.11.2025
+ * @since 11.05.2026
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
@@ -69,6 +65,8 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
 
     @Override
     public void clearAll() {
+        this.getCacheNames().forEach(this::getCache);
+
         caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.clear());
     }
 
@@ -80,21 +78,11 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
     @Override
     @Nullable
     public EnhancedCache getCache(@NonNull String name) {
-        EnhancedCache enhancedCache = caches.computeIfAbsent(name, s -> {
+        return caches.computeIfAbsent(name, s -> {
             Cache cache = delegate.getCache(s);
 
-            if (cache != null) {
-                return new DefaultEnhancedCache(cache);
-            } else {
-                return NonExistentEnhancedCache.INSTANCE;
-            }
+            return cache != null ? new DefaultEnhancedCache(cache) : null;
         });
-
-        if (enhancedCache instanceof NonExistentEnhancedCache) {
-            return null;
-        } else {
-            return enhancedCache;
-        }
     }
 
     @Override
@@ -110,10 +98,10 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
      */
     @Override
     public void enable(String cacheName) {
-        Cache cache = this.getCache(cacheName);
+        EnhancedCache cache = this.getCache(cacheName);
 
         if (cache != null) {
-            ((EnhancedCache) cache).enable();
+            cache.enable();
         }
     }
 
@@ -124,10 +112,10 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
      */
     @Override
     public void disable(String cacheName) {
-        Cache cache = this.getCache(cacheName);
+        EnhancedCache cache = this.getCache(cacheName);
 
         if (cache != null) {
-            ((EnhancedCache) cache).disable();
+            cache.disable();
         }
     }
 
@@ -136,9 +124,9 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
      */
     @Override
     public void enableAll() {
-        this.caches.forEach((cacheManagerName, enhancedCache) -> {
-            enhancedCache.enable();
-        });
+        this.getCacheNames().forEach(this::getCache);
+
+        this.caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.enable());
     }
 
     /**
@@ -146,9 +134,9 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
      */
     @Override
     public void disableAll() {
-        this.caches.forEach((cacheManagerName, enhancedCache) -> {
-            enhancedCache.disable();
-        });
+        this.getCacheNames().forEach(this::getCache);
+
+        this.caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.disable());
     }
 
     /**
@@ -159,10 +147,10 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
      */
     @Override
     public boolean isEnabled(String cacheName) {
-        Cache cache = this.getCache(cacheName);
+        EnhancedCache cache = this.getCache(cacheName);
 
         if (cache != null) {
-            return ((EnhancedCache) cache).isEnabled();
+            return cache.isEnabled();
         }
 
         return false;

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
+ * @author Artemiy Degtyarev
  */
 public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
 
@@ -63,6 +64,7 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
         Optional.ofNullable(this.getCache(cacheName)).ifPresent(cache -> cache.evictIfPresent(key));
     }
 
+    /** Best-effort with respect to caches created concurrently; late arrivals may be skipped, so callers should not rely on strong consistency. */
     @Override
     public void clearAll() {
         this.getCacheNames().forEach(this::getCache);
@@ -121,6 +123,7 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
 
     /**
      * Enable all caches.
+     * <p>Best-effort with respect to caches created concurrently; late arrivals may be skipped, so callers should not rely on strong consistency.
      */
     @Override
     public void enableAll() {
@@ -131,6 +134,7 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
 
     /**
      * Disable all caches.
+     * <p>Best-effort with respect to caches created concurrently; late arrivals may be skipped, so callers should not rely on strong consistency.
      */
     @Override
     public void disableAll() {

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
@@ -56,7 +56,7 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
 
     @Override
     public void clear(String cacheName) {
-        Optional.ofNullable(this.getCache(cacheName)).ifPresent(Cache::invalidate);
+        Optional.ofNullable(this.getCache(cacheName)).ifPresent(Cache::clear);
     }
 
     @Override

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManager.java
@@ -17,145 +17,50 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.cache;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
-
-import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 
+import java.util.Collection;
+
 /**
- * CacheManager implementation that provides dynamic control over cache operations.
- * <p>
- * Current implementation stores the map of {@link EnhancedCache EnhancedCache instances}.
- * All the operations, like clear, eviction by key, get by key etc. can be performed of the
- * {@link EnhancedCache}, rather than on the {@link #delegate}, since {@link EnhancedCache}
- * instance by design internally holds the reference to the exact same {@link Cache} object
- * on the heap, as the underlying {@link #delegate} does.
+ * Extension of {@link CacheManager} that exposes management operations on top of an existing
+ * {@link CacheManager}. Implementations are typically attached to user-defined {@link CacheManager}
+ * beans through an AOP proxy so that the original concrete type is preserved.
  *
- * @since 24.11.2025
- * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
+ * @author Nikita Kirillov
  */
-public class EnhancedCacheManager implements CacheManager {
+public interface EnhancedCacheManager extends CacheManager {
 
-    private final String cacheManagerBeanName;
-    private final CacheManager delegate;
-    private final Map<String, EnhancedCache> caches = new ConcurrentHashMap<>();
-
-    public EnhancedCacheManager(String cacheManagerBeanName, CacheManager delegate) {
-        this.delegate = delegate;
-        this.cacheManagerBeanName = cacheManagerBeanName;
-    }
-
-    public String getUnderlyingCacheManagerBeanName() {
-        return cacheManagerBeanName;
-    }
-
-    public void clear(String cacheName) {
-        Optional.ofNullable(this.getCache(cacheName)).ifPresent(Cache::invalidate);
-    }
-
-    public void clear(String cacheName, Object key) {
-        Optional.ofNullable(this.getCache(cacheName)).ifPresent(cache -> cache.evictIfPresent(key));
-    }
-
-    public void clearAll() {
-        caches.forEach((cacheManagerName, enhancedCache) -> enhancedCache.clear());
-    }
-
-    public Collection<EnhancedCache> getAll() {
-        return caches.values();
-    }
+    /**
+     * @return the bean name of the underlying {@link CacheManager} that this enhanced manager wraps.
+     */
+    String getUnderlyingCacheManagerBeanName();
 
     @Override
     @Nullable
-    public EnhancedCache getCache(@NonNull String name) {
-        EnhancedCache enhancedCache = caches.computeIfAbsent(name, s -> {
-            Cache cache = delegate.getCache(s);
-
-            if (cache != null) {
-                return new DefaultEnhancedCache(cache);
-            } else {
-                return NonExistentEnhancedCache.INSTANCE;
-            }
-        });
-
-        if (enhancedCache instanceof NonExistentEnhancedCache) {
-            return null;
-        } else {
-            return enhancedCache;
-        }
-    }
-
-    @Override
-    @NonNull
-    public Collection<String> getCacheNames() {
-        return delegate.getCacheNames();
-    }
+    EnhancedCache getCache(@NonNull String name);
 
     /**
-     * Enable cache, if exists.
-     *
-     * @param cacheName cache name to enable.
+     * @return all enhanced caches that have been resolved through this manager.
      */
-    public void enable(String cacheName) {
-        Cache cache = this.getCache(cacheName);
+    Collection<EnhancedCache> getAll();
 
-        if (cache != null) {
-            ((EnhancedCache) cache).enable();
-        }
-    }
+    void clear(String cacheName);
 
-    /**
-     * Disable cache, if exists.
-     *
-     * @param cacheName cache name to enable.
-     */
-    public void disable(String cacheName) {
-        Cache cache = this.getCache(cacheName);
+    void clear(String cacheName, Object key);
 
-        if (cache != null) {
-            ((EnhancedCache) cache).disable();
-        }
-    }
+    void clearAll();
 
-    /**
-     * Enable all caches.
-     */
-    public void enableAll() {
-        this.caches.forEach((cacheManagerName, enhancedCache) -> {
-            enhancedCache.enable();
-        });
-    }
+    void enable(String cacheName);
 
-    /**
-     * Disable all caches.
-     */
-    public void disableAll() {
-        this.caches.forEach((cacheManagerName, enhancedCache) -> {
-            enhancedCache.disable();
-        });
-    }
+    void disable(String cacheName);
 
-    /**
-     * Check if a specific cache is currently enabled.
-     *
-     * @param cacheName the name of the cache to check
-     * @return {@code true} if the cache exists and is enabled, {@code false} otherwise
-     */
-    public boolean isEnabled(String cacheName) {
-        Cache cache = this.getCache(cacheName);
+    void enableAll();
 
-        if (cache != null) {
-            return ((EnhancedCache) cache).isEnabled();
-        }
+    void disableAll();
 
-        return false;
-    }
+    boolean isEnabled(String cacheName);
 }

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManager.java
@@ -28,9 +28,10 @@ import java.util.Collection;
  * {@link CacheManager}. Implementations are typically attached to user-defined {@link CacheManager}
  * beans through an AOP proxy so that the original concrete type is preserved.
  *
+ * @since 24.11.2025
+ * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
- * @author Nikita Kirillov
  */
 public interface EnhancedCacheManager extends CacheManager {
 

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManager.java
@@ -32,6 +32,7 @@ import java.util.Collection;
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
+ * @author Artemiy Degtyarev
  */
 public interface EnhancedCacheManager extends CacheManager {
 

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
@@ -23,6 +23,8 @@ import org.springframework.aop.IntroductionInterceptor;
 import org.springframework.aop.support.AopUtils;
 
 import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Routes {@link EnhancedCacheManager} (and its inherited {@link org.springframework.cache.CacheManager})
@@ -32,6 +34,7 @@ import java.lang.reflect.Method;
  */
 public class EnhancedCacheManagerIntroduction implements IntroductionInterceptor {
     private final EnhancedCacheManager delegate;
+    private final Map<Method, Method> delegateMethods = new ConcurrentHashMap<>();
 
     public EnhancedCacheManagerIntroduction(EnhancedCacheManager delegate) {
         this.delegate = delegate;
@@ -50,7 +53,7 @@ public class EnhancedCacheManagerIntroduction implements IntroductionInterceptor
 
     @Override
     public boolean implementsInterface(Class<?> intf) {
-        return intf.equals(EnhancedCacheManager.class);
+        return intf.isAssignableFrom(EnhancedCacheManager.class);
     }
 
     @Nullable
@@ -58,10 +61,12 @@ public class EnhancedCacheManagerIntroduction implements IntroductionInterceptor
         if (invokedMethod.getDeclaringClass().equals(Object.class))
             return null;
 
-        try {
-            return EnhancedCacheManager.class.getMethod(invokedMethod.getName(), invokedMethod.getParameterTypes());
-        } catch (NoSuchMethodException e) {
-            return null;
-        }
+        return delegateMethods.computeIfAbsent(invokedMethod, s -> {
+            try {
+                return EnhancedCacheManager.class.getMethod(s.getName(), s.getParameterTypes());
+            } catch (NoSuchMethodException e) {
+                return null;
+            }
+        });
     }
 }

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
@@ -31,8 +31,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * invocations on the proxy to the supplied delegate, while letting any concrete-class-specific method
  * proceed to the proxied target. This preserves the runtime type of the original {@code CacheManager}
  * bean while exposing the enhanced management API.
+ *
+ * @since 11.05.2026
+ * @author Artemiy Degtyarev
  */
-public class EnhancedCacheManagerIntroduction implements IntroductionInterceptor {
+final class EnhancedCacheManagerIntroduction implements IntroductionInterceptor {
     private final EnhancedCacheManager delegate;
     private final Map<Method, Method> delegateMethods = new ConcurrentHashMap<>();
 

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
@@ -1,0 +1,47 @@
+package com.axelixlabs.axelix.sbs.spring.core.cache;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.jspecify.annotations.Nullable;
+import org.springframework.aop.IntroductionInterceptor;
+import org.springframework.aop.support.AopUtils;
+
+import java.lang.reflect.Method;
+
+/**
+ * Routes {@link EnhancedCacheManager} (and its inherited {@link org.springframework.cache.CacheManager})
+ * invocations on the proxy to the supplied delegate, while letting any concrete-class-specific method
+ * proceed to the proxied target. This preserves the runtime type of the original {@code CacheManager}
+ * bean while exposing the enhanced management API.
+ */
+public class EnhancedCacheManagerIntroduction implements IntroductionInterceptor {
+    private final EnhancedCacheManager delegate;
+
+    public EnhancedCacheManagerIntroduction(EnhancedCacheManager delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    @Nullable
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        Method delegateMethod = findDelegateMethod(invocation.getMethod());
+
+        if (delegateMethod != null)
+            return AopUtils.invokeJoinpointUsingReflection(delegate, delegateMethod, invocation.getArguments());
+
+        return invocation.proceed();
+    }
+
+    @Override
+    public boolean implementsInterface(Class<?> intf) {
+        return intf.isAssignableFrom(EnhancedCacheManager.class);
+    }
+
+    @Nullable
+    private Method findDelegateMethod(Method invokedMethod) {
+        try {
+            return EnhancedCacheManager.class.getMethod(invokedMethod.getName(), invokedMethod.getParameterTypes());
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
+++ b/sbs/axelix-spring-boot-3/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import org.aopalliance.intercept.MethodInvocation;
@@ -33,11 +50,14 @@ public class EnhancedCacheManagerIntroduction implements IntroductionInterceptor
 
     @Override
     public boolean implementsInterface(Class<?> intf) {
-        return intf.isAssignableFrom(EnhancedCacheManager.class);
+        return intf.equals(EnhancedCacheManager.class);
     }
 
     @Nullable
     private Method findDelegateMethod(Method invokedMethod) {
+        if (invokedMethod.getDeclaringClass().equals(Object.class))
+            return null;
+
         try {
             return EnhancedCacheManager.class.getMethod(invokedMethod.getName(), invokedMethod.getParameterTypes());
         } catch (NoSuchMethodException e) {

--- a/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
+++ b/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
@@ -269,8 +269,8 @@ class DefaultCacheOperationsDispatcherTest {
         dispatcher.disableCacheManager(cacheManagerName);
 
         // then.
-        assertThat(dispatcher.get(cacheManagerName, TEST_CACHE_1).isEnabled()).isTrue();
-        assertThat(dispatcher.get(cacheManagerName, TEST_CACHE_2).isEnabled()).isTrue();
+        assertThat(dispatcher.get(cacheManagerName, TEST_CACHE_1).isEnabled()).isFalse();
+        assertThat(dispatcher.get(cacheManagerName, TEST_CACHE_2).isEnabled()).isFalse();
     }
 
     @Test

--- a/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
+++ b/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
@@ -37,10 +37,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link DefaultCacheOperationsDispatcher}.
  *
- * @since 24.06.2025
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
+ * @since 24.06.2025
  */
 class DefaultCacheOperationsDispatcherTest {
 
@@ -61,7 +61,7 @@ class DefaultCacheOperationsDispatcherTest {
         Map<String, CacheManager> managers = new HashMap<>();
 
         cacheManager1 = new DefaultEnhancedCacheManager(
-                TEST_CACHE_MANAGER_1, new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2));
+            TEST_CACHE_MANAGER_1, new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2));
         cacheManager2 = new DefaultEnhancedCacheManager(TEST_CACHE_MANAGER_2, new ConcurrentMapCacheManager(TEST_CACHE_2));
         managers.put(TEST_CACHE_MANAGER_1, cacheManager1);
         managers.put(TEST_CACHE_MANAGER_2, cacheManager2);
@@ -91,7 +91,7 @@ class DefaultCacheOperationsDispatcherTest {
     @Test
     void shouldNoOpOnClearingNonExistentCacheManager() {
         assertThatThrownBy(() -> dispatcher.clear("nonExistentCacheManager", "cache"))
-                .isInstanceOf(CacheManagerNotFoundException.class);
+            .isInstanceOf(CacheManagerNotFoundException.class);
     }
 
     @Test
@@ -113,7 +113,7 @@ class DefaultCacheOperationsDispatcherTest {
         // then.
         assertThat(cache.get(keyToRemove)).isNull();
         assertThat(cache.get(keyToKeep)).isNotNull().satisfies(cacheValue -> assertThat(cacheValue.get())
-                .isEqualTo("value2"));
+            .isEqualTo("value2"));
     }
 
     @Test
@@ -230,7 +230,7 @@ class DefaultCacheOperationsDispatcherTest {
     @Test
     void isCacheEnabled_shouldReturnTrueForEnabledCache() {
         assertThat(dispatcher.get(TEST_CACHE_MANAGER_1, TEST_CACHE_1).isEnabled())
-                .isTrue();
+            .isTrue();
     }
 
     @Test
@@ -311,11 +311,11 @@ class DefaultCacheOperationsDispatcherTest {
         // then.
         assertThat(first.getEstimatedEntrySize()).isEqualTo(2L);
         assertThat(first.getLookupHistory().stream()
-                        .filter(it -> SingleCache.LookupOutcome.MISS.equals(it.getOutcome())))
-                .hasSize(2);
+            .filter(it -> SingleCache.LookupOutcome.MISS.equals(it.getOutcome())))
+            .hasSize(2);
         assertThat(first.getLookupHistory().stream()
-                        .filter(it -> SingleCache.LookupOutcome.HIT.equals(it.getOutcome())))
-                .hasSize(2);
+            .filter(it -> SingleCache.LookupOutcome.HIT.equals(it.getOutcome())))
+            .hasSize(2);
 
         // given.
         Cache cache2 = cacheManager2.getCache(TEST_CACHE_2);
@@ -329,11 +329,11 @@ class DefaultCacheOperationsDispatcherTest {
         // then.
         assertThat(second.getEstimatedEntrySize()).isEqualTo(1L);
         assertThat(second.getLookupHistory().stream()
-                        .filter(it -> SingleCache.LookupOutcome.MISS.equals(it.getOutcome())))
-                .hasSize(1);
+            .filter(it -> SingleCache.LookupOutcome.MISS.equals(it.getOutcome())))
+            .hasSize(1);
         assertThat(second.getLookupHistory().stream()
-                        .filter(it -> SingleCache.LookupOutcome.HIT.equals(it.getOutcome())))
-                .hasSize(1);
+            .filter(it -> SingleCache.LookupOutcome.HIT.equals(it.getOutcome())))
+            .hasSize(1);
     }
 
     @Test
@@ -349,14 +349,14 @@ class DefaultCacheOperationsDispatcherTest {
 
         // then.
         CachesFeed.CacheDto cache = cachesFeed.getCacheManagers().stream()
-                .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
-                .findFirst()
-                .orElseThrow()
-                .getCaches()
-                .stream()
-                .filter(it -> TEST_CACHE_1.equals(it.getName()))
-                .findFirst()
-                .orElseThrow();
+            .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
+            .findFirst()
+            .orElseThrow()
+            .getCaches()
+            .stream()
+            .filter(it -> TEST_CACHE_1.equals(it.getName()))
+            .findFirst()
+            .orElseThrow();
 
         assertThat(cache.isContainsStats()).isTrue();
     }
@@ -372,14 +372,14 @@ class DefaultCacheOperationsDispatcherTest {
 
         // then.
         CachesFeed.CacheDto cache = cachesFeed.getCacheManagers().stream()
-                .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
-                .findFirst()
-                .orElseThrow()
-                .getCaches()
-                .stream()
-                .filter(it -> TEST_CACHE_1.equals(it.getName()))
-                .findFirst()
-                .orElseThrow();
+            .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
+            .findFirst()
+            .orElseThrow()
+            .getCaches()
+            .stream()
+            .filter(it -> TEST_CACHE_1.equals(it.getName()))
+            .findFirst()
+            .orElseThrow();
 
         assertThat(cache.isContainsStats()).isFalse();
     }
@@ -387,35 +387,35 @@ class DefaultCacheOperationsDispatcherTest {
     @Test
     void shouldReturnNull_ForNonExistentManager() {
         assertThatThrownBy(() -> dispatcher.get("nonExistentManager", TEST_CACHE_1))
-                .isInstanceOf(CacheManagerNotFoundException.class);
+            .isInstanceOf(CacheManagerNotFoundException.class);
     }
 
     @Test
     void enableCacheManager_shouldThrowExceptionForNonExistentManager() {
         assertThatThrownBy(() -> dispatcher.enableCacheManager("nonExistentManager"))
-                .isInstanceOf(CacheManagerNotFoundException.class)
-                .hasMessageContaining("nonExistentManager");
+            .isInstanceOf(CacheManagerNotFoundException.class)
+            .hasMessageContaining("nonExistentManager");
     }
 
     @Test
     void disableCacheManager_shouldThrowExceptionForNonExistentManager() {
         assertThatThrownBy(() -> dispatcher.disableCacheManager("nonExistentManager"))
-                .isInstanceOf(CacheManagerNotFoundException.class)
-                .hasMessageContaining("nonExistentManager");
+            .isInstanceOf(CacheManagerNotFoundException.class)
+            .hasMessageContaining("nonExistentManager");
     }
 
     @Test
     void enableCache_shouldThrowExceptionForNonExistentManager() {
         assertThatThrownBy(() -> dispatcher.enableCache("nonExistentManager", TEST_CACHE_1))
-                .isInstanceOf(CacheManagerNotFoundException.class)
-                .hasMessageContaining("nonExistentManager");
+            .isInstanceOf(CacheManagerNotFoundException.class)
+            .hasMessageContaining("nonExistentManager");
     }
 
     @Test
     void disableCache_shouldThrowExceptionForNonExistentManager() {
         assertThatThrownBy(() -> dispatcher.disableCache("nonExistentManager", TEST_CACHE_1))
-                .isInstanceOf(CacheManagerNotFoundException.class)
-                .hasMessageContaining("nonExistentManager");
+            .isInstanceOf(CacheManagerNotFoundException.class)
+            .hasMessageContaining("nonExistentManager");
     }
 
     @Test

--- a/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
+++ b/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
@@ -60,9 +60,9 @@ class DefaultCacheOperationsDispatcherTest {
     void setUp() {
         Map<String, CacheManager> managers = new HashMap<>();
 
-        cacheManager1 = new EnhancedCacheManager(
+        cacheManager1 = new DefaultEnhancedCacheManager(
                 TEST_CACHE_MANAGER_1, new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2));
-        cacheManager2 = new EnhancedCacheManager(TEST_CACHE_MANAGER_2, new ConcurrentMapCacheManager(TEST_CACHE_2));
+        cacheManager2 = new DefaultEnhancedCacheManager(TEST_CACHE_MANAGER_2, new ConcurrentMapCacheManager(TEST_CACHE_2));
         managers.put(TEST_CACHE_MANAGER_1, cacheManager1);
         managers.put(TEST_CACHE_MANAGER_2, cacheManager2);
 

--- a/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerTest.java
+++ b/sbs/axelix-spring-boot-3/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerTest.java
@@ -42,7 +42,7 @@ class EnhancedCacheManagerTest {
     @BeforeEach
     void setUp() {
         CacheManager cacheManager = new ConcurrentMapCacheManager();
-        subject = new EnhancedCacheManager("testCacheManagerBeanName", cacheManager);
+        subject = new DefaultEnhancedCacheManager("testCacheManagerBeanName", cacheManager);
     }
 
     @Test


### PR DESCRIPTION
Replace the manual EnhancedCacheManager decorator with a CGLIB proxy

Closes #1005 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cache managers are now exposed as enhanced cache contracts via AOP-backed proxies for consistent runtime behavior.
* **New Features**
  * Added a default enhanced cache manager with lazy per-cache wrapping, cache listing, clear/evict, and per-cache/global enable/disable controls.
* **Tests**
  * Unit tests updated to use the new default implementation and adjusted expectations for cache enablement.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axelixlabs/axelix/pull/1010)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->