### PR TITLE
GH-1075 Persist users that came from OIDC in the database

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApi.java
@@ -37,7 +37,6 @@ import com.axelixlabs.axelix.master.api.external.request.user.UserDeleteRequest;
 import com.axelixlabs.axelix.master.api.external.request.user.UserUpdateRequest;
 import com.axelixlabs.axelix.master.api.external.swagger.DefaultApiResponse;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.SecurityAutoConfiguration;
-import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 import com.axelixlabs.axelix.master.service.state.UserService;
@@ -69,8 +68,7 @@ public class UserManagementApi {
     public ResponseEntity<Void> createUser(@RequestBody UserCreateRequest request) {
         try {
 
-            userService.create(
-                    request.username(), request.email(), request.password(), request.role(), UserOrigin.LOCAL);
+            userService.createLocal(request.username(), request.email(), request.password(), request.role());
             return ResponseEntity.status(HttpStatus.CREATED).build();
 
         } catch (UserInvalidValueException

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/infrastructure/McpOAuth2MetadataController.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/infrastructure/McpOAuth2MetadataController.java
@@ -27,7 +27,6 @@ import com.axelixlabs.axelix.master.api.external.ApiPaths;
 import com.axelixlabs.axelix.master.api.external.ExternalApiRestController;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.properties.OAuth2Properties;
 import com.axelixlabs.axelix.master.autoconfiguration.mcp.ConditionalOnMcpServerEnabled;
-import com.axelixlabs.axelix.master.autoconfiguration.web.WebAutoConfiguration;
 
 import static com.axelixlabs.axelix.master.autoconfiguration.auth.SecurityAutoConfiguration.OAUTH_LOGIN_PROPERTIES_PREFIX;
 
@@ -46,7 +45,7 @@ public class McpOAuth2MetadataController {
     private final String scopes;
 
     public McpOAuth2MetadataController(OAuth2Properties oAuth2Properties) {
-        this.mcpServerFullPath = oAuth2Properties.baseUrl() + WebAutoConfiguration.EXTERNAL_API_PATH + "/api/mcp";
+        this.mcpServerFullPath = oAuth2Properties.baseUrl() + "/api/mcp";
         this.issuerUri = oAuth2Properties.issuerUri();
         this.scopes = oAuth2Properties.scopes();
     }

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackController.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackController.java
@@ -17,6 +17,7 @@
  */
 package com.axelixlabs.axelix.master.api.infrastructure;
 
+import java.time.Instant;
 import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
@@ -129,13 +130,14 @@ public class OAuth2CallbackController {
 
         if (entity != null) {
             if (entity.userOrigin() != UserOrigin.OIDC) {
-                throw new BadRequestException("OIDC user conflicts with an existing non-OIDC account");
+                throw new BadRequestException("OIDC user with username '" + user.getUsername()
+                        + "' conflicts with an existing non-OIDC account");
             }
-            userService.updateUserPatch(entity.id(), entity.username(), email, null, Set.of(role.getName()));
+            userService.updateUserPatch(
+                    entity.id(), entity.username(), email, null, Set.of(role.getName()), Instant.now());
         } else {
-            userService.create(user.getUsername(), email, null, role.getName(), UserOrigin.OIDC);
+            userService.createFromOidc(user.getUsername(), email, role.getName());
         }
-        userService.updateLastLoginAt(user.getUsername());
     }
 
     @Nullable

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackController.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackController.java
@@ -19,6 +19,9 @@ package com.axelixlabs.axelix.master.api.infrastructure;
 
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
+import tools.jackson.databind.ObjectMapper;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -33,10 +36,13 @@ import com.axelixlabs.axelix.common.auth.core.User;
 import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
 import com.axelixlabs.axelix.master.api.external.ApiPaths;
 import com.axelixlabs.axelix.master.api.external.ExternalApiRestController;
+import com.axelixlabs.axelix.master.domain.UserEntity;
+import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.service.auth.CookieService;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcRoleExtractor;
 import com.axelixlabs.axelix.master.service.auth.oauth.Tokens;
+import com.axelixlabs.axelix.master.service.state.UserService;
 import com.axelixlabs.axelix.master.service.transport.BadRequestException;
 
 import static com.axelixlabs.axelix.master.autoconfiguration.auth.SecurityAutoConfiguration.OAUTH_LOGIN_PROPERTIES_PREFIX;
@@ -63,16 +69,22 @@ public class OAuth2CallbackController {
     private final CookieService cookieService;
     private final JwtEncoderService jwtEncoderService;
     private final OidcRoleExtractor oidcRoleExtractor;
+    private final UserService userService;
+    private final ObjectMapper objectMapper;
 
     public OAuth2CallbackController(
             OidcClient oidcClient,
             CookieService cookieService,
             JwtEncoderService jwtEncoderService,
-            OidcRoleExtractor oidcRoleExtractor) {
+            OidcRoleExtractor oidcRoleExtractor,
+            UserService userService,
+            ObjectMapper objectMapper) {
         this.oidcClient = oidcClient;
         this.cookieService = cookieService;
         this.jwtEncoderService = jwtEncoderService;
         this.oidcRoleExtractor = oidcRoleExtractor;
+        this.userService = userService;
+        this.objectMapper = objectMapper;
     }
 
     @GetMapping(path = ApiPaths.OAuth2Api.CALLBACK)
@@ -89,9 +101,13 @@ public class OAuth2CallbackController {
 
         String username = oidcClient.validateIdTokenAndExtractUsername(tokens.idToken());
 
-        Role role = oidcRoleExtractor.extractRole(tokens.accessToken());
+        String userInfoJson = oidcClient.validateAccessTokenAndExtractUserInfo(tokens.accessToken());
+
+        Role role = oidcRoleExtractor.extractRole(userInfoJson);
 
         User user = new PasswordlessUser(username, Set.of(role));
+
+        upsertUserUpdateLastLoginAt(user, userInfoJson, role);
 
         String ourToken = jwtEncoderService.generateToken(user);
 
@@ -103,5 +119,32 @@ public class OAuth2CallbackController {
                 .header(HttpHeaders.SET_COOKIE, cookieAuthorities.toString())
                 .header(HttpHeaders.LOCATION, WALLBOARD_PATH)
                 .build();
+    }
+
+    // Always update role & email
+    private void upsertUserUpdateLastLoginAt(User user, String userInfoJson, Role role) {
+        UserEntity entity = userService.findUserByUsername(user.getUsername()).orElse(null);
+
+        String email = extractEmail(userInfoJson);
+
+        if (entity != null) {
+            if (entity.userOrigin() != UserOrigin.OIDC) {
+                throw new BadRequestException("OIDC user conflicts with an existing non-OIDC account");
+            }
+            userService.updateUserPatch(entity.id(), entity.username(), email, null, Set.of(role.getName()));
+        } else {
+            userService.create(user.getUsername(), email, null, role.getName(), UserOrigin.OIDC);
+        }
+        userService.updateLastLoginAt(user.getUsername());
+    }
+
+    @Nullable
+    private String extractEmail(String userInfoJson) {
+        try {
+            String email = objectMapper.readTree(userInfoJson).get("email").asString(null);
+            return (email == null || email.isBlank()) ? null : email;
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/SecurityAutoConfiguration.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/SecurityAutoConfiguration.java
@@ -215,8 +215,9 @@ public class SecurityAutoConfiguration {
 
         @Bean
         @ConditionalOnMcpServerEnabled
-        public McpAuthenticationHandler bearerMcpAuthenticationHandler(OidcRoleExtractor oidcRoleExtractor) {
-            return new BearerMcpAuthenticationHandler(oidcRoleExtractor);
+        public McpAuthenticationHandler bearerMcpAuthenticationHandler(
+                OidcClient oidcClient, OidcRoleExtractor oidcRoleExtractor) {
+            return new BearerMcpAuthenticationHandler(oidcClient, oidcRoleExtractor);
         }
 
         @Bean
@@ -244,8 +245,8 @@ public class SecurityAutoConfiguration {
         }
 
         @Bean
-        public OidcRoleExtractor oidcRoleExtractor(OidcClient oidcClient, OAuth2Properties oAuth2Properties) {
-            return new JmesPathOidcRoleExtractor(oidcClient, oAuth2Properties.roleAttributePath());
+        public OidcRoleExtractor oidcRoleExtractor(OAuth2Properties oAuth2Properties) {
+            return new JmesPathOidcRoleExtractor(oAuth2Properties.roleAttributePath());
         }
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/OidcRoleExtractionException.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/OidcRoleExtractionException.java
@@ -15,26 +15,16 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.master.service.auth.oauth;
-
-import com.axelixlabs.axelix.common.auth.core.Role;
-import com.axelixlabs.axelix.master.exception.auth.OidcRoleExtractionException;
+package com.axelixlabs.axelix.master.exception.auth;
 
 /**
- * A component capable of extracting the user's role from the UserInfo endpoint JSON response.
+ * Exception thrown during the OIDC token exchange flow, specifically when
+ * the user role cannot be successfully resolved from the UserInfo endpoint response.
  *
- * @author Mikhail Polivakha
  * @author Nikita Kirillov
  */
-public interface OidcRoleExtractor {
-
-    /**
-     * Extracts the {@link Role} from the provided UserInfo JSON string.
-     *
-     * @param userInfoJson the raw JSON response payload from the UserInfo endpoint.
-     *
-     * @return the role that is extracted. Never {@code null}.
-     * @throws OidcRoleExtractionException if the role cannot be extracted from the JSON response of the UserInfo endpoint
-     */
-    Role extractRole(String userInfoJson) throws OidcRoleExtractionException;
+public class OidcRoleExtractionException extends OAuth2AuthenticationException {
+    public OidcRoleExtractionException(String message) {
+        super(message);
+    }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/OidcRoleExtractionException.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/OidcRoleExtractionException.java
@@ -24,6 +24,7 @@ package com.axelixlabs.axelix.master.exception.auth;
  * @author Nikita Kirillov
  */
 public class OidcRoleExtractionException extends OAuth2AuthenticationException {
+
     public OidcRoleExtractionException(String message) {
         super(message);
     }

--- a/master/src/main/java/com/axelixlabs/axelix/master/mcp/auth/handler/BearerMcpAuthenticationHandler.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/mcp/auth/handler/BearerMcpAuthenticationHandler.java
@@ -50,7 +50,7 @@ public class BearerMcpAuthenticationHandler implements McpAuthenticationHandler 
         try {
             String userInfoJson = oidcClient.validateAccessTokenAndExtractUserInfo(credential);
             Role role = roleExtractor.extractRole(userInfoJson);
-            return new PasswordlessUser("MCP_AGENT", Set.of(role));
+            return new PasswordlessUser("AI_AGENT", Set.of(role));
         } catch (OAuth2AuthenticationException e) {
             throw new AuthenticationException(e);
         }

--- a/master/src/main/java/com/axelixlabs/axelix/master/mcp/auth/handler/BearerMcpAuthenticationHandler.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/mcp/auth/handler/BearerMcpAuthenticationHandler.java
@@ -25,7 +25,8 @@ import com.axelixlabs.axelix.common.auth.core.PasswordlessUser;
 import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.common.auth.core.User;
 import com.axelixlabs.axelix.master.exception.auth.AuthenticationException;
-import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
+import com.axelixlabs.axelix.master.exception.auth.OAuth2AuthenticationException;
+import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcRoleExtractor;
 
 /**
@@ -35,9 +36,11 @@ import com.axelixlabs.axelix.master.service.auth.oauth.OidcRoleExtractor;
  */
 public class BearerMcpAuthenticationHandler implements McpAuthenticationHandler {
 
+    private final OidcClient oidcClient;
     private final OidcRoleExtractor roleExtractor;
 
-    public BearerMcpAuthenticationHandler(OidcRoleExtractor roleExtractor) {
+    public BearerMcpAuthenticationHandler(OidcClient oidcClient, OidcRoleExtractor roleExtractor) {
+        this.oidcClient = oidcClient;
         this.roleExtractor = roleExtractor;
     }
 
@@ -45,9 +48,10 @@ public class BearerMcpAuthenticationHandler implements McpAuthenticationHandler 
     public User handleAuthentication(String credential) throws AuthenticationException {
         // credential is expected to be an access token
         try {
-            Role role = roleExtractor.extractRole(credential);
+            String userInfoJson = oidcClient.validateAccessTokenAndExtractUserInfo(credential);
+            Role role = roleExtractor.extractRole(userInfoJson);
             return new PasswordlessUser("MCP_AGENT", Set.of(role));
-        } catch (OidcTokenExchangeException e) {
+        } catch (OAuth2AuthenticationException e) {
             throw new AuthenticationException(e);
         }
     }

--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/UserRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/UserRepository.java
@@ -49,7 +49,8 @@ public interface UserRepository extends ListCrudRepository<UserEntity, String> {
                 username = :username,
                 email = :email,
                 password = COALESCE(:password, password),
-                roles = :roles
+                roles = :roles,
+                last_login_at = COALESCE(:lastLoginAt, last_login_at)
         WHERE id = :id
         """)
     void updateUserPatch(
@@ -57,5 +58,6 @@ public interface UserRepository extends ListCrudRepository<UserEntity, String> {
             @Param("username") String username,
             @Param("email") @Nullable String email,
             @Param("password") @Nullable String password,
-            @Param("roles") UserEntity.Roles roles);
+            @Param("roles") UserEntity.Roles roles,
+            @Param("lastLoginAt") Instant lastLoginAt);
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/UserRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/UserRepository.java
@@ -59,5 +59,5 @@ public interface UserRepository extends ListCrudRepository<UserEntity, String> {
             @Param("email") @Nullable String email,
             @Param("password") @Nullable String password,
             @Param("roles") UserEntity.Roles roles,
-            @Param("lastLoginAt") Instant lastLoginAt);
+            @Param("lastLoginAt") @Nullable Instant lastLoginAt);
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClient.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/DefaultOidcClient.java
@@ -155,7 +155,6 @@ public class DefaultOidcClient implements OidcClient {
     }
 
     @Override
-    @Nullable
     @SuppressWarnings({"PMD.CyclomaticComplexity"})
     public String validateAccessTokenAndExtractUserInfo(String accessToken)
             throws OidcTokenExchangeException, OidcMetadataUnavailableException {
@@ -163,19 +162,19 @@ public class DefaultOidcClient implements OidcClient {
         try {
             String userInfoEndpoint = oidcMetadataProvider.getUserInfoEndpoint();
 
-            String userInfoBody = restClient
+            String userInfoJson = restClient
                     .get()
                     .uri(userInfoEndpoint)
                     .header(HttpHeaders.AUTHORIZATION, AuthenticationSchemes.BEARER.prefix() + accessToken)
                     .retrieve()
                     .body(String.class);
 
-            if (userInfoBody == null) {
+            if (userInfoJson == null) {
                 throw new OidcMetadataUnavailableException(
                         "Failed to decode the response from user_info OIDC endpoint");
             }
 
-            return userInfoBody;
+            return userInfoJson;
         } catch (HttpClientErrorException e) {
             if (Set.of((HttpStatusCode) HttpStatus.UNAUTHORIZED, HttpStatus.FORBIDDEN)
                     .contains(e.getStatusCode())) {

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractor.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractor.java
@@ -27,11 +27,11 @@ import org.slf4j.LoggerFactory;
 
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.Role;
-import com.axelixlabs.axelix.master.exception.auth.OidcMetadataUnavailableException;
-import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
+import com.axelixlabs.axelix.master.exception.auth.OidcRoleExtractionException;
 
 /**
- * Extracts user role from OIDC tokens using a JMESPath expression.
+ * An {@link OidcRoleExtractor} implementation that extracts the user's role
+ * from the UserInfo JSON payload using a JMESPath expression.
  *
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
@@ -44,11 +44,7 @@ public class JmesPathOidcRoleExtractor implements OidcRoleExtractor {
     @Nullable
     private final Expression<JsonNode> jmesPathExpression;
 
-    private final OidcClient oidcClient;
-
-    public JmesPathOidcRoleExtractor(OidcClient oidcClient, @Nullable String roleAttributePath) {
-        this.oidcClient = oidcClient;
-
+    public JmesPathOidcRoleExtractor(@Nullable String roleAttributePath) {
         if (roleAttributePath != null && !roleAttributePath.isEmpty()) {
             this.jmesPathExpression = new JacksonRuntime().compile(roleAttributePath);
         } else {
@@ -57,37 +53,20 @@ public class JmesPathOidcRoleExtractor implements OidcRoleExtractor {
     }
 
     @Override
-    public Role extractRole(String accessToken) throws OidcTokenExchangeException {
+    public Role extractRole(String userInfoJson) throws OidcRoleExtractionException {
         if (jmesPathExpression == null) {
             return DefaultRole.VIEWER;
         }
 
-        Role role = extractRoleFromUserInfo(accessToken);
+        Role role = extractRoleFromJson(userInfoJson);
 
         if (role == null) {
-            throw new OidcTokenExchangeException(String.format(
-                    "Failed to extract role from tokens. JMES path expression: '%s' - role not found in ID token nor UserInfo endpoint",
+            throw new OidcRoleExtractionException(String.format(
+                    "Failed to extract role from UserInfo JSON payload using JMESPath expression: '%s'",
                     jmesPathExpression));
         }
 
         return role;
-    }
-
-    @Nullable
-    private Role extractRoleFromUserInfo(String accessToken) {
-        try {
-            String userInfo = oidcClient.validateAccessTokenAndExtractUserInfo(accessToken);
-
-            if (userInfo == null) {
-                return null;
-            }
-
-            return extractRoleFromJson(userInfo);
-        } catch (OidcTokenExchangeException | OidcMetadataUnavailableException e) {
-            log.debug("Failed to extract role from UserInfo: {}", e.getMessage());
-        }
-
-        return null;
     }
 
     @Nullable

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcClient.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/OidcClient.java
@@ -17,8 +17,6 @@
  */
 package com.axelixlabs.axelix.master.service.auth.oauth;
 
-import org.jspecify.annotations.Nullable;
-
 import com.axelixlabs.axelix.common.auth.exception.ExpiredJwtTokenException;
 import com.axelixlabs.axelix.common.auth.exception.InvalidJwtTokenException;
 import com.axelixlabs.axelix.common.auth.exception.JwtProcessingException;
@@ -75,7 +73,6 @@ public interface OidcClient {
      * @throws OidcTokenExchangeException       if the token is invalid, expired or malformed
      * @throws OidcMetadataUnavailableException if userinfo_endpoint is unavailable
      */
-    @Nullable
     String validateAccessTokenAndExtractUserInfo(String accessToken)
             throws OidcTokenExchangeException, OidcMetadataUnavailableException;
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseUserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseUserService.java
@@ -70,7 +70,7 @@ public class DatabaseUserService implements UserService {
                 UUID.randomUUID().toString(),
                 requireNonBlankTrimmed(username),
                 email == null ? null : requireNonBlankTrimmed(email),
-                password == null ? null : passwordEncoder.encode(requireNonBlankTrimmed(password)),
+                passwordEncoder.encode(requireNonBlankTrimmed(password)),
                 new UserEntity.Roles(Set.of(validateAndNormalizeRole(role))),
                 UserOrigin.LOCAL,
                 null);

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseUserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseUserService.java
@@ -63,14 +63,15 @@ public class DatabaseUserService implements UserService {
     }
 
     @Override
-    public void create(String username, @Nullable String email, String password, String role, UserOrigin userOrigin)
+    public void create(
+            String username, @Nullable String email, @Nullable String password, String role, UserOrigin userOrigin)
             throws UserRoleNotFoundException, UserInvalidValueException {
 
         UserEntity userEntity = new UserEntity(
                 UUID.randomUUID().toString(),
                 requireNonBlankTrimmed(username),
                 email == null ? null : requireNonBlankTrimmed(email),
-                passwordEncoder.encode(requireNonBlankTrimmed(password)),
+                password == null ? null : passwordEncoder.encode(requireNonBlankTrimmed(password)),
                 new UserEntity.Roles(Set.of(validateAndNormalizeRole(role))),
                 userOrigin,
                 null);
@@ -123,8 +124,8 @@ public class DatabaseUserService implements UserService {
                 new UserEntity.Roles(validRoles));
     }
 
-    private String requireNonBlankTrimmed(@Nullable String value) throws UserInvalidValueException {
-        if (value != null && !value.isBlank()) {
+    private String requireNonBlankTrimmed(String value) throws UserInvalidValueException {
+        if (!value.isBlank()) {
             return value.trim();
         }
 

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseUserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseUserService.java
@@ -63,8 +63,7 @@ public class DatabaseUserService implements UserService {
     }
 
     @Override
-    public void create(
-            String username, @Nullable String email, @Nullable String password, String role, UserOrigin userOrigin)
+    public void createLocal(String username, @Nullable String email, String password, String role)
             throws UserRoleNotFoundException, UserInvalidValueException {
 
         UserEntity userEntity = new UserEntity(
@@ -73,8 +72,23 @@ public class DatabaseUserService implements UserService {
                 email == null ? null : requireNonBlankTrimmed(email),
                 password == null ? null : passwordEncoder.encode(requireNonBlankTrimmed(password)),
                 new UserEntity.Roles(Set.of(validateAndNormalizeRole(role))),
-                userOrigin,
+                UserOrigin.LOCAL,
                 null);
+
+        jdbcAggregateTemplate.insert(userEntity);
+    }
+
+    @Override
+    public void createFromOidc(String username, @Nullable String email, String role) {
+
+        UserEntity userEntity = new UserEntity(
+                UUID.randomUUID().toString(),
+                requireNonBlankTrimmed(username),
+                email == null ? null : requireNonBlankTrimmed(email),
+                null,
+                new UserEntity.Roles(Set.of(validateAndNormalizeRole(role))),
+                UserOrigin.OIDC,
+                Instant.now()); // the assumption is that the user is created during the initial login
 
         jdbcAggregateTemplate.insert(userEntity);
     }
@@ -106,7 +120,12 @@ public class DatabaseUserService implements UserService {
 
     @Override
     public void updateUserPatch(
-            String id, String username, @Nullable String email, @Nullable String password, Set<String> roles)
+            String id,
+            String username,
+            @Nullable String email,
+            @Nullable String password,
+            Set<String> roles,
+            @Nullable Instant lastLoginAt)
             throws UserRoleNotFoundException, UserInvalidValueException {
 
         if (roles.isEmpty()) {
@@ -121,7 +140,8 @@ public class DatabaseUserService implements UserService {
                 requireNonBlankTrimmed(username),
                 email == null ? null : requireNonBlankTrimmed(email),
                 password == null ? null : passwordEncoder.encode(requireNonBlankTrimmed(password)),
-                new UserEntity.Roles(validRoles));
+                new UserEntity.Roles(validRoles),
+                lastLoginAt);
     }
 
     private String requireNonBlankTrimmed(String value) throws UserInvalidValueException {

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/UserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/UserService.java
@@ -43,18 +43,29 @@ import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 public interface UserService {
 
     /**
-     * Creates a new managed user from a Users Management API request.
+     * Creates a new {@link UserOrigin#LOCAL} user.
      *
-     * @param username   Login username of the new user. Must be unique.
-     * @param email      Email address of the new user, or {@code null} if not provided. If supplied, must be unique.
-     * @param password   Plain-text password (must be hashed server-side before persistence).
-     * @param role       Role name to assign to the new user. Must not be blank or {@code null}.
-     * @param userOrigin Origin of the account (e.g. {@link UserOrigin#OIDC} or {@link UserOrigin#LOCAL}).
+     * @param username Login username of the new user. Must be unique.
+     * @param email    Email address of the new user, or {@code null} if not provided. If supplied, must be unique.
+     * @param password Plain-text password (must be hashed server-side before persistence).
+     * @param role     Role name to assign to the new user. Must not be blank or {@code null}.
      *
      * @throws UserRoleNotFoundException if the provided role does not exist in the service.
      * @throws UserInvalidValueException if any of the provided string fields is blank.
      */
-    void create(String username, @Nullable String email, @Nullable String password, String role, UserOrigin userOrigin);
+    void createLocal(String username, @Nullable String email, String password, String role);
+
+    /**
+     * Creates a new {@link UserOrigin#OIDC} user.
+     *
+     * @param username Login username of the new user. Must be unique.
+     * @param email    Email address of the new user, or {@code null} if not provided. If supplied, must be unique.
+     * @param role     Role name to assign to the new user. Must not be blank or {@code null}.
+     *
+     * @throws UserRoleNotFoundException if the provided role does not exist in the service.
+     * @throws UserInvalidValueException if any of the provided string fields is blank.
+     */
+    void createFromOidc(String username, @Nullable String email, String role);
 
     /**
      * Deletes the user with the given identifier. No-op if the user does not exist.
@@ -113,7 +124,24 @@ public interface UserService {
      * @throws UserRoleNotFoundException if any of the provided role names does not exist in the service.
      * @throws UserInvalidValueException if any of the provided string fields is blank.
      */
-    void updateUserPatch(
+    default void updateUserPatch(
             String id, String username, @Nullable String email, @Nullable String password, Set<String> roles)
+            throws UserRoleNotFoundException, UserInvalidValueException {
+
+        updateUserPatch(id, username, email, password, roles, null);
+    }
+
+    /**
+     * Same contract as the sibling {@link #updateUserPatch(String, String, String, String, Set)} with the exception
+     * that this method also allows to update the {@link UserEntity#lastLoginAt()}. Passing {@code null} means the
+     * {@link UserEntity#lastLoginAt()} should not be updated.
+     */
+    void updateUserPatch(
+            String id,
+            String username,
+            @Nullable String email,
+            @Nullable String password,
+            Set<String> roles,
+            @Nullable Instant lastLoginAt)
             throws UserRoleNotFoundException, UserInvalidValueException;
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/UserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/UserService.java
@@ -54,7 +54,7 @@ public interface UserService {
      * @throws UserRoleNotFoundException if the provided role does not exist in the service.
      * @throws UserInvalidValueException if any of the provided string fields is blank.
      */
-    void create(String username, @Nullable String email, String password, String role, UserOrigin userOrigin);
+    void create(String username, @Nullable String email, @Nullable String password, String role, UserOrigin userOrigin);
 
     /**
      * Deletes the user with the given identifier. No-op if the user does not exist.

--- a/master/src/main/resources/application-local.yaml
+++ b/master/src/main/resources/application-local.yaml
@@ -3,11 +3,12 @@ axelix:
   master:
     discovery:
       self-registration:
+        enabled: true
         eviction:
           heartbeat-timeout: 45s
           schedule: "0 * * * * *"
       auto:
-        enabled: true
+        enabled: false
         broadcast:
           schedule: "0 * * * * *"
         platform: kubernetes
@@ -26,6 +27,8 @@ axelix:
         # Random singing key for local development
         signing-key: 22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
       options:
+        local:
+          enabled: true
         super-admin:
           credentials:
             username: admin

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserApiTest.java
@@ -154,7 +154,7 @@ class UserApiTest {
 
     @Test
     void shouldAuthenticateUserFromDatabase() {
-        userService.create("db-user", "db-user@example.com", "db-password", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("db-user", "db-user@example.com", "db-password", "VIEWER");
         UserEntity user = userRepository.findByUsername("db-user").orElseThrow();
 
         LoginRequest loginRequest = new LoginRequest("db-user", "db-password");
@@ -173,8 +173,7 @@ class UserApiTest {
 
     @Test
     void shouldNotAuthenticateUserFromDatabaseWithInvalidCredentials() {
-        userService.create(
-                "db-user", "db-user@example.com", "db-password", DefaultRole.VIEWER.getName(), UserOrigin.LOCAL);
+        userService.createLocal("db-user", "db-user@example.com", "db-password", DefaultRole.VIEWER.getName());
 
         LoginRequest loginRequest = new LoginRequest("db-user", "wrong-password");
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/McpOAuth2MetadataControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/McpOAuth2MetadataControllerTest.java
@@ -52,7 +52,7 @@ class McpOAuth2MetadataControllerTest {
             """
    {
      "authorization_servers" : [ "http://localhost:8081/realms/axelix" ],
-     "resource" : "http://localhost:8080/api/external/api/mcp",
+     "resource" : "http://localhost:8080/api/mcp",
      "scopes_supported" : [ "openid" ]
    }
    """;

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
@@ -21,7 +21,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
-import org.assertj.core.api.Assertions;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -206,9 +205,7 @@ class OAuth2CallbackControllerTest {
         assertThat(updated.email()).isEqualTo(updatedEmail);
         assertThat(updated.roles().values()).containsOnly(DefaultRole.EDITOR.getName());
         assertThat(updated.userOrigin()).isEqualTo(UserOrigin.OIDC);
-        assertThat(updated.lastLoginAt())
-                .isNotNull()
-                .isBetween(beforeLogin, afterLogin);
+        assertThat(updated.lastLoginAt()).isNotNull().isBetween(beforeLogin, afterLogin);
     }
 
     @Test

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
@@ -17,8 +17,11 @@
  */
 package com.axelixlabs.axelix.master.api.infrastructure;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
+import org.assertj.core.api.Assertions;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -125,10 +128,13 @@ class OAuth2CallbackControllerTest {
         when(oidcClient.validateIdTokenAndExtractUsername(ID_TOKEN)).thenReturn(username);
         when(oidcClient.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN)).thenReturn(userInfoJson);
         when(oidcRoleExtractor.extractRole(userInfoJson)).thenReturn(DefaultRole.EDITOR);
+        Instant beforeLogin = Instant.now();
 
         // when.
         ResponseEntity<Void> response = restTemplate.getForEntity(
                 "http://localhost:" + port + "/api/external/oauth2/callback?code=" + CODE, Void.class);
+
+        Instant afterLogin = Instant.now();
 
         // then.
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
@@ -171,14 +177,45 @@ class OAuth2CallbackControllerTest {
         assertThat(userEntity.password()).isNull();
         assertThat(userEntity.roles().values()).hasSize(1).containsOnly("EDITOR");
         assertThat(userEntity.userOrigin()).isEqualTo(UserOrigin.OIDC);
-        assertThat(userEntity.lastLoginAt()).isNotNull();
+        assertThat(userEntity.lastLoginAt()).isNotNull().isBetween(beforeLogin, afterLogin);
+    }
+
+    @Test
+    void shouldUpdateLastLoginAtForExistingOidcUser() {
+        // given.
+        String username = "test-user";
+        String updatedEmail = "updated@gmail.com";
+        userService.createFromOidc(username, "original@gmail.com", DefaultRole.VIEWER.getName());
+
+        // and.
+        String userInfoJson = "{\"email\": \"%s\"}".formatted(updatedEmail);
+        when(oidcClient.exchangeCodeForTokens(CODE)).thenReturn(tokens);
+        when(oidcClient.validateIdTokenAndExtractUsername(ID_TOKEN)).thenReturn(username);
+        when(oidcClient.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN)).thenReturn(userInfoJson);
+        when(oidcRoleExtractor.extractRole(userInfoJson)).thenReturn(DefaultRole.EDITOR);
+        Instant beforeLogin = Instant.now();
+
+        // when.
+        ResponseEntity<Void> response = restTemplate.getForEntity(
+                "http://localhost:" + port + "/api/external/oauth2/callback?code=" + CODE, Void.class);
+        Instant afterLogin = Instant.now();
+
+        // then.
+        UserEntity updated = userRepository.findByUsername(username).orElseThrow();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+        assertThat(updated.email()).isEqualTo(updatedEmail);
+        assertThat(updated.roles().values()).containsOnly(DefaultRole.EDITOR.getName());
+        assertThat(updated.userOrigin()).isEqualTo(UserOrigin.OIDC);
+        assertThat(updated.lastLoginAt())
+                .isNotNull()
+                .isBetween(beforeLogin, afterLogin);
     }
 
     @Test
     void shouldReturn400WhenOidcUserConflictsWithExistingLocalAccount() {
         // given.
         String username = "test-user";
-        userService.createLocal(username, null, null, "ADMIN");
+        userService.createLocal(username, null, "test-password", "ADMIN");
 
         // and.
         String userInfoJson = "someJson";
@@ -191,7 +228,13 @@ class OAuth2CallbackControllerTest {
         ResponseEntity<Void> response = restTemplate.getForEntity(
                 "http://localhost:" + port + "/api/external/oauth2/callback?code=" + CODE, Void.class);
 
+        Optional<UserEntity> userInDb = userRepository.findByUsername(username);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(userInDb).isPresent().hasValueSatisfying(userEntity -> {
+            assertThat(userEntity.userOrigin()).isEqualTo(UserOrigin.LOCAL);
+            assertThat(userEntity.roles().values()).containsOnly("ADMIN");
+        });
     }
 
     @Test

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
@@ -20,6 +20,7 @@ package com.axelixlabs.axelix.master.api.infrastructure;
 import java.util.List;
 
 import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,11 +42,15 @@ import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.PasswordlessUser;
 import com.axelixlabs.axelix.common.auth.exception.InvalidJwtTokenException;
 import com.axelixlabs.axelix.common.auth.service.JwtDecoderService;
+import com.axelixlabs.axelix.master.domain.UserEntity;
+import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.exception.auth.OidcMetadataUnavailableException;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
+import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcRoleExtractor;
 import com.axelixlabs.axelix.master.service.auth.oauth.Tokens;
+import com.axelixlabs.axelix.master.service.state.UserService;
 
 import static com.axelixlabs.axelix.master.autoconfiguration.mcp.McpAutoConfiguration.MCP_CONFIGURATION_PROPERTIES_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,6 +78,8 @@ class OAuth2CallbackControllerTest {
 
     private static final String CODE = "test-code";
     private static final String ID_TOKEN = "test-id-token";
+    private static final String ACCESS_TOKEN = "test-access-token";
+    private static final Tokens tokens = new Tokens(ID_TOKEN, ACCESS_TOKEN);
 
     @LocalServerPort
     private int port;
@@ -88,21 +95,36 @@ class OAuth2CallbackControllerTest {
     @Autowired
     private JwtDecoderService jwtDecoderService;
 
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
+
     @BeforeEach
     void prepare() {
         restTemplate = new TestRestTemplate(new RestTemplateBuilder().redirects(HttpRedirects.DONT_FOLLOW));
+        userRepository.deleteAll();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        userRepository.deleteAll();
     }
 
     @Test
     void happyPath() {
         // given.
         String username = "test-user";
-        var tokens = new Tokens(ID_TOKEN, "access-token");
+        String email = "example@gmail.com";
+        // language=json
+        String userInfoJson = "{\"email\": \"%s\"}".formatted(email);
 
         // and.
         when(oidcClient.exchangeCodeForTokens(CODE)).thenReturn(tokens);
         when(oidcClient.validateIdTokenAndExtractUsername(ID_TOKEN)).thenReturn(username);
-        when(oidcRoleExtractor.extractRole(tokens.accessToken())).thenReturn(DefaultRole.EDITOR);
+        when(oidcClient.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN)).thenReturn(userInfoJson);
+        when(oidcRoleExtractor.extractRole(userInfoJson)).thenReturn(DefaultRole.EDITOR);
 
         // when.
         ResponseEntity<Void> response = restTemplate.getForEntity(
@@ -140,6 +162,36 @@ class OAuth2CallbackControllerTest {
                 .doesNotContain(
                         DefaultAuthority.ENV_VALUES_READ.getName(),
                         DefaultAuthority.CONFIG_PROPS_VALUES_READ.getName());
+
+        // Verify that the OIDC user was correctly provisioned and persisted in the database
+        UserEntity userEntity = userRepository.findByUsername(username).get();
+        assertThat(userEntity.id()).isNotNull();
+        assertThat(userEntity.username()).isEqualTo(username);
+        assertThat(userEntity.email()).isEqualTo(email);
+        assertThat(userEntity.password()).isNull();
+        assertThat(userEntity.roles().values()).hasSize(1).containsOnly("EDITOR");
+        assertThat(userEntity.userOrigin()).isEqualTo(UserOrigin.OIDC);
+        assertThat(userEntity.lastLoginAt()).isNotNull();
+    }
+
+    @Test
+    void shouldReturn400WhenOidcUserConflictsWithExistingLocalAccount() {
+        // given.
+        String username = "test-user";
+        userService.create(username, null, null, "ADMIN", UserOrigin.LOCAL);
+
+        // and.
+        String userInfoJson = "someJson";
+        when(oidcClient.exchangeCodeForTokens(CODE)).thenReturn(tokens);
+        when(oidcClient.validateIdTokenAndExtractUsername(ID_TOKEN)).thenReturn(username);
+        when(oidcClient.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN)).thenReturn(userInfoJson);
+        when(oidcRoleExtractor.extractRole(userInfoJson)).thenReturn(DefaultRole.EDITOR);
+
+        // when.
+        ResponseEntity<Void> response = restTemplate.getForEntity(
+                "http://localhost:" + port + "/api/external/oauth2/callback?code=" + CODE, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -165,7 +217,7 @@ class OAuth2CallbackControllerTest {
 
     @Test
     void shouldReturn401WhenIdTokenValidationFails() {
-        when(oidcClient.exchangeCodeForTokens(CODE)).thenReturn(new Tokens(ID_TOKEN, "access-token"));
+        when(oidcClient.exchangeCodeForTokens(CODE)).thenReturn(tokens);
         when(oidcClient.validateIdTokenAndExtractUsername(ID_TOKEN))
                 .thenThrow(new InvalidJwtTokenException("invalid token"));
 
@@ -179,8 +231,8 @@ class OAuth2CallbackControllerTest {
 
     @Test
     void shouldReturn502WhenUserInfoEndpointUnavailable() {
-        when(oidcClient.exchangeCodeForTokens(CODE)).thenReturn(new Tokens(ID_TOKEN, "access-token"));
-        when(oidcClient.validateIdTokenAndExtractUsername(ID_TOKEN))
+        when(oidcClient.exchangeCodeForTokens(CODE)).thenReturn(tokens);
+        when(oidcClient.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN))
                 .thenThrow(new OidcMetadataUnavailableException("metadata unavailable"));
 
         // when.

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
@@ -178,7 +178,7 @@ class OAuth2CallbackControllerTest {
     void shouldReturn400WhenOidcUserConflictsWithExistingLocalAccount() {
         // given.
         String username = "test-user";
-        userService.create(username, null, null, "ADMIN", UserOrigin.LOCAL);
+        userService.createLocal(username, null, null, "ADMIN");
 
         // and.
         String userInfoJson = "someJson";

--- a/master/src/test/java/com/axelixlabs/axelix/master/filter/auth/AbstractMcpAuthorizationFilterTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/filter/auth/AbstractMcpAuthorizationFilterTest.java
@@ -53,7 +53,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.master.autoconfiguration.mcp.McpAutoConfiguration;
-import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
 import com.axelixlabs.axelix.master.repository.InstanceRepository;
 import com.axelixlabs.axelix.master.repository.UserRepository;
@@ -188,8 +187,7 @@ abstract class AbstractMcpAuthorizationFilterTest {
             String username = "test-user";
             String password = "test-password";
 
-            userService.create(
-                    username, "test-email@example.com", password, DefaultRole.VIEWER.getName(), UserOrigin.LOCAL);
+            userService.createLocal(username, "test-email@example.com", password, DefaultRole.VIEWER.getName());
 
             // and.
             registerInstanceForBeansTool(activeInstanceId);
@@ -241,8 +239,7 @@ abstract class AbstractMcpAuthorizationFilterTest {
             String activeInstanceId = UUID.randomUUID().toString();
             String username = "viewer-user";
             String password = "viewer-password";
-            userService.create(
-                    username, username + "@example.com", password, DefaultRole.VIEWER.getName(), UserOrigin.LOCAL);
+            userService.createLocal(username, username + "@example.com", password, DefaultRole.VIEWER.getName());
 
             HttpHeaders headers = commonMcpHeaders();
             headers.set(HttpHeaders.AUTHORIZATION, "Basic " + basicCredentials(username, password));
@@ -262,8 +259,7 @@ abstract class AbstractMcpAuthorizationFilterTest {
             // given.
             String username = "viewer-user";
             String password = "viewer-password";
-            userService.create(
-                    username, username + "@example.com", password, DefaultRole.VIEWER.getName(), UserOrigin.LOCAL);
+            userService.createLocal(username, username + "@example.com", password, DefaultRole.VIEWER.getName());
 
             HttpHeaders headers = commonMcpHeaders();
             headers.set(HttpHeaders.AUTHORIZATION, "Basic " + basicCredentials(username, password));

--- a/master/src/test/java/com/axelixlabs/axelix/master/filter/auth/AbstractMcpAuthorizationFilterTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/filter/auth/AbstractMcpAuthorizationFilterTest.java
@@ -57,6 +57,7 @@ import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
 import com.axelixlabs.axelix.master.repository.InstanceRepository;
 import com.axelixlabs.axelix.master.repository.UserRepository;
+import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcRoleExtractor;
 import com.axelixlabs.axelix.master.service.state.InstanceRegistry;
 import com.axelixlabs.axelix.master.service.state.UserService;
@@ -73,6 +74,8 @@ import static org.mockito.Mockito.when;
  *
  * @author Mikhail Polivakha
  */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(McpAutoConfiguration.class)
 abstract class AbstractMcpAuthorizationFilterTest {
 
     private static final String MCP_PROTOCOL_VERSION_HEADER = "MCP-Protocol-Version";
@@ -150,8 +153,6 @@ abstract class AbstractMcpAuthorizationFilterTest {
                 TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
-    @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-    @Import(McpAutoConfiguration.class)
     @TestPropertySource(
             properties = {
                 "axelix.master.mcp-server.enabled=true",
@@ -276,8 +277,6 @@ abstract class AbstractMcpAuthorizationFilterTest {
         }
     }
 
-    @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-    @Import(McpAutoConfiguration.class)
     @TestPropertySource(
             properties = {
                 "axelix.master.mcp-server.enabled=true",
@@ -290,16 +289,21 @@ abstract class AbstractMcpAuthorizationFilterTest {
     static class BearerAuthTest extends AbstractMcpAuthorizationFilterTest {
 
         @MockitoBean
+        private OidcClient oidcClient;
+
+        @MockitoBean
         private OidcRoleExtractor oidcRoleExtractor;
 
         @Test
         void shouldAuthenticateAndProxyMcpToolCallEndToEnd() {
             String activeInstanceId = UUID.randomUUID().toString();
             String token = "editor-access-token";
+            String userInfoJson = "someJson";
 
             // given.
             registerInstanceForBeansTool(activeInstanceId);
-            when(oidcRoleExtractor.extractRole(token)).thenReturn(DefaultRole.VIEWER);
+            when(oidcClient.validateAccessTokenAndExtractUserInfo(token)).thenReturn(userInfoJson);
+            when(oidcRoleExtractor.extractRole(userInfoJson)).thenReturn(DefaultRole.VIEWER);
             HttpHeaders headers = bearerAuthHeaders(token);
             String mcpSessionId = initializeMcpSession(restTemplate, headers);
             headers.set(MCP_SESSION_ID_HEADER, mcpSessionId);
@@ -310,6 +314,24 @@ abstract class AbstractMcpAuthorizationFilterTest {
 
             // then.
             assertSuccessfulToolCallResponse(response);
+        }
+
+        @Test
+        void shouldReturnOkWhenViewerIsTryingToListMcpEndpoints() {
+            // given.
+            String token = "viewer-access-token";
+            String userInfoJson = "someJson";
+
+            when(oidcClient.validateAccessTokenAndExtractUserInfo(token)).thenReturn(userInfoJson);
+            when(oidcRoleExtractor.extractRole(userInfoJson)).thenReturn(DefaultRole.VIEWER);
+            HttpHeaders headers = bearerAuthHeaders(token);
+
+            // when.
+            ResponseEntity<String> response = restTemplate.postForEntity(
+                    "/api/mcp", new HttpEntity<>(buildInitializeRequest(), headers), String.class);
+
+            // then.
+            assertSuccessfulInitializeResponse(response);
         }
 
         @ParameterizedTest
@@ -336,7 +358,8 @@ abstract class AbstractMcpAuthorizationFilterTest {
         void shouldReturnUnauthorizedWhenBearerTokenIsInvalid(String request) {
             // given.
             String token = "malformed-token";
-            when(oidcRoleExtractor.extractRole(token)).thenThrow(new OidcTokenExchangeException("Malformed token"));
+            when(oidcClient.validateAccessTokenAndExtractUserInfo(token))
+                    .thenThrow(new OidcTokenExchangeException("Malformed token"));
             HttpHeaders headers = bearerAuthHeaders(token);
 
             // when.
@@ -357,7 +380,10 @@ abstract class AbstractMcpAuthorizationFilterTest {
             // given.
             String activeInstanceId = UUID.randomUUID().toString();
             String token = "viewer-access-token";
-            when(oidcRoleExtractor.extractRole(token)).thenReturn(DefaultRole.VIEWER);
+            String userInfoJson = "someJson";
+
+            when(oidcClient.validateAccessTokenAndExtractUserInfo(token)).thenReturn(userInfoJson);
+            when(oidcRoleExtractor.extractRole(userInfoJson)).thenReturn(DefaultRole.VIEWER);
             HttpHeaders headers = bearerAuthHeaders(token);
 
             // when.
@@ -368,21 +394,6 @@ abstract class AbstractMcpAuthorizationFilterTest {
 
             // then.
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-        }
-
-        @Test
-        void shouldReturnOkWhenViewerIsTryingToListMcpEndpoints() {
-            // given.
-            String token = "viewer-access-token";
-            when(oidcRoleExtractor.extractRole(token)).thenReturn(DefaultRole.VIEWER);
-            HttpHeaders headers = bearerAuthHeaders(token);
-
-            // when.
-            ResponseEntity<String> response = restTemplate.postForEntity(
-                    "/api/mcp", new HttpEntity<>(buildInitializeRequest(), headers), String.class);
-
-            // then.
-            assertSuccessfulInitializeResponse(response);
         }
 
         private HttpHeaders bearerAuthHeaders(String token) {

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractorTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/oauth/JmesPathOidcRoleExtractorTest.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.master.service.auth.oauth;
 
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -27,17 +26,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.Role;
-import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
+import com.axelixlabs.axelix.master.exception.auth.OidcRoleExtractionException;
 import com.axelixlabs.axelix.master.utils.TestResourceReader;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.of;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link JmesPathOidcRoleExtractor}
@@ -46,97 +40,65 @@ import static org.mockito.Mockito.when;
  */
 class JmesPathOidcRoleExtractorTest {
 
-    private OidcClient oidcClient;
-
-    @BeforeEach
-    void setUp() {
-        oidcClient = mock(OidcClient.class);
-    }
-
     @Test
     void shouldExtractRoleFromUserInfo() {
         // given.
-        String accessToken = "test-access-token";
         String userInfoJson = TestResourceReader.readResource("other/user-info-response.json");
 
         // and.
-        when(oidcClient.validateAccessTokenAndExtractUserInfo(accessToken)).thenReturn(userInfoJson);
-        JmesPathOidcRoleExtractor extractor = new JmesPathOidcRoleExtractor(oidcClient, "roles[0]");
+        JmesPathOidcRoleExtractor extractor = new JmesPathOidcRoleExtractor("roles[0]");
 
         // when.
-        Role role = extractor.extractRole(accessToken);
+        Role role = extractor.extractRole(userInfoJson);
 
         // then.
         assertThat(role).isEqualTo(DefaultRole.ADMIN);
-        verify(oidcClient).validateAccessTokenAndExtractUserInfo(accessToken);
     }
 
     @MethodSource(value = "absentRoleAttributePath")
     @ParameterizedTest
     void shouldReturnViewerWhenExpressionIsNotSpecified(String roleAttributePath) {
         // given.
-        String accessToken = "test-access-token";
-        var subject = new JmesPathOidcRoleExtractor(oidcClient, roleAttributePath);
+        String userInfoJson = "someJson";
+        var subject = new JmesPathOidcRoleExtractor(roleAttributePath);
 
         // when.
-        Role role = subject.extractRole(accessToken);
+        Role role = subject.extractRole(userInfoJson);
 
         // then.
         assertThat(role).isEqualTo(DefaultRole.VIEWER);
-        verify(oidcClient, never()).validateAccessTokenAndExtractUserInfo(anyString());
     }
 
     @Test
     void shouldThrowWhenRoleCannotBeExtracted() {
         // given.
-        String accessToken = "test-access-token";
-        when(oidcClient.validateAccessTokenAndExtractUserInfo(accessToken)).thenReturn("""
-            {
-                "name" : "Test"
-            }
-            """);
-        JmesPathOidcRoleExtractor extractor = new JmesPathOidcRoleExtractor(oidcClient, "roles[0]");
+        String userInfoJson = "someJson";
+
+        JmesPathOidcRoleExtractor extractor = new JmesPathOidcRoleExtractor("roles[0]");
 
         // when & then.
-        assertThatThrownBy(() -> extractor.extractRole(accessToken)).isInstanceOf(OidcTokenExchangeException.class);
+        assertThatThrownBy(() -> extractor.extractRole(userInfoJson)).isInstanceOf(OidcRoleExtractionException.class);
     }
 
     @Test
     void shouldExtractEditorFromUserInfo() {
         // given.
-        String accessToken = "test-access-token";
-        when(oidcClient.validateAccessTokenAndExtractUserInfo(accessToken))
-                .thenReturn(
-                        // language=json
-                        """
+        // language=json
+        String userInfoJson = """
                     {
                         "data": [
                             {
                                 "roles": ["viewer", "editor"]
                             }
                         ]
-                    }""");
-        var subject = new JmesPathOidcRoleExtractor(oidcClient, "data[0].roles[1]");
+                    }""";
+        var subject = new JmesPathOidcRoleExtractor("data[0].roles[1]");
 
         // when.
-        Role role = subject.extractRole(accessToken);
+        Role role = subject.extractRole(userInfoJson);
 
         // then.
         assertThat(role).isEqualTo(DefaultRole.EDITOR);
-    }
-
-    @Test
-    void shouldThrowWhenUserInfoRequestFails() {
-        // given.
-        String accessToken = "test-access-token";
-
-        when(oidcClient.validateAccessTokenAndExtractUserInfo(accessToken))
-                .thenThrow(new OidcTokenExchangeException("userinfo failed"));
-
-        var subject = new JmesPathOidcRoleExtractor(oidcClient, "roles[0]");
-
-        // when & then.
-        assertThatThrownBy(() -> subject.extractRole(accessToken)).isInstanceOf(OidcTokenExchangeException.class);
     }
 
     static Stream<Arguments> absentRoleAttributePath() {

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
@@ -43,6 +43,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Base class for integration tests of {@link DatabaseUserService}.
  *
  * @author Sergey Cherkasov
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
  */
 @SpringBootTest
 abstract class DatabaseUserServiceTest {
@@ -63,7 +65,7 @@ abstract class DatabaseUserServiceTest {
     }
 
     @Test
-    void create_Local_shouldPersistUser() {
+    void createLocal_shouldPersistUser() {
         // when.
         userService.createLocal("alice", "alice@example.com", "plainPass", "ADMIN");
 
@@ -83,9 +85,9 @@ abstract class DatabaseUserServiceTest {
     }
 
     @Test
-    void create_Local_shouldAllowNullEmail() {
+    void createFroOidc_shouldAllowNullEmail() {
         // when.
-        userService.createLocal("bob", null, "plainPass", "VIEWER");
+        userService.createFromOidc("bob", null, "VIEWER");
 
         // then.
         UserEntity saved = userRepository.findByUsername("bob").orElseThrow();
@@ -95,7 +97,7 @@ abstract class DatabaseUserServiceTest {
     }
 
     @Test
-    void create_Local_shouldThrowWhenRoleIsNotAllowed() {
+    void createLocal_shouldThrowWhenRoleIsNotAllowed() {
         // when.
         assertThatThrownBy(() -> userService.createLocal("alice", "alice@example.com", "p", "SUPER_ADMIN"))
                 // then.
@@ -103,8 +105,8 @@ abstract class DatabaseUserServiceTest {
         assertThat(userRepository.findAll()).isEmpty();
     }
 
-    @Test
-    void create_Local_shouldThrowWhenRoleDoesNotExist() {
+    @Test // TODO: This test should be revisited since in enterprise we're going to be able to supply many roles
+    void createLocal_shouldThrowWhenRoleDoesNotExist() {
         // when.
         assertThatThrownBy(() -> userService.createLocal("alice", "alice@example.com", "p", "NOT_A_ROLE"))
                 // then.
@@ -113,7 +115,7 @@ abstract class DatabaseUserServiceTest {
     }
 
     @Test
-    void create_Local_shouldThrowWhenUsernameIsBlank() {
+    void createLocal_shouldThrowWhenUsernameIsBlank() {
         // when.
         assertThatThrownBy(() -> userService.createLocal("   ", "alice@example.com", "p", "VIEWER"))
                 // then.
@@ -122,7 +124,7 @@ abstract class DatabaseUserServiceTest {
     }
 
     @Test
-    void create_Local_shouldThrowWhenEmailIsBlank() {
+    void createLocal_shouldThrowWhenEmailIsBlank() {
         // when.
         assertThatThrownBy(() -> userService.createLocal("alice", "   ", "p", "VIEWER"))
                 // then.
@@ -131,7 +133,7 @@ abstract class DatabaseUserServiceTest {
     }
 
     @Test
-    void create_Local_shouldThrowWhenPasswordIsBlank() {
+    void createLocal_shouldThrowWhenPasswordIsBlank() {
         // when.
         assertThatThrownBy(() -> userService.createLocal("alice", "alice@example.com", "   ", "VIEWER"))
                 // then.
@@ -140,7 +142,7 @@ abstract class DatabaseUserServiceTest {
     }
 
     @Test
-    void create_Local_shouldThrowWhenRoleIsBlank() {
+    void createLocal_shouldThrowWhenRoleIsBlank() {
         // when.
         assertThatThrownBy(() -> userService.createLocal("alice", "alice@example.com", "p", "   "))
                 // then.
@@ -169,7 +171,7 @@ abstract class DatabaseUserServiceTest {
     @Test
     void findAll_shouldReturnAllUsers() {
         userService.createLocal("alice", "a@example.com", "p", "VIEWER");
-        userService.createLocal("bob", "b@example.com", "p", "ADMIN");
+        userService.createFromOidc("bob", "b@example.com", "ADMIN");
 
         // when.
         List<UserEntity> all = userService.findAll();

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
@@ -63,9 +63,9 @@ abstract class DatabaseUserServiceTest {
     }
 
     @Test
-    void create_shouldPersistUser() {
+    void create_Local_shouldPersistUser() {
         // when.
-        userService.create("alice", "alice@example.com", "plainPass", "ADMIN", UserOrigin.LOCAL);
+        userService.createLocal("alice", "alice@example.com", "plainPass", "ADMIN");
 
         // then.
         List<UserEntity> users = userRepository.findAll();
@@ -83,9 +83,9 @@ abstract class DatabaseUserServiceTest {
     }
 
     @Test
-    void create_shouldAllowNullEmail() {
+    void create_Local_shouldAllowNullEmail() {
         // when.
-        userService.create("bob", null, "plainPass", "VIEWER", UserOrigin.OIDC);
+        userService.createLocal("bob", null, "plainPass", "VIEWER");
 
         // then.
         UserEntity saved = userRepository.findByUsername("bob").orElseThrow();
@@ -95,54 +95,54 @@ abstract class DatabaseUserServiceTest {
     }
 
     @Test
-    void create_shouldThrowWhenRoleIsNotAllowed() {
+    void create_Local_shouldThrowWhenRoleIsNotAllowed() {
         // when.
-        assertThatThrownBy(() -> userService.create("alice", "alice@example.com", "p", "SUPER_ADMIN", UserOrigin.LOCAL))
+        assertThatThrownBy(() -> userService.createLocal("alice", "alice@example.com", "p", "SUPER_ADMIN"))
                 // then.
                 .isInstanceOf(UserRoleNotFoundException.class);
         assertThat(userRepository.findAll()).isEmpty();
     }
 
     @Test
-    void create_shouldThrowWhenRoleDoesNotExist() {
+    void create_Local_shouldThrowWhenRoleDoesNotExist() {
         // when.
-        assertThatThrownBy(() -> userService.create("alice", "alice@example.com", "p", "NOT_A_ROLE", UserOrigin.LOCAL))
+        assertThatThrownBy(() -> userService.createLocal("alice", "alice@example.com", "p", "NOT_A_ROLE"))
                 // then.
                 .isInstanceOf(UserRoleNotFoundException.class);
         assertThat(userRepository.findAll()).isEmpty();
     }
 
     @Test
-    void create_shouldThrowWhenUsernameIsBlank() {
+    void create_Local_shouldThrowWhenUsernameIsBlank() {
         // when.
-        assertThatThrownBy(() -> userService.create("   ", "alice@example.com", "p", "VIEWER", UserOrigin.LOCAL))
+        assertThatThrownBy(() -> userService.createLocal("   ", "alice@example.com", "p", "VIEWER"))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
     }
 
     @Test
-    void create_shouldThrowWhenEmailIsBlank() {
+    void create_Local_shouldThrowWhenEmailIsBlank() {
         // when.
-        assertThatThrownBy(() -> userService.create("alice", "   ", "p", "VIEWER", UserOrigin.LOCAL))
+        assertThatThrownBy(() -> userService.createLocal("alice", "   ", "p", "VIEWER"))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
     }
 
     @Test
-    void create_shouldThrowWhenPasswordIsBlank() {
+    void create_Local_shouldThrowWhenPasswordIsBlank() {
         // when.
-        assertThatThrownBy(() -> userService.create("alice", "alice@example.com", "   ", "VIEWER", UserOrigin.LOCAL))
+        assertThatThrownBy(() -> userService.createLocal("alice", "alice@example.com", "   ", "VIEWER"))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
     }
 
     @Test
-    void create_shouldThrowWhenRoleIsBlank() {
+    void create_Local_shouldThrowWhenRoleIsBlank() {
         // when.
-        assertThatThrownBy(() -> userService.create("alice", "alice@example.com", "p", "   ", UserOrigin.LOCAL))
+        assertThatThrownBy(() -> userService.createLocal("alice", "alice@example.com", "p", "   "))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -150,7 +150,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void deleteAllById_shouldRemoveUser() {
-        userService.create("alice", "alice@example.com", "p", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("alice", "alice@example.com", "p", "VIEWER");
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -168,8 +168,8 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void findAll_shouldReturnAllUsers() {
-        userService.create("alice", "a@example.com", "p", "VIEWER", UserOrigin.LOCAL);
-        userService.create("bob", "b@example.com", "p", "ADMIN", UserOrigin.OIDC);
+        userService.createLocal("alice", "a@example.com", "p", "VIEWER");
+        userService.createLocal("bob", "b@example.com", "p", "ADMIN");
 
         // when.
         List<UserEntity> all = userService.findAll();
@@ -186,7 +186,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void findUserByUsername_shouldReturnMatchingUser() {
-        userService.create("alice", "a@example.com", "p", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("alice", "a@example.com", "p", "VIEWER");
 
         // when.
         Optional<UserEntity> found = userService.findUserByUsername("alice");
@@ -206,7 +206,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void findUserById_shouldReturnMatchingUser() {
-        userService.create("alice", "a@example.com", "p", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("alice", "a@example.com", "p", "VIEWER");
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -227,7 +227,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void updateLastLoginAt_shouldSetLastLoginAtToNow() {
-        userService.create("alice", "a@example.com", "p", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("alice", "a@example.com", "p", "VIEWER");
 
         // when.
         userService.updateLastLoginAt("alice");
@@ -239,7 +239,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldUpdateAllProvidedFields() {
-        userService.create("oldName", "old@example.com", "oldPass", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("oldName", "old@example.com", "oldPass", "VIEWER");
         UserEntity existing = userRepository.findByUsername("oldName").orElseThrow();
 
         // when.
@@ -257,7 +257,7 @@ abstract class DatabaseUserServiceTest {
     void updateUserPatch_shouldUpdateAllProvidedFields_PasswordIsNotProvided() {
         // given.
         String oldPassword = "oldPass";
-        userService.create("oldName", "old@example.com", oldPassword, "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("oldName", "old@example.com", oldPassword, "VIEWER");
         UserEntity existing = userRepository.findByUsername("oldName").orElseThrow();
 
         // when.
@@ -273,7 +273,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldHashNewPassword() {
-        userService.create("alice", "a@example.com", "oldPass", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("alice", "a@example.com", "oldPass", "VIEWER");
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -292,7 +292,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenRoleIsNotAllowed() {
-        userService.create("alice", "a@example.com", "p", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("alice", "a@example.com", "p", "VIEWER");
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -305,7 +305,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenUsernameIsBlank() {
-        userService.create("alice", "a@example.com", "p", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("alice", "a@example.com", "p", "VIEWER");
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -319,7 +319,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenEmailIsBlank() {
-        userService.create("alice", "a@example.com", "p", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("alice", "a@example.com", "p", "VIEWER");
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -332,7 +332,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenPasswordIsBlank() {
-        userService.create("alice", "a@example.com", "p", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("alice", "a@example.com", "p", "VIEWER");
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -346,7 +346,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenRolesAreEmpty() {
-        userService.create("alice", "a@example.com", "p", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("alice", "a@example.com", "p", "VIEWER");
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -360,7 +360,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenRolesContainBlank() {
-        userService.create("alice", "a@example.com", "p", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("alice", "a@example.com", "p", "VIEWER");
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -374,7 +374,7 @@ abstract class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldReplaceRolesCompletely() {
-        userService.create("alice", "a@example.com", "p", "VIEWER", UserOrigin.LOCAL);
+        userService.createLocal("alice", "a@example.com", "p", "VIEWER");
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
@@ -92,7 +92,7 @@ abstract class DatabaseUserServiceTest {
         // then.
         UserEntity saved = userRepository.findByUsername("bob").orElseThrow();
         assertThat(saved.email()).isNull();
-        assertThat(passwordEncoder.matches("plainPass", saved.password())).isTrue();
+        assertThat(saved.password()).isNull();
         assertThat(saved.userOrigin()).isEqualTo(UserOrigin.OIDC);
     }
 


### PR DESCRIPTION
close #1075 , #1124 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened OAuth2/OIDC flows: access tokens are validated, roles are resolved from user-info JSON, and OAuth metadata now exposes a simplified resource URL.
* **New Features**
  * Automatic creation/updating of OIDC users (passwordless) with last-login tracking.
* **Tests**
  * Updated tests to exercise token validation, user-info-driven role resolution, and user persistence.
* **Chores**
  * Local config: disabled self-registration auto mode; enabled local JWT options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->