### PR TITLE
GH-1032 Drop the `kotlin-stdlib` plugin from the `sbs` module

### DIFF
--- a/sbs/starter-domain/build.gradle.kts
+++ b/sbs/starter-domain/build.gradle.kts
@@ -1,10 +1,6 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
-
 plugins {
     id("shared")
     id("com.axelixlabs.axelix-internal")
-    kotlin("jvm") version "2.2.21"
 }
 
 val springBootTestPlatformVersion = "2.7.18"
@@ -31,8 +27,3 @@ tasks.withType<JavaCompile>().configureEach {
     options.release = 11
     options.compilerArgs.add("-parameters")
 }
-
-tasks.withType<KotlinJvmCompile>().configureEach {
-    compilerOptions.jvmTarget.set(JvmTarget.JVM_11)
-}
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated starter-domain module build configuration from Kotlin to Java compilation while maintaining Java 11 compatibility and parameter annotation support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axelixlabs/axelix/pull/1033)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->