### PR TITLE
Fix ghcr.io image tag  configuring-master.mdx

### DIFF
--- a/docs/docs/setting-up-master-ui/configuring-master/configuring-master.mdx
+++ b/docs/docs/setting-up-master-ui/configuring-master/configuring-master.mdx
@@ -356,7 +356,7 @@ Use this when you want a single, immutable artifact that already bundles both Ma
 The release pipeline publishes the image to GitHub Container Registry:
 
 ```
-ghcr.io/axelixlabs/axelix:1.0.0-M1
+ghcr.io/axelixlabs/axelix:v1.0.0-M1
 ```
 
 :::note
@@ -375,7 +375,7 @@ docker run --rm -p 8080:8080 \
     -Daxelix.master.auth.jwt.algorithm=HMAC512 \
     -Daxelix.master.auth.jwt.signing-key=replace-with-a-long-random-secret \
     -Daxelix.master.auth.options.super-admin.credentials.password=replace-me" \
-  ghcr.io/axelixlabs/axelix:1.0.0-M1
+  ghcr.io/axelixlabs/axelix:v1.0.0-M1
 ```
 
 A few notes about this command:


### PR DESCRIPTION
Fixed typo in image tag for docker

Correct name  v1.0.0-M1
```
podman search --list-tags ghcr.io/axelixlabs/axelix
NAME                       TAG
ghcr.io/axelixlabs/axelix  v1.0.0-M1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker image tag format in setup documentation to match the published tag format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->