### PR TITLE
GH-1140 Fix the bug with named ports in K8S

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/k8s/KubernetesDiscoveryClient.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/discovery/k8s/KubernetesDiscoveryClient.java
@@ -192,7 +192,7 @@ public class KubernetesDiscoveryClient implements DiscoveryClient {
 
         Map<String, String> metadata = Map.of(
                 "namespace", namespace,
-                "servicePortName", port.getName(),
+                "servicePortName", Optional.ofNullable(port.getName()).orElse(""),
                 "protocol", port.getProtocol());
 
         return new KubernetesServiceInstance(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced null-safety handling for service port metadata in Kubernetes service discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->