### PR TITLE
GH-1085 Update the configuration documentation for the master and starter

### DIFF
--- a/docs/docs/setting-up-master-ui/configuring-master/configuring-master.mdx
+++ b/docs/docs/setting-up-master-ui/configuring-master/configuring-master.mdx
@@ -113,10 +113,7 @@ When `axelix.master.auth.options.oauth2.enabled=true`, the following properties 
 
 Auto-discovery lets Master find Spring Boot Starter–equipped applications without each one having to call in. On the schedule set by `broadcast.schedule`, Master queries the Kubernetes API for Services in the configured namespaces, filters them by label, and probes `/actuator/axelix-metadata` on each match using a JWT it issues itself with `axelix.master.auth.jwt.signing-key`. A successful probe registers the instance; a probe failure drops it from the list.
 
-To turn the feature on you must set two properties:
-
-- `axelix.master.discovery.auto.enabled=true` — switches autodiscovery on (default `false`, i.e. off).
-- `axelix.master.discovery.auto.platform=kubernetes` — the discovery platform. Currently `kubernetes` is the only supported value.
+To turn the feature on, set `axelix.master.discovery.auto.enabled=true` (default `false`, i.e. off). Kubernetes is currently the only supported discovery platform.
 
 When Master runs **inside** the cluster as a pod, the Kubernetes connection settings (`kube-apiserver-url`, `sa-token-path`, `ca-cert-path`) default to in-pod values and need no override; the starter side just has to expose `axelix-metadata` and share the JWT signing key. When Master runs **outside** the cluster, point those three to the external API URL, a token file with the required RBAC, and the cluster CA path. Use `filters.namespaces` and `filters.labels` to scope the scan.
 
@@ -125,7 +122,6 @@ When Master runs **inside** the cluster as a pod, the Kubernetes connection sett
 | Property                                                     | Default                                                                          | Description                                                                                |
 |--------------------------------------------------------------|----------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
 | `axelix.master.discovery.auto.enabled`                       | `false`                                                                          | Enable platform-driven autodiscovery of managed services.                                  |
-| `axelix.master.discovery.auto.platform`                      | *(unset)* <span className={styles.required}>required</span> | Discovery platform. Currently `kubernetes` is the only supported value. Required whenever `auto.enabled=true`. |
 | `axelix.master.discovery.auto.broadcast.schedule`            | `0 * * * * *`                                                                    | Cron expression that triggers the discovery scan.                                          |
 | `axelix.master.discovery.auto.kubernetes.kube-apiserver-url` | `https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}`            | URL of the Kubernetes API server.                                                          |
 | `axelix.master.discovery.auto.kubernetes.sa-token-path`      | `/var/run/secrets/kubernetes.io/serviceaccount/token`                            | Path inside the Master pod where the ServiceAccount token is mounted.                      |
@@ -141,7 +137,7 @@ Self-registration is the opposite direction of autodiscovery: Master *accepts* h
 
 The endpoint is `POST /api/internal/service/register`. It is gated by the same JWT signing key set under `axelix.master.auth.jwt.*` — without a matching key, heartbeats are rejected.
 
-On the Master side there are **no required overrides** — every property here has a working default. The feature is **on by default** (`enabled=true`); set it to `false` only if you want Master to refuse all heartbeats. The starter-side properties that go *into* the heartbeat (`master-url`, `instance-url`, `instance-name`) are documented in the [Configuring Spring Boot Starter](../../installation/configuring-spring-boot-starter.mdx) page.
+On the Master side there are **no required overrides** — every property here has a working default. The feature is **on by default** (`enabled=true`); set it to `false` only if you want Master to refuse all heartbeats. The starter-side properties that go *into* the heartbeat (`master-url`, `instance-actuator-url`, `instance-name`) are documented in the [Configuring Spring Boot Starter](../../installation/configuring-spring-boot-starter.mdx) page.
 
 <div className={styles.configTable}>
 
@@ -179,7 +175,7 @@ Provide a JWT signing key and an algorithm. Everything else can stay on defaults
 java \
   -Daxelix.master.auth.jwt.algorithm=HMAC512 \
   -Daxelix.master.auth.jwt.signing-key=replace-with-a-long-random-secret \
-  -jar master.jar
+  -jar axelix-1.0.0-M1.jar
 ```
 
 Master is then reachable at `http://localhost:8080`. Sign in with the super-admin credentials you configured.
@@ -323,11 +319,11 @@ Use this when you want a single, immutable artifact that already bundles both Ma
 The release pipeline publishes the image to GitHub Container Registry:
 
 ```
-ghcr.io/axelixlabs/axelix:1.0.0-SNAPSHOT
+ghcr.io/axelixlabs/axelix:1.0.0-M1
 ```
 
 :::note
-The snippets below pin `1.0.0-SNAPSHOT` for illustration. Check the [Releases page](https://github.com/axelixlabs/axelix/releases) for the latest published tag and substitute it in your own commands.
+The snippets below pin `1.0.0-M1` for illustration. Check the [Releases page](https://github.com/axelixlabs/axelix/releases) for the latest published tag and substitute it in your own commands.
 :::
 
 ### Run command
@@ -340,7 +336,7 @@ docker run --rm -p 8080:8080 \
     -Daxelix.master.auth.jwt.algorithm=HMAC512 \
     -Daxelix.master.auth.jwt.signing-key=replace-with-a-long-random-secret \
     -Daxelix.master.auth.options.super-admin.credentials.password=replace-me" \
-  ghcr.io/axelixlabs/axelix:1.0.0-SNAPSHOT
+  ghcr.io/axelixlabs/axelix:1.0.0-M1
 ```
 
 A few notes about this command:
@@ -353,7 +349,7 @@ A few notes about this command:
 
 Use this when you want Master plus an external database in one declarative file — the natural shape for a small self-hosted deployment.
 
-The repository does not currently ship a Compose file for running Master itself; the example below is a complete stack you can drop into a new `docker-compose.yaml`, edit, and start with `docker compose up -d`. The `master` service is pinned to `1.0.0-SNAPSHOT` here — swap in the latest tag from the [Releases page](https://github.com/axelixlabs/axelix/releases) before shipping.
+The repository does not currently ship a Compose file for running Master itself, the example below is a complete stack you can drop into a new `docker-compose.yaml`, edit, and start with `docker compose up -d`. The `master` service is pinned to `1.0.0-M1` here — swap in the latest tag from the [Releases page](https://github.com/axelixlabs/axelix/releases) before shipping.
 
 ```yaml title="docker-compose.yaml"
 services:
@@ -372,7 +368,7 @@ services:
       retries: 10
 
   master:
-    image: ghcr.io/axelixlabs/axelix:1.0.0-SNAPSHOT
+    image: ghcr.io/axelixlabs/axelix:1.0.0-M1
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/docs/setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx
+++ b/docs/docs/setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx
@@ -25,7 +25,7 @@ A few facts worth pinning down before you copy any of the snippets below.
 Declare the starter coordinate matching your Boot major version.
 
 :::note
-The snippets below pin `1.0.0-SNAPSHOT` for illustration. Check the [Releases page](https://github.com/axelixlabs/axelix/releases) for the latest published tag and use that version in your own build.
+The snippets below pin `1.0.0-M1` for illustration. Check the [Releases page](https://github.com/axelixlabs/axelix/releases) for the latest published tag and use that version in your own build.
 :::
 
 <Tabs groupId="spring-boot-major">
@@ -36,7 +36,7 @@ The snippets below pin `1.0.0-SNAPSHOT` for illustration. Check the [Releases pa
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("com.axelixlabs:axelix-spring-boot-3-starter:1.0.0-SNAPSHOT")
+    implementation("com.axelixlabs:axelix-spring-boot-3-starter:1.0.0-M1")
 }
 ```
 
@@ -45,7 +45,7 @@ dependencies {
 
 ```groovy title="build.gradle"
 dependencies {
-    implementation 'com.axelixlabs:axelix-spring-boot-3-starter:1.0.0-SNAPSHOT'
+    implementation 'com.axelixlabs:axelix-spring-boot-3-starter:1.0.0-M1'
 }
 ```
 
@@ -57,7 +57,7 @@ dependencies {
   <dependency>
     <groupId>com.axelixlabs</groupId>
     <artifactId>axelix-spring-boot-3-starter</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-M1</version>
   </dependency>
 </dependencies>
 ```
@@ -73,7 +73,7 @@ dependencies {
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("com.axelixlabs:axelix-spring-boot-2-starter:1.0.0-SNAPSHOT")
+    implementation("com.axelixlabs:axelix-spring-boot-2-starter:1.0.0-M1")
 }
 ```
 
@@ -82,7 +82,7 @@ dependencies {
 
 ```groovy title="build.gradle"
 dependencies {
-    implementation 'com.axelixlabs:axelix-spring-boot-2-starter:1.0.0-SNAPSHOT'
+    implementation 'com.axelixlabs:axelix-spring-boot-2-starter:1.0.0-M1'
 }
 ```
 
@@ -94,7 +94,7 @@ dependencies {
   <dependency>
     <groupId>com.axelixlabs</groupId>
     <artifactId>axelix-spring-boot-2-starter</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-M1</version>
   </dependency>
 </dependencies>
 ```
@@ -205,7 +205,7 @@ axelix:
     discovery:
       auto: true
       master-url: http://master.internal:8080/api/internal/service/register
-      instance-url: http://my-app.internal:8080
+      instance-actuator-url: http://my-app.internal:8080
       instance-name: orders-service
       heartbeat-interval: 15s
 ```
@@ -216,7 +216,7 @@ axelix:
 ```properties
 axelix.sbs.discovery.auto=true
 axelix.sbs.discovery.master-url=http://master.internal:8080/api/internal/service/register
-axelix.sbs.discovery.instance-url=http://my-app.internal:8080
+axelix.sbs.discovery.instance-actuator-url=http://my-app.internal:8080
 axelix.sbs.discovery.instance-name=orders-service
 axelix.sbs.discovery.heartbeat-interval=15s
 ```
@@ -226,12 +226,67 @@ axelix.sbs.discovery.heartbeat-interval=15s
 
 A few details that catch people out:
 
-- `instance-url` is the **base** URL of the service as Master will reach it from its own network — host and port only. The starter appends the actuator base path (`/actuator` by default, or whatever you set in `management.endpoints.web.base-path`) when assembling the registration payload.
+- `instance-actuator-url` is the **base** URL of the service as Master will reach it from its own network — host and port only. The starter appends the actuator base path (`/actuator` by default, or whatever you set in `management.endpoints.web.base-path`) when assembling the registration payload.
 - `master-url` is the **full** URL including `/api/internal/service/register`. The starter posts to it verbatim.
 - `instance-name` is the label Master shows for this instance in the UI and in MCP responses. Pick a name that survives restarts and replicas — typically the service name, not the pod name.
 - Self-registration is accepted by Master out of the box (`axelix.master.discovery.self-registration.enabled` is `true` by default); set it to `false` if you want to refuse heartbeats. Master evicts an instance after `axelix.master.discovery.self-registration.eviction.heartbeat-timeout` of silence (`45s` by default), so keep `heartbeat-interval` comfortably under that.
 
 The starter validates these properties at startup, misspelling `master-url` or pointing it at a malformed URL fails fast rather than silently dropping heartbeats.
+
+## Sanitize sensitive property values
+
+The Axelix `axelix-env` and `axelix-configprops` endpoints return property values to Master. To keep secrets out of
+casual reads, the starter masks values it returns to callers that lack the right authority. The mechanism is the same
+for both endpoints, controlled by a single starter property:
+
+`axelix.sbs.endpoints.config.sanitized-properties`
+
+- **Empty list (default)** — every value returned by `axelix-env` and `axelix-configprops` is replaced with
+  `******` for callers without the relevant authority. The default is intentionally conservative: no opt-in needed
+  to be safe.
+- **Non-empty list** — only the listed keys are masked; everything else is returned raw to any caller. Use this when
+  the conservative default is too aggressive and you want to mask only specific keys (passwords, tokens, signing keys).
+
+Authority is checked per-endpoint:
+
+- **`axelix-env`** — the `ENV_VALUES_READ` authority lets the caller see raw values.
+- **`axelix-configprops`** — the `CONFIG_PROPS_VALUES_READ` authority lets the caller see raw values.
+
+Both authorities are granted by Master's built-in **ADMIN** and **SUPER_ADMIN** roles. **VIEWER** and **EDITOR**
+always go through the sanitization function. See
+[Roles and authorities](../../setting-up-master-ui/authentication/authentication.mdx#roles-and-authorities) for the
+full matrix.
+
+<Tabs groupId="spring-config">
+  <TabItem value="yaml" label="application.yaml">
+
+```yaml
+axelix:
+  sbs:
+    endpoints:
+      config:
+        sanitized-properties:
+          - database.password
+          - spring.datasource.password
+          - jwt.signing-key
+```
+
+  </TabItem>
+  <TabItem value="properties" label="application.properties">
+
+```properties
+axelix.sbs.endpoints.config.sanitized-properties[0]=database.password
+axelix.sbs.endpoints.config.sanitized-properties[1]=spring.datasource.password
+axelix.sbs.endpoints.config.sanitized-properties[2]=jwt.signing-key
+```
+
+  </TabItem>
+</Tabs>
+
+:::note
+The standard Spring Boot Actuator masking switches — `management.endpoint.env.show-values`,
+`management.endpoint.env.keys-to-sanitize`, and their `configprops` equivalents — are **not** consulted.
+:::
 
 ## Configuration reference
 
@@ -256,7 +311,7 @@ Self-registration is **off by default** (`axelix.sbs.discovery.auto=false`) — 
 When `axelix.sbs.discovery.auto=true`, the following properties become **required**:
 
 - `axelix.sbs.discovery.master-url`
-- `axelix.sbs.discovery.instance-url`
+- `axelix.sbs.discovery.instance-actuator-url`
 - `axelix.sbs.discovery.instance-name`
 
 The Master-side receiver of these heartbeats — endpoint, eviction timeout, eviction sweep schedule — is documented on the Master page in [Discovery — self-registration](../../installation/configuring-master.mdx#discovery--self-registration). The JWT signing key configured under `axelix.sbs.auth.jwt.signing-key` must match `axelix.master.auth.jwt.signing-key` on Master, otherwise heartbeats are rejected with `401`.
@@ -267,9 +322,19 @@ The Master-side receiver of these heartbeats — endpoint, eviction timeout, evi
 |------------------------------------------------|---------|------------------------------------------------------------------------------------------------------------------------------|
 | `axelix.sbs.discovery.auto`                    | `false` | Master switch. Set to `true` to enable self-registration; leave `false` to rely on Master-side autodiscovery.                |
 | `axelix.sbs.discovery.master-url`              | *(unset)* <span className={styles.required}>required</span> | Full URL of Master's self-registration endpoint, e.g. `http://master:8080/api/internal/service/register`. Required when `auto=true`. |
-| `axelix.sbs.discovery.instance-url`            | *(unset)* <span className={styles.required}>required</span> | Base URL of this service as reachable from Master (no `/actuator` suffix). Required when `auto=true`.                        |
+| `axelix.sbs.discovery.instance-actuator-url`            | *(unset)* <span className={styles.required}>required</span> | Base URL of this service as reachable from Master (no `/actuator` suffix). Required when `auto=true`.                        |
 | `axelix.sbs.discovery.instance-name`           | *(unset)* <span className={styles.required}>required</span> | Display name shown in Axelix UI and MCP responses. Required when `auto=true`.                                                |
 | `axelix.sbs.discovery.heartbeat-interval`      | `15s`   | Interval between heartbeats. Should be smaller than Master's eviction `heartbeat-timeout`.                                   |
+
+</div>
+
+### Endpoint value sanitization
+
+<div className={styles.configTable}>
+
+| Property                                              | Default | Description                                                                                                                                                                                                                          |
+|-------------------------------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `axelix.sbs.endpoints.config.sanitized-properties`    | *(empty list)* | Property keys whose values are masked as `******` for callers without `ENV_VALUES_READ` (for `axelix-env`) or `CONFIG_PROPS_VALUES_READ` (for `axelix-configprops`). Empty list means **all** values are masked. See [Sanitize sensitive property values](#sanitize-sensitive-property-values) for the matching rules. |
 
 </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Narrowed autodiscovery guidance: only the auto-enabled flag is required (Kubernetes-only).
  * Renamed self-registration property to instance-actuator-url and updated examples.
  * Updated Docker/Docker Compose examples to use 1.0.0-M1 image tag.
  * Pinned Spring Boot starter examples to 1.0.0-M1.
  * Added "Sanitize sensitive property values" section and updated endpoint/authorization notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/axelixlabs/axelix/pull/1086?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->