### PR TITLE
GH-1146 Integrate transaction and cache metrics via MeterRegistry for SB-3

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/build.gradle.kts
+++ b/sbs/axelix-spring-boot-3-starter/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     compileOnly("org.springframework.cloud:spring-cloud-starter-openfeign")
     compileOnly("org.springframework.kafka:spring-kafka")
     compileOnly("com.github.ben-manes.caffeine:caffeine")
+    compileOnly("io.micrometer:micrometer-core")
 
     // processor
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}")

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixCachesEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixCachesEndpointAutoConfiguration.java
@@ -76,7 +76,7 @@ public class AxelixCachesEndpointAutoConfiguration {
     @ConditionalOnMissingBean
     public CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
             ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider) {
-        return new CacheManagerBeanPostProcessor(metricsPublisherObjectProvider.getIfAvailable());
+        return new CacheManagerBeanPostProcessor(metricsPublisherObjectProvider);
     }
 
     @Bean

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixCachesEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixCachesEndpointAutoConfiguration.java
@@ -19,9 +19,14 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import java.util.Map;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
@@ -32,6 +37,8 @@ import com.axelixlabs.axelix.sbs.spring.core.cache.CacheOperationsDispatcher;
 import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
 import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheOperationsDispatcher;
 import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheSizeProvider;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
 
 /**
  * Auto-configuration class for the caches custom actuator endpoint.
@@ -40,7 +47,7 @@ import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheSizeProvider;
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
  */
-@AutoConfiguration(after = {CacheAutoConfiguration.class})
+@AutoConfiguration(after = {CacheAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class})
 @ConditionalOnAvailableEndpoint(endpoint = AxelixCachesEndpoint.class)
 public class AxelixCachesEndpointAutoConfiguration {
 
@@ -67,7 +74,15 @@ public class AxelixCachesEndpointAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor() {
-        return new CacheManagerBeanPostProcessor();
+    public CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
+            ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider) {
+        return new CacheManagerBeanPostProcessor(metricsPublisherObjectProvider.getIfAvailable());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(MeterRegistry.class)
+    public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
+        return new DefaultAxelixMetricsPublisher(meterRegistry);
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -17,13 +17,20 @@
  */
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.config.TransactionMonitoringConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
 import com.axelixlabs.axelix.sbs.spring.core.transactions.DefaultQueriesRecorder;
 import com.axelixlabs.axelix.sbs.spring.core.transactions.DefaultTransactionMonitoringService;
 import com.axelixlabs.axelix.sbs.spring.core.transactions.DefaultTransactionStatsCollector;
@@ -42,7 +49,7 @@ import com.axelixlabs.axelix.sbs.spring.core.validate.ValidationListener;
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
  */
-@AutoConfiguration
+@AutoConfiguration(after = CompositeMeterRegistryAutoConfiguration.class)
 @ConditionalOnAvailableEndpoint(endpoint = TransactionMonitoringEndpoint.class)
 public class TransactionMonitoringAutoConfiguration {
 
@@ -83,8 +90,11 @@ public class TransactionMonitoringAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public TransactionMonitoringBeanPostProcessor transactionMonitoringBeanPostProcessor(
-            TransactionStatsCollector transactionStatsCollector, QueriesRecorder queriesCollector) {
-        return new TransactionMonitoringBeanPostProcessor(transactionStatsCollector, queriesCollector);
+            TransactionStatsCollector transactionStatsCollector,
+            QueriesRecorder queriesCollector,
+            ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider) {
+        return new TransactionMonitoringBeanPostProcessor(
+                transactionStatsCollector, queriesCollector, metricsPublisherObjectProvider.getIfAvailable());
     }
 
     @Bean
@@ -98,5 +108,12 @@ public class TransactionMonitoringAutoConfiguration {
     public ProxyingDataSourceBeanPostProcessor transactionMonitoringDataSourceBeanPostProcessor(
             QueriesRecorder queriesCollector) {
         return new ProxyingDataSourceBeanPostProcessor(queriesCollector);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnBean(MeterRegistry.class)
+    public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
+        return new DefaultAxelixMetricsPublisher(meterRegistry);
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -94,7 +94,7 @@ public class TransactionMonitoringAutoConfiguration {
             QueriesRecorder queriesCollector,
             ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider) {
         return new TransactionMonitoringBeanPostProcessor(
-                transactionStatsCollector, queriesCollector, metricsPublisherObjectProvider.getIfAvailable());
+                transactionStatsCollector, queriesCollector, metricsPublisherObjectProvider);
     }
 
     @Bean

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -18,12 +18,15 @@
 package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.DefaultIntroductionAdvisor;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.cache.CacheManager;
+
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
 
 /**
  * BeanPostProcessor that wraps existing CacheManager beans with EnhancedCacheManager
@@ -35,6 +38,12 @@ import org.springframework.cache.CacheManager;
  */
 public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
 
+    private final @Nullable AxelixMetricsPublisher metricsPublisher;
+
+    public CacheManagerBeanPostProcessor(@Nullable AxelixMetricsPublisher metricsPublisher) {
+        this.metricsPublisher = metricsPublisher;
+    }
+
     @Override
     public Object postProcessAfterInitialization(@NonNull Object bean, @NonNull String beanName) throws BeansException {
         if (!(bean instanceof CacheManager) || bean instanceof EnhancedCacheManager) {
@@ -44,7 +53,7 @@ public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
     }
 
     private Object createEnhancedCacheManagerProxy(CacheManager target, String beanName) {
-        DefaultEnhancedCacheManager delegate = new DefaultEnhancedCacheManager(beanName, target);
+        DefaultEnhancedCacheManager delegate = new DefaultEnhancedCacheManager(beanName, target, metricsPublisher);
 
         ProxyFactory proxyFactory = new ProxyFactory();
         proxyFactory.setTarget(target);

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -18,11 +18,11 @@
 package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.DefaultIntroductionAdvisor;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.cache.CacheManager;
 
@@ -38,10 +38,10 @@ import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
  */
 public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
 
-    private final @Nullable AxelixMetricsPublisher metricsPublisher;
+    private final ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider;
 
-    public CacheManagerBeanPostProcessor(@Nullable AxelixMetricsPublisher metricsPublisher) {
-        this.metricsPublisher = metricsPublisher;
+    public CacheManagerBeanPostProcessor(ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider) {
+        this.metricsPublisherObjectProvider = metricsPublisherObjectProvider;
     }
 
     @Override
@@ -53,7 +53,8 @@ public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
     }
 
     private Object createEnhancedCacheManagerProxy(CacheManager target, String beanName) {
-        DefaultEnhancedCacheManager delegate = new DefaultEnhancedCacheManager(beanName, target, metricsPublisher);
+        DefaultEnhancedCacheManager delegate =
+                new DefaultEnhancedCacheManager(beanName, target, metricsPublisherObjectProvider.getIfAvailable());
 
         ProxyFactory proxyFactory = new ProxyFactory();
         proxyFactory.setTarget(target);

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCache.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCache.java
@@ -28,6 +28,8 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.cache.Cache;
 
 import com.axelixlabs.axelix.sbs.spring.core.SlidingWindow;
+import com.axelixlabs.axelix.sbs.spring.core.cache.CacheLookup.Outcome;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
 
 /**
  * Cache implementation that can be dynamically enabled or disabled at runtime.
@@ -43,11 +45,14 @@ public class DefaultEnhancedCache implements EnhancedCache {
     private final AtomicBoolean enabled;
     private final SlidingWindow<@NonNull CacheLookup> cacheLookupHistory;
 
-    public DefaultEnhancedCache(@NonNull Cache delegate) {
+    private final @Nullable AxelixMetricsPublisher metricsPublisher;
+
+    public DefaultEnhancedCache(@NonNull Cache delegate, @Nullable AxelixMetricsPublisher metricsPublisher) {
         this.delegate = delegate;
         this.enabled = new AtomicBoolean(true);
         // TODO: We need to find a way to allow for configuring those values
         this.cacheLookupHistory = new SlidingWindow<>(200);
+        this.metricsPublisher = metricsPublisher;
     }
 
     @Override
@@ -88,8 +93,16 @@ public class DefaultEnhancedCache implements EnhancedCache {
 
         if (result == null) {
             cacheLookupHistory.put(CacheLookup.miss());
+
+            if (metricsPublisher != null) {
+                metricsPublisher.incrementCacheLookup(delegate.getName(), Outcome.MISS.getValue());
+            }
         } else {
             cacheLookupHistory.put(CacheLookup.hit());
+
+            if (metricsPublisher != null) {
+                metricsPublisher.incrementCacheLookup(delegate.getName(), Outcome.HIT.getValue());
+            }
         }
         return result;
     }
@@ -110,14 +123,26 @@ public class DefaultEnhancedCache implements EnhancedCache {
         T value = null;
 
         if (enabled.get()) {
-            boolean[] miss = {false};
+            AtomicBoolean miss = new AtomicBoolean();
 
             value = delegate.get(key, () -> {
-                miss[0] = true;
+                miss.set(true);
                 return valueLoader.call();
             });
 
-            cacheLookupHistory.put(miss[0] ? CacheLookup.miss() : CacheLookup.hit());
+            if (miss.get()) {
+                cacheLookupHistory.put(CacheLookup.miss());
+
+                if (metricsPublisher != null) {
+                    metricsPublisher.incrementCacheLookup(delegate.getName(), Outcome.MISS.getValue());
+                }
+            } else {
+                cacheLookupHistory.put(CacheLookup.hit());
+
+                if (metricsPublisher != null) {
+                    metricsPublisher.incrementCacheLookup(delegate.getName(), Outcome.HIT.getValue());
+                }
+            }
         }
 
         return value;
@@ -151,6 +176,11 @@ public class DefaultEnhancedCache implements EnhancedCache {
     @Override
     public List<CacheLookup> getCacheLookups() {
         return cacheLookupHistory.get();
+    }
+
+    @Override
+    public AtomicBoolean getEnabledFlag() {
+        return this.enabled;
     }
 
     private boolean executeIfEnabledOrElseFalse(BooleanSupplier supplier) {

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCache.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCache.java
@@ -95,13 +95,13 @@ public class DefaultEnhancedCache implements EnhancedCache {
             cacheLookupHistory.put(CacheLookup.miss());
 
             if (metricsPublisher != null) {
-                metricsPublisher.incrementCacheLookup(delegate.getName(), Outcome.MISS.getValue());
+                metricsPublisher.incrementCacheLookup(delegate.getName(), Outcome.MISS);
             }
         } else {
             cacheLookupHistory.put(CacheLookup.hit());
 
             if (metricsPublisher != null) {
-                metricsPublisher.incrementCacheLookup(delegate.getName(), Outcome.HIT.getValue());
+                metricsPublisher.incrementCacheLookup(delegate.getName(), Outcome.HIT);
             }
         }
         return result;
@@ -134,13 +134,13 @@ public class DefaultEnhancedCache implements EnhancedCache {
                 cacheLookupHistory.put(CacheLookup.miss());
 
                 if (metricsPublisher != null) {
-                    metricsPublisher.incrementCacheLookup(delegate.getName(), Outcome.MISS.getValue());
+                    metricsPublisher.incrementCacheLookup(delegate.getName(), Outcome.MISS);
                 }
             } else {
                 cacheLookupHistory.put(CacheLookup.hit());
 
                 if (metricsPublisher != null) {
-                    metricsPublisher.incrementCacheLookup(delegate.getName(), Outcome.HIT.getValue());
+                    metricsPublisher.incrementCacheLookup(delegate.getName(), Outcome.HIT);
                 }
             }
         }
@@ -176,11 +176,6 @@ public class DefaultEnhancedCache implements EnhancedCache {
     @Override
     public List<CacheLookup> getCacheLookups() {
         return cacheLookupHistory.get();
-    }
-
-    @Override
-    public AtomicBoolean getEnabledFlag() {
-        return this.enabled;
     }
 
     private boolean executeIfEnabledOrElseFalse(BooleanSupplier supplier) {

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
@@ -28,6 +28,8 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+
 /**
  * Default {@link EnhancedCacheManager} implementation that delegates the core
  * {@link CacheManager} contract to an underlying manager and maintains a map of
@@ -44,10 +46,13 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
     private final String cacheManagerBeanName;
     private final CacheManager delegate;
     private final Map<String, EnhancedCache> caches = new ConcurrentHashMap<>();
+    private final @Nullable AxelixMetricsPublisher metricsPublisher;
 
-    public DefaultEnhancedCacheManager(String cacheManagerBeanName, CacheManager delegate) {
+    public DefaultEnhancedCacheManager(
+            String cacheManagerBeanName, CacheManager delegate, @Nullable AxelixMetricsPublisher metricsPublisher) {
         this.delegate = delegate;
         this.cacheManagerBeanName = cacheManagerBeanName;
+        this.metricsPublisher = metricsPublisher;
     }
 
     @Override
@@ -81,11 +86,16 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
     @Override
     @Nullable
     public EnhancedCache getCache(@NonNull String name) {
-        return caches.computeIfAbsent(name, s -> {
+        EnhancedCache enhancedCache = caches.computeIfAbsent(name, s -> {
             Cache cache = delegate.getCache(s);
-
-            return cache != null ? new DefaultEnhancedCache(cache) : null;
+            return cache != null ? new DefaultEnhancedCache(cache, metricsPublisher) : null;
         });
+
+        if (enhancedCache != null && metricsPublisher != null) {
+            metricsPublisher.registerCacheStatusGauge(name, enhancedCache.getEnabledFlag());
+        }
+
+        return enhancedCache;
     }
 
     @Override

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
@@ -86,16 +86,18 @@ public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
     @Override
     @Nullable
     public EnhancedCache getCache(@NonNull String name) {
-        EnhancedCache enhancedCache = caches.computeIfAbsent(name, s -> {
+        return caches.computeIfAbsent(name, s -> {
             Cache cache = delegate.getCache(s);
-            return cache != null ? new DefaultEnhancedCache(cache, metricsPublisher) : null;
+            if (cache == null) {
+                return null;
+            }
+
+            EnhancedCache enhancedCache = new DefaultEnhancedCache(cache, metricsPublisher);
+            if (metricsPublisher != null) {
+                metricsPublisher.registerCacheStatusGauge(enhancedCache);
+            }
+            return enhancedCache;
         });
-
-        if (enhancedCache != null && metricsPublisher != null) {
-            metricsPublisher.registerCacheStatusGauge(name, enhancedCache.getEnabledFlag());
-        }
-
-        return enhancedCache;
     }
 
     @Override

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCache.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCache.java
@@ -18,6 +18,7 @@
 package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.springframework.cache.Cache;
 
@@ -54,6 +55,11 @@ public interface EnhancedCache extends Cache {
      * @return {@code true} if this cache is enabled, {@code false} otherwise.
      */
     boolean isEnabled();
+
+    /**
+     * Returns the internal enabled flag for metrics integration.
+     */
+    AtomicBoolean getEnabledFlag();
 
     /**
      * @return the estimated number of cache misses.

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCache.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCache.java
@@ -18,7 +18,6 @@
 package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.springframework.cache.Cache;
 
@@ -55,11 +54,6 @@ public interface EnhancedCache extends Cache {
      * @return {@code true} if this cache is enabled, {@code false} otherwise.
      */
     boolean isEnabled();
-
-    /**
-     * Returns the internal enabled flag for metrics integration.
-     */
-    AtomicBoolean getEnabledFlag();
 
     /**
      * @return the estimated number of cache misses.

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsPublisher.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsPublisher.java
@@ -17,7 +17,9 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.metrics;
 
-import java.util.concurrent.atomic.AtomicBoolean;
+import com.axelixlabs.axelix.sbs.spring.core.cache.CacheLookup;
+import com.axelixlabs.axelix.sbs.spring.core.cache.EnhancedCache;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionStatus;
 
 /**
  * Interface responsible for publishing application-level metrics to the underlying metrics system.
@@ -29,14 +31,14 @@ public interface AxelixMetricsPublisher {
     /**
      * Publishes aggregated transaction statistics.
      *
-     * @param className    the simple name of the target class executing the transaction
-     * @param methodName   the name of the target method executing the transaction
-     * @param durationNano transaction execution duration in nanoseconds
-     * @param status       the final outcome status of the transaction (e.g., "success" or "error")
-     * @param queryCount   the total number of SQL queries executed inside the transaction scope
+     * @param className      the simple name of the target class executing the transaction
+     * @param methodName     the name of the target method executing the transaction
+     * @param durationMillis transaction execution duration in milliseconds
+     * @param status         the final outcome status of the transaction (e.g., "success" or "error")
+     * @param queryCount     the total number of SQL queries executed inside the transaction scope
      */
     void publishTransactionMetrics(
-            String className, String methodName, long durationNano, String status, int queryCount);
+            String className, String methodName, long durationMillis, TransactionStatus status, int queryCount);
 
     /**
      * Increments the cache lookup counter based on the operation result type.
@@ -44,13 +46,13 @@ public interface AxelixMetricsPublisher {
      * @param cacheName  the name of the cache being queried
      * @param outcome    the outcome of the cache lookup (strictly "hit" or "miss")
      */
-    void incrementCacheLookup(String cacheName, String outcome);
+    void incrementCacheLookup(String cacheName, CacheLookup.Outcome outcome);
 
     /**
      * Registers a gauge to dynamically monitor the current cache execution status (enabled or disabled).
      *
-     * @param cacheName   the name of the cache to monitor
-     * @param enabledFlag the thread-safe flag indicating whether the cache is currently enabled
+     * @see   EnhancedCache
+     * @param enhancedCache the enhanced cache instance to monitor
      */
-    void registerCacheStatusGauge(String cacheName, AtomicBoolean enabledFlag);
+    void registerCacheStatusGauge(EnhancedCache enhancedCache);
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultAxelixMetricsPublisher.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultAxelixMetricsPublisher.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.metrics;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * Default implementation of {@link AxelixMetricsPublisher}
+ *
+ * @author Nikita Kirillov
+ */
+public class DefaultAxelixMetricsPublisher implements AxelixMetricsPublisher {
+
+    private final ConcurrentHashMap<String, Counter> cacheCounters = new ConcurrentHashMap<>();
+
+    private final MeterRegistry meterRegistry;
+
+    public DefaultAxelixMetricsPublisher(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public void publishTransactionMetrics(
+            String className, String methodName, long durationNano, String status, int queryCount) {
+        Timer.builder(AxelixMetricNames.TRANSACTION_DURATION)
+                .description("Duration of transactions")
+                .tag("class", className)
+                .tag("method", methodName)
+                .tag("status", status)
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(meterRegistry)
+                .record(durationNano, TimeUnit.NANOSECONDS);
+
+        Counter.builder(AxelixMetricNames.TRANSACTION_QUERIES)
+                .description("Total number of SQL queries executed inside transactions")
+                .tag("class", className)
+                .tag("method", methodName)
+                .register(meterRegistry)
+                .increment(queryCount);
+    }
+
+    @Override
+    public void incrementCacheLookup(String cacheName, String outcome) {
+        String counterKey = cacheName + ":" + outcome;
+
+        cacheCounters
+                .computeIfAbsent(counterKey, key -> Counter.builder(AxelixMetricNames.CACHE_REQUESTS)
+                        .description("Total number of cache lookups")
+                        .tag("cache", cacheName)
+                        .tag("result", outcome)
+                        .register(meterRegistry))
+                .increment();
+    }
+
+    @Override
+    public void registerCacheStatusGauge(String cacheName, AtomicBoolean enabledFlag) {
+        Tags cacheTags = Tags.of("cache", cacheName);
+
+        meterRegistry.gauge(AxelixMetricNames.CACHE_ENABLED, cacheTags, enabledFlag, flag -> flag.get() ? 1.0 : 0.0);
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultAxelixMetricsPublisher.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultAxelixMetricsPublisher.java
@@ -19,12 +19,15 @@ package com.axelixlabs.axelix.sbs.spring.core.metrics;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
+
+import com.axelixlabs.axelix.sbs.spring.core.cache.CacheLookup;
+import com.axelixlabs.axelix.sbs.spring.core.cache.EnhancedCache;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionStatus;
 
 /**
  * Default implementation of {@link AxelixMetricsPublisher}
@@ -43,15 +46,15 @@ public class DefaultAxelixMetricsPublisher implements AxelixMetricsPublisher {
 
     @Override
     public void publishTransactionMetrics(
-            String className, String methodName, long durationNano, String status, int queryCount) {
+            String className, String methodName, long durationMillis, TransactionStatus status, int queryCount) {
         Timer.builder(AxelixMetricNames.TRANSACTION_DURATION)
                 .description("Duration of transactions")
                 .tag("class", className)
                 .tag("method", methodName)
-                .tag("status", status)
+                .tag("status", status.getValue())
                 .publishPercentiles(0.5, 0.95, 0.99)
                 .register(meterRegistry)
-                .record(durationNano, TimeUnit.NANOSECONDS);
+                .record(durationMillis, TimeUnit.MILLISECONDS);
 
         Counter.builder(AxelixMetricNames.TRANSACTION_QUERIES)
                 .description("Total number of SQL queries executed inside transactions")
@@ -62,22 +65,25 @@ public class DefaultAxelixMetricsPublisher implements AxelixMetricsPublisher {
     }
 
     @Override
-    public void incrementCacheLookup(String cacheName, String outcome) {
-        String counterKey = cacheName + ":" + outcome;
+    public void incrementCacheLookup(String cacheName, CacheLookup.Outcome outcome) {
+        String outcomeValue = outcome.getValue();
+        String counterKey = cacheName + ":" + outcomeValue;
 
         cacheCounters
-                .computeIfAbsent(counterKey, key -> Counter.builder(AxelixMetricNames.CACHE_REQUESTS)
-                        .description("Total number of cache lookups")
-                        .tag("cache", cacheName)
-                        .tag("result", outcome)
-                        .register(meterRegistry))
+                .computeIfAbsent(
+                        counterKey,
+                        key -> Counter.builder(AxelixMetricNames.CACHE_REQUESTS)
+                                .description("Total number of cache lookups")
+                                .tag("cache", cacheName)
+                                .tag("result", outcomeValue)
+                                .register(meterRegistry))
                 .increment();
     }
 
     @Override
-    public void registerCacheStatusGauge(String cacheName, AtomicBoolean enabledFlag) {
-        Tags cacheTags = Tags.of("cache", cacheName);
+    public void registerCacheStatusGauge(EnhancedCache enhancedCache) {
+        Tags cacheTags = Tags.of("cache", enhancedCache.getName());
 
-        meterRegistry.gauge(AxelixMetricNames.CACHE_ENABLED, cacheTags, enabledFlag, flag -> flag.get() ? 1.0 : 0.0);
+        meterRegistry.gauge(AxelixMetricNames.CACHE_ENABLED, cacheTags, enhancedCache, c -> c.isEnabled() ? 1.0 : 0.0);
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessor.java
@@ -45,6 +45,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.ReflectionUtils.MethodFilter;
 
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+
 /**
  * BeanPostProcessor that creates AOP proxies for beans with @Transactional methods
  * to enable real-time transaction monitoring and statistics collection.
@@ -60,12 +62,16 @@ public class TransactionMonitoringBeanPostProcessor implements BeanPostProcessor
     private final Map<MethodClassKey, Propagation> propagationCache;
     private final TransactionStatsCollector statsCollector;
     private final QueriesRecorder queriesCollector;
+    private final @Nullable AxelixMetricsPublisher metricsPublisher;
 
     public TransactionMonitoringBeanPostProcessor(
-            TransactionStatsCollector statsCollector, QueriesRecorder queriesCollector) {
+            TransactionStatsCollector statsCollector,
+            QueriesRecorder queriesCollector,
+            @Nullable AxelixMetricsPublisher metricsPublisher) {
         this.propagationCache = new ConcurrentHashMap<>();
         this.statsCollector = statsCollector;
         this.queriesCollector = queriesCollector;
+        this.metricsPublisher = metricsPublisher;
     }
 
     @Override
@@ -137,8 +143,8 @@ public class TransactionMonitoringBeanPostProcessor implements BeanPostProcessor
         proxyFactory.setTarget(bean);
         proxyFactory.setProxyTargetClass(true);
 
-        TransactionMonitoringInterceptor interceptor =
-                new TransactionMonitoringInterceptor(propagationCache, statsCollector, queriesCollector);
+        TransactionMonitoringInterceptor interceptor = new TransactionMonitoringInterceptor(
+                propagationCache, statsCollector, queriesCollector, metricsPublisher);
 
         // Pointcut provides fast filtering at the proxy level and is necessary for performance
         DefaultPointcutAdvisor advisor = new DefaultPointcutAdvisor(createTransactionMonitoringPointcut(), interceptor);

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessor.java
@@ -36,6 +36,7 @@ import org.springframework.aop.support.AopUtils;
 import org.springframework.aop.support.DefaultPointcutAdvisor;
 import org.springframework.aop.support.StaticMethodMatcherPointcut;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.core.annotation.MergedAnnotation;
 import org.springframework.core.annotation.MergedAnnotations;
@@ -62,16 +63,16 @@ public class TransactionMonitoringBeanPostProcessor implements BeanPostProcessor
     private final Map<MethodClassKey, Propagation> propagationCache;
     private final TransactionStatsCollector statsCollector;
     private final QueriesRecorder queriesCollector;
-    private final @Nullable AxelixMetricsPublisher metricsPublisher;
+    private final ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider;
 
     public TransactionMonitoringBeanPostProcessor(
             TransactionStatsCollector statsCollector,
             QueriesRecorder queriesCollector,
-            @Nullable AxelixMetricsPublisher metricsPublisher) {
+            ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider) {
         this.propagationCache = new ConcurrentHashMap<>();
         this.statsCollector = statsCollector;
         this.queriesCollector = queriesCollector;
-        this.metricsPublisher = metricsPublisher;
+        this.metricsPublisherObjectProvider = metricsPublisherObjectProvider;
     }
 
     @Override
@@ -144,7 +145,7 @@ public class TransactionMonitoringBeanPostProcessor implements BeanPostProcessor
         proxyFactory.setProxyTargetClass(true);
 
         TransactionMonitoringInterceptor interceptor = new TransactionMonitoringInterceptor(
-                propagationCache, statsCollector, queriesCollector, metricsPublisher);
+                propagationCache, statsCollector, queriesCollector, metricsPublisherObjectProvider.getIfAvailable());
 
         // Pointcut provides fast filtering at the proxy level and is necessary for performance
         DefaultPointcutAdvisor advisor = new DefaultPointcutAdvisor(createTransactionMonitoringPointcut(), interceptor);

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringInterceptor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringInterceptor.java
@@ -28,6 +28,11 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+
+import static com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionStatus.error;
+import static com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionStatus.success;
+
 /**
  * {@link MethodInterceptor} that monitors transaction execution and collects performance statistics.
  *
@@ -42,14 +47,17 @@ public class TransactionMonitoringInterceptor implements MethodInterceptor {
     private final Map<MethodClassKey, Propagation> propagationCache;
     private final TransactionStatsCollector statsCollector;
     private final QueriesRecorder queriesCollector;
+    private final @Nullable AxelixMetricsPublisher metricsPublisher;
 
     public TransactionMonitoringInterceptor(
             Map<MethodClassKey, Propagation> propagationCache,
             TransactionStatsCollector statsCollector,
-            QueriesRecorder queriesCollector) {
+            QueriesRecorder queriesCollector,
+            @Nullable AxelixMetricsPublisher metricsPublisher) {
         this.propagationCache = propagationCache;
         this.statsCollector = statsCollector;
         this.queriesCollector = queriesCollector;
+        this.metricsPublisher = metricsPublisher;
     }
 
     @Override
@@ -67,14 +75,30 @@ public class TransactionMonitoringInterceptor implements MethodInterceptor {
 
             queriesCollector.clearAll();
 
+            // METRICS. Create transaction status
+            String status = success.name();
+
             try {
                 return invocation.proceed();
+            } catch (Throwable e) {
+
+                // METRICS. Change transaction status
+                status = error.name();
+
+                throw e;
             } finally {
-                long duration = System.nanoTime() - txStartTime;
+
+                long durationNano = System.nanoTime() - txStartTime;
                 List<SqlQueryRecord> queries = queriesCollector.popAllRecords();
 
                 statsCollector.recordTransaction(
-                        key, new TransactionRecord(duration / 1_000_000, startTimestampMs, queries));
+                        key, new TransactionRecord(durationNano / 1_000_000, startTimestampMs, queries));
+
+                // METRICS. Publish metrics in MeterRegistry
+                if (metricsPublisher != null) {
+                    metricsPublisher.publishTransactionMetrics(
+                            declaringClass.getSimpleName(), method.getName(), durationNano, status, queries.size());
+                }
             }
         }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringInterceptor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringInterceptor.java
@@ -30,9 +30,6 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
 
-import static com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionStatus.error;
-import static com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionStatus.success;
-
 /**
  * {@link MethodInterceptor} that monitors transaction execution and collects performance statistics.
  *
@@ -76,28 +73,35 @@ public class TransactionMonitoringInterceptor implements MethodInterceptor {
             queriesCollector.clearAll();
 
             // METRICS. Create transaction status
-            String status = success.name();
+            TransactionStatus transactionStatus = TransactionStatus.SUCCESS;
 
             try {
                 return invocation.proceed();
             } catch (Throwable e) {
 
                 // METRICS. Change transaction status
-                status = error.name();
+                transactionStatus = TransactionStatus.ERROR;
 
                 throw e;
             } finally {
 
                 long durationNano = System.nanoTime() - txStartTime;
+                long durationMillis = durationNano / 1_000_000;
                 List<SqlQueryRecord> queries = queriesCollector.popAllRecords();
 
-                statsCollector.recordTransaction(
-                        key, new TransactionRecord(durationNano / 1_000_000, startTimestampMs, queries));
+                statsCollector.recordTransaction(key, new TransactionRecord(durationMillis, startTimestampMs, queries));
 
                 // METRICS. Publish metrics in MeterRegistry
-                if (metricsPublisher != null) {
-                    metricsPublisher.publishTransactionMetrics(
-                            declaringClass.getSimpleName(), method.getName(), durationNano, status, queries.size());
+                try {
+                    if (metricsPublisher != null) {
+                        metricsPublisher.publishTransactionMetrics(
+                                declaringClass.getSimpleName(),
+                                method.getName(),
+                                durationMillis,
+                                transactionStatus,
+                                queries.size());
+                    }
+                } catch (Exception ignored) {
                 }
             }
         }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixCachesEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixCachesEndpointAutoConfigurationTest.java
@@ -140,7 +140,7 @@ class AxelixCachesEndpointAutoConfigurationTest {
 
     static class CustomCacheManagerBeanPostProcessor extends CacheManagerBeanPostProcessor {
         public CustomCacheManagerBeanPostProcessor(ObjectProvider<AxelixMetricsPublisher> objectProvider) {
-            super(objectProvider.getIfAvailable());
+            super(objectProvider);
         }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixCachesEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixCachesEndpointAutoConfigurationTest.java
@@ -19,6 +19,7 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -28,6 +29,7 @@ import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpoint;
 import com.axelixlabs.axelix.sbs.spring.core.cache.CacheManagerBeanPostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.cache.CacheOperationsDispatcher;
 import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -116,8 +118,9 @@ class AxelixCachesEndpointAutoConfigurationTest {
     @TestConfiguration
     static class CustomCacheManagerBeanPostProcessorConfig {
         @Bean
-        public CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor() {
-            return new CustomCacheManagerBeanPostProcessor();
+        public CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
+                ObjectProvider<AxelixMetricsPublisher> objectProvider) {
+            return new CustomCacheManagerBeanPostProcessor(objectProvider);
         }
     }
 
@@ -135,5 +138,9 @@ class AxelixCachesEndpointAutoConfigurationTest {
         }
     }
 
-    static class CustomCacheManagerBeanPostProcessor extends CacheManagerBeanPostProcessor {}
+    static class CustomCacheManagerBeanPostProcessor extends CacheManagerBeanPostProcessor {
+        public CustomCacheManagerBeanPostProcessor(ObjectProvider<AxelixMetricsPublisher> objectProvider) {
+            super(objectProvider.getIfAvailable());
+        }
+    }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -193,7 +193,7 @@ class TransactionMonitoringAutoConfigurationTest {
 
         public CustomTransactionMonitoringBeanPostProcessor(
                 TransactionStatsCollector transactionStatsCollector, QueriesRecorder queriesCollector) {
-            super(transactionStatsCollector, queriesCollector);
+            super(transactionStatsCollector, queriesCollector, null);
         }
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
@@ -455,7 +455,7 @@ class JwtAuthorizationFilterTest {
         @Bean
         public static CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
                 ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
-            return new CacheManagerBeanPostProcessor(axelixMetricsPublisherObjectProvider.getIfAvailable());
+            return new CacheManagerBeanPostProcessor(axelixMetricsPublisherObjectProvider);
         }
 
         @Bean

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
@@ -22,12 +22,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -76,6 +78,8 @@ import com.axelixlabs.axelix.sbs.spring.core.env.AxelixEnvironmentEndpoint;
 import com.axelixlabs.axelix.sbs.spring.core.env.EnvironmentService;
 import com.axelixlabs.axelix.sbs.spring.core.env.EnvironmentTestConfig;
 import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -449,8 +453,14 @@ class JwtAuthorizationFilterTest {
         }
 
         @Bean
-        public static CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor() {
-            return new CacheManagerBeanPostProcessor();
+        public static CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
+                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
+            return new CacheManagerBeanPostProcessor(axelixMetricsPublisherObjectProvider.getIfAvailable());
+        }
+
+        @Bean
+        public AxelixMetricsPublisher axelixMetricsPublisher() {
+            return new DefaultAxelixMetricsPublisher(new SimpleMeterRegistry());
         }
 
         @Bean(name = MAIN_CACHE_MANAGER)

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
@@ -20,6 +20,7 @@ package com.axelixlabs.axelix.sbs.spring.core.cache;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -28,6 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -50,6 +52,8 @@ import com.axelixlabs.axelix.common.api.caches.CachesFeed;
 import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheDto;
 import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheManagerDto;
 import com.axelixlabs.axelix.sbs.spring.core.Main;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -527,8 +531,14 @@ class AxelixCachesEndpointTest {
         }
 
         @Bean
-        public static CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor() {
-            return new CacheManagerBeanPostProcessor();
+        public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
+            return new DefaultAxelixMetricsPublisher(meterRegistry);
+        }
+
+        @Bean
+        public static CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
+                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
+            return new CacheManagerBeanPostProcessor(axelixMetricsPublisherObjectProvider.getIfAvailable());
         }
 
         @Bean(name = MAIN_CACHE_MANAGER)

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
@@ -538,7 +538,7 @@ class AxelixCachesEndpointTest {
         @Bean
         public static CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
                 ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
-            return new CacheManagerBeanPostProcessor(axelixMetricsPublisherObjectProvider.getIfAvailable());
+            return new CacheManagerBeanPostProcessor(axelixMetricsPublisherObjectProvider);
         }
 
         @Bean(name = MAIN_CACHE_MANAGER)

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
@@ -20,6 +20,7 @@ package com.axelixlabs.axelix.sbs.spring.core.cache;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +30,8 @@ import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 
 import com.axelixlabs.axelix.common.api.caches.CachesFeed;
 import com.axelixlabs.axelix.common.api.caches.SingleCache;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -58,12 +61,15 @@ class DefaultCacheOperationsDispatcherTest {
 
     @BeforeEach
     void setUp() {
+        AxelixMetricsPublisher axelixMetricsPublisher = new DefaultAxelixMetricsPublisher(new SimpleMeterRegistry());
         Map<String, CacheManager> managers = new HashMap<>();
 
         cacheManager1 = new DefaultEnhancedCacheManager(
-                TEST_CACHE_MANAGER_1, new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2));
-        cacheManager2 =
-                new DefaultEnhancedCacheManager(TEST_CACHE_MANAGER_2, new ConcurrentMapCacheManager(TEST_CACHE_2));
+                TEST_CACHE_MANAGER_1,
+                new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2),
+                axelixMetricsPublisher);
+        cacheManager2 = new DefaultEnhancedCacheManager(
+                TEST_CACHE_MANAGER_2, new ConcurrentMapCacheManager(TEST_CACHE_2), axelixMetricsPublisher);
         managers.put(TEST_CACHE_MANAGER_1, cacheManager1);
         managers.put(TEST_CACHE_MANAGER_2, cacheManager2);
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheTest.java
@@ -28,9 +28,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.cache.Cache;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
@@ -57,22 +59,32 @@ class DefaultEnhancedCacheTest {
     private static final String VALUE = "testValue";
     private static final String CACHE_NAME = "testCacheName";
 
-    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    private final AxelixMetricsPublisher axelixMetricsPublisher = new DefaultAxelixMetricsPublisher(meterRegistry);
+    private MeterRegistry meterRegistry;
+    private AxelixMetricsPublisher axelixMetricsPublisher;
 
     @Mock
     private Cache delegate;
 
-    private DefaultEnhancedCache enhancedCache;
+    private EnhancedCache enhancedCache;
 
     @BeforeEach
     void setUp() {
-        when(delegate.getName()).thenReturn(CACHE_NAME);
+        meterRegistry = new SimpleMeterRegistry();
+        axelixMetricsPublisher = new DefaultAxelixMetricsPublisher(meterRegistry);
+
+        Mockito.lenient().when(delegate.getName()).thenReturn(CACHE_NAME);
         enhancedCache = new DefaultEnhancedCache(delegate, axelixMetricsPublisher);
     }
 
     @Nested
     class EnableDisable {
+
+        @BeforeEach
+        void setUp() {
+            EnhancedCacheManager enhancedCacheManager = new DefaultEnhancedCacheManager(
+                    "cacheManager", new ConcurrentMapCacheManager(CACHE_NAME), axelixMetricsPublisher);
+            enhancedCache = enhancedCacheManager.getCache(CACHE_NAME);
+        }
 
         @Test
         void shouldBeEnabledByDefault() {
@@ -571,6 +583,7 @@ class DefaultEnhancedCacheTest {
                 .counter();
 
         if (expectedHits != 0.0) {
+            assertThat(cacheHitsCounter).isNotNull();
             assertThat(cacheHitsCounter.count()).isEqualTo(expectedHits);
         }
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheTest.java
@@ -19,6 +19,10 @@ package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import java.util.concurrent.Callable;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -28,6 +32,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.cache.Cache;
 
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+
+import static com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricNames.CACHE_ENABLED;
+import static com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricNames.CACHE_REQUESTS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -39,12 +48,17 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link DefaultEnhancedCache}.
  *
  * @author Mikhail Polivakha
+ * @author Nikita Kirillov
  */
 @ExtendWith(MockitoExtension.class)
 class DefaultEnhancedCacheTest {
 
     private static final String KEY = "testKey";
     private static final String VALUE = "testValue";
+    private static final String CACHE_NAME = "testCacheName";
+
+    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final AxelixMetricsPublisher axelixMetricsPublisher = new DefaultAxelixMetricsPublisher(meterRegistry);
 
     @Mock
     private Cache delegate;
@@ -53,7 +67,8 @@ class DefaultEnhancedCacheTest {
 
     @BeforeEach
     void setUp() {
-        enhancedCache = new DefaultEnhancedCache(delegate);
+        when(delegate.getName()).thenReturn(CACHE_NAME);
+        enhancedCache = new DefaultEnhancedCache(delegate, axelixMetricsPublisher);
     }
 
     @Nested
@@ -69,18 +84,21 @@ class DefaultEnhancedCacheTest {
 
             // then.
             assertThat(isEnabled).isTrue();
+            checkMeterRegistryCacheStatusGauge(isEnabled);
         }
 
         @Test
         void shouldDisableCache() {
             // given.
             assertThat(enhancedCache.isEnabled()).isTrue();
+            checkMeterRegistryCacheStatusGauge(true);
 
             // when.
             enhancedCache.disable();
 
             // then.
             assertThat(enhancedCache.isEnabled()).isFalse();
+            checkMeterRegistryCacheStatusGauge(false);
         }
 
         @Test
@@ -88,24 +106,28 @@ class DefaultEnhancedCacheTest {
             // given.
             enhancedCache.disable();
             assertThat(enhancedCache.isEnabled()).isFalse();
+            checkMeterRegistryCacheStatusGauge(false);
 
             // when.
             enhancedCache.enable();
 
             // then.
             assertThat(enhancedCache.isEnabled()).isTrue();
+            checkMeterRegistryCacheStatusGauge(true);
         }
 
         @Test
         void shouldBeNoOpWhenCacheIsAlreadyEnabled() {
             // given.
             assertThat(enhancedCache.isEnabled()).isTrue();
+            checkMeterRegistryCacheStatusGauge(true);
 
             // when.
             enhancedCache.enable();
 
             // then.
             assertThat(enhancedCache.isEnabled()).isTrue();
+            checkMeterRegistryCacheStatusGauge(true);
         }
 
         @Test
@@ -113,12 +135,14 @@ class DefaultEnhancedCacheTest {
             // given.
             enhancedCache.disable();
             assertThat(enhancedCache.isEnabled()).isFalse();
+            checkMeterRegistryCacheStatusGauge(false);
 
             // when.
             enhancedCache.disable();
 
             // then.
             assertThat(enhancedCache.isEnabled()).isFalse();
+            checkMeterRegistryCacheStatusGauge(false);
         }
     }
 
@@ -461,6 +485,8 @@ class DefaultEnhancedCacheTest {
             assertThat(enhancedCache.getCacheLookups())
                     .extracting(CacheLookup::outcome)
                     .containsOnly(CacheLookup.Outcome.HIT);
+            // and then.
+            checkMeterRegistryCacheLookup(3d, 0d);
         }
 
         @Test
@@ -480,6 +506,8 @@ class DefaultEnhancedCacheTest {
             assertThat(enhancedCache.getCacheLookups())
                     .extracting(CacheLookup::outcome)
                     .containsOnly(CacheLookup.Outcome.MISS);
+            // and then.
+            checkMeterRegistryCacheLookup(0d, 3d);
         }
 
         @Test
@@ -521,6 +549,41 @@ class DefaultEnhancedCacheTest {
                             CacheLookup.Outcome.HIT,
                             CacheLookup.Outcome.MISS,
                             CacheLookup.Outcome.HIT);
+            // and then.
+            checkMeterRegistryCacheLookup(3d, 2d);
+        }
+    }
+
+    private void checkMeterRegistryCacheStatusGauge(boolean cacheEnabled) {
+        Gauge gauge = meterRegistry.find(CACHE_ENABLED).tag("cache", CACHE_NAME).gauge();
+
+        assertThat(gauge).isNotNull();
+        // The value is returned as a double (1.0 for enabled, 0.0 for disabled)
+        assertThat(gauge.value()).isEqualTo(cacheEnabled ? 1.0 : 0.0);
+    }
+
+    private void checkMeterRegistryCacheLookup(double expectedHits, double expectedMisses) {
+        // 1. Verify Cache Hits
+        Counter cacheHitsCounter = meterRegistry
+                .find(CACHE_REQUESTS)
+                .tag("cache", CACHE_NAME)
+                .tag("result", CacheLookup.Outcome.HIT.getValue())
+                .counter();
+
+        if (expectedHits != 0.0) {
+            assertThat(cacheHitsCounter.count()).isEqualTo(expectedHits);
+        }
+
+        // 2. Verify Cache Misses
+        Counter cacheMissesCounter = meterRegistry
+                .find(CACHE_REQUESTS)
+                .tag("cache", CACHE_NAME)
+                .tag("result", CacheLookup.Outcome.MISS.getValue())
+                .counter();
+
+        if (expectedMisses != 0.0) {
+            assertThat(cacheMissesCounter).isNotNull();
+            assertThat(cacheMissesCounter.count()).isEqualTo(expectedMisses);
         }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerTest.java
@@ -17,12 +17,16 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.cache;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -42,7 +46,8 @@ class EnhancedCacheManagerTest {
     @BeforeEach
     void setUp() {
         CacheManager cacheManager = new ConcurrentMapCacheManager();
-        subject = new DefaultEnhancedCacheManager("testCacheManagerBeanName", cacheManager);
+        AxelixMetricsPublisher axelixMetricsPublisher = new DefaultAxelixMetricsPublisher(new SimpleMeterRegistry());
+        subject = new DefaultEnhancedCacheManager("testCacheManagerBeanName", cacheManager, axelixMetricsPublisher);
     }
 
     @Test

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessorTest.java
@@ -27,12 +27,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -45,6 +47,9 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -132,8 +137,11 @@ class TransactionMonitoringBeanPostProcessorTest {
 
         @Bean
         public TransactionMonitoringBeanPostProcessor transactionMonitoringBeanPostProcessor(
-                TransactionStatsCollector transactionStatsCollector, QueriesRecorder queriesCollector) {
-            return new TransactionMonitoringBeanPostProcessor(transactionStatsCollector, queriesCollector);
+                TransactionStatsCollector transactionStatsCollector,
+                QueriesRecorder queriesCollector,
+                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
+            return new TransactionMonitoringBeanPostProcessor(
+                    transactionStatsCollector, queriesCollector, axelixMetricsPublisherObjectProvider.getIfAvailable());
         }
 
         @Bean
@@ -157,6 +165,11 @@ class TransactionMonitoringBeanPostProcessorTest {
         public PropagationTestService propagationTestService(
                 OwnerRepository ownerRepository, PropagationTestHelper helper) {
             return new PropagationTestService(ownerRepository, helper);
+        }
+
+        @Bean
+        public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
+            return new DefaultAxelixMetricsPublisher(meterRegistry);
         }
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessorTest.java
@@ -141,7 +141,7 @@ class TransactionMonitoringBeanPostProcessorTest {
                 QueriesRecorder queriesCollector,
                 ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
             return new TransactionMonitoringBeanPostProcessor(
-                    transactionStatsCollector, queriesCollector, axelixMetricsPublisherObjectProvider.getIfAvailable());
+                    transactionStatsCollector, queriesCollector, axelixMetricsPublisherObjectProvider);
         }
 
         @Bean

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
@@ -102,6 +102,7 @@ class TransactionMonitoringEndpointTest {
     @BeforeEach
     void cleanUp() {
         transactionStatsCollector.clearAllStats();
+        meterRegistry.clear();
     }
 
     @Test
@@ -542,7 +543,7 @@ class TransactionMonitoringEndpointTest {
                 QueriesRecorder queriesCollector,
                 ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
             return new TransactionMonitoringBeanPostProcessor(
-                    transactionStatsCollector, queriesCollector, axelixMetricsPublisherObjectProvider.getIfAvailable());
+                    transactionStatsCollector, queriesCollector, axelixMetricsPublisherObjectProvider);
         }
 
         @Bean

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
@@ -20,6 +20,7 @@ package com.axelixlabs.axelix.sbs.spring.core.transactions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -33,9 +34,13 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import com.jayway.jsonpath.JsonPath;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -52,10 +57,14 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
 import com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest.TransactionMonitoringEndpointTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
 
+import static com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricNames.TRANSACTION_DURATION;
+import static com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricNames.TRANSACTION_QUERIES;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -73,6 +82,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Import({TransactionMonitoringEndpointTestConfiguration.class, JwtAuthTestConfiguration.class})
 class TransactionMonitoringEndpointTest {
 
+    private final String expectedClassName = PropagationTestHelper.class.getSimpleName();
+
     @Autowired
     private TestRestTemplateBuilder restTemplate;
 
@@ -84,6 +95,9 @@ class TransactionMonitoringEndpointTest {
 
     @Autowired
     private OwnerRepository ownerRepository;
+
+    @Autowired
+    private MeterRegistry meterRegistry;
 
     @BeforeEach
     void cleanUp() {
@@ -143,6 +157,9 @@ class TransactionMonitoringEndpointTest {
         assertThatJson(responseBody)
                 .node("entrypoints[0].executionStats.medianDurationMs")
                 .isNumber();
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "saveRequiresNew", "success", 1);
     }
 
     @Test
@@ -220,6 +237,9 @@ class TransactionMonitoringEndpointTest {
             assertThat(queryStartTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
             assertThat(queryEndTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
         }
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "testSaveMultipleOwners", "success", 3);
     }
 
     @Test
@@ -282,6 +302,9 @@ class TransactionMonitoringEndpointTest {
             assertThat(queryStartTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
             assertThat(queryEndTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
         }
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "findOwnerById", "success", 2);
     }
 
     @Test
@@ -342,6 +365,9 @@ class TransactionMonitoringEndpointTest {
             assertThat(queryStartTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
             assertThat(queryEndTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
         }
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "updateOwner", "success", 2);
     }
 
     @Test
@@ -380,6 +406,9 @@ class TransactionMonitoringEndpointTest {
                   } ]
                 }
             """);
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "testRollbackScenario", "error", 1);
     }
 
     @Test
@@ -441,6 +470,36 @@ class TransactionMonitoringEndpointTest {
                   } ]
                 }
             """);
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "testNested", "success", 1);
+    }
+
+    private void checkMeterRegistry(
+            String expectedClassName, String expectedMethodName, String status, int expectedQueryCount) {
+        // given when. Verify Transaction Duration Timer
+        Timer transactionTimer = meterRegistry
+                .find(TRANSACTION_DURATION)
+                .tag("class", expectedClassName)
+                .tag("method", expectedMethodName)
+                .tag("status", status)
+                .timer();
+
+        // then.
+        assertThat(transactionTimer).isNotNull();
+        assertThat(transactionTimer.count()).isEqualTo(1);
+        assertThat(transactionTimer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+
+        // given when. Verify SQL Queries Counter
+        Counter queriesCounter = meterRegistry
+                .find(TRANSACTION_QUERIES)
+                .tag("class", expectedClassName)
+                .tag("method", expectedMethodName)
+                .counter();
+
+        // then.
+        assertThat(queriesCounter).isNotNull();
+        assertThat(queriesCounter.count()).isEqualTo(expectedQueryCount);
     }
 
     @ProtectedEndpointTests(
@@ -479,8 +538,11 @@ class TransactionMonitoringEndpointTest {
 
         @Bean
         public TransactionMonitoringBeanPostProcessor transactionMonitoringBeanPostProcessor(
-                TransactionStatsCollector transactionStatsCollector, QueriesRecorder queriesCollector) {
-            return new TransactionMonitoringBeanPostProcessor(transactionStatsCollector, queriesCollector);
+                TransactionStatsCollector transactionStatsCollector,
+                QueriesRecorder queriesCollector,
+                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
+            return new TransactionMonitoringBeanPostProcessor(
+                    transactionStatsCollector, queriesCollector, axelixMetricsPublisherObjectProvider.getIfAvailable());
         }
 
         @Bean
@@ -497,6 +559,11 @@ class TransactionMonitoringEndpointTest {
         @Bean
         public PropagationTestHelper propagationTestHelper(OwnerRepository ownerRepository) {
             return new PropagationTestHelper(ownerRepository);
+        }
+
+        @Bean
+        public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
+            return new DefaultAxelixMetricsPublisher(meterRegistry);
         }
     }
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheLookup.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheLookup.java
@@ -43,8 +43,18 @@ public class CacheLookup {
     }
 
     public enum Outcome {
-        HIT,
-        MISS
+        HIT("hit"),
+        MISS("miss");
+
+        private final String value;
+
+        Outcome(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
     }
 
     public Outcome outcome() {

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricNames.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricNames.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.metrics;
+
+/**
+ * Utility class containing standardized metric name constants for the Axelix starter.
+ *
+ * @author Nikita Kirillov
+ */
+public final class AxelixMetricNames {
+
+    public static final String TRANSACTION_DURATION = "axelix_transaction_duration";
+    public static final String TRANSACTION_QUERIES = "axelix_transaction_queries";
+    public static final String CACHE_REQUESTS = "axelix_cache_requests";
+    public static final String CACHE_ENABLED = "axelix_cache_enabled";
+
+    private AxelixMetricNames() {}
+}

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsPublisher.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsPublisher.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.metrics;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Interface responsible for publishing application-level metrics to the underlying metrics system.
+ *
+ * @author Nikita Kirillov
+ */
+public interface AxelixMetricsPublisher {
+
+    /**
+     * Publishes aggregated transaction statistics.
+     *
+     * @param className    the simple name of the target class executing the transaction
+     * @param methodName   the name of the target method executing the transaction
+     * @param durationNano transaction execution duration in nanoseconds
+     * @param status       the final outcome status of the transaction (e.g., "success" or "error")
+     * @param queryCount   the total number of SQL queries executed inside the transaction scope
+     */
+    void publishTransactionMetrics(
+            String className, String methodName, long durationNano, String status, int queryCount);
+
+    /**
+     * Increments the cache lookup counter based on the operation result type.
+     *
+     * @param cacheName  the name of the cache being queried
+     * @param outcome    the outcome of the cache lookup (strictly "hit" or "miss")
+     */
+    void incrementCacheLookup(String cacheName, String outcome);
+
+    /**
+     * Registers a gauge to dynamically monitor the current cache execution status (enabled or disabled).
+     *
+     * @param cacheName   the name of the cache to monitor
+     * @param enabledFlag the thread-safe flag indicating whether the cache is currently enabled
+     */
+    void registerCacheStatusGauge(String cacheName, AtomicBoolean enabledFlag);
+}

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionStatus.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionStatus.java
@@ -23,6 +23,16 @@ package com.axelixlabs.axelix.sbs.spring.core.transactions;
  * @author Nikita Kirillov
  */
 public enum TransactionStatus {
-    success,
-    error
+    SUCCESS("success"),
+    ERROR("error");
+
+    private final String value;
+
+    TransactionStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionStatus.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionStatus.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions;
+
+/**
+ * Represents the final outcome status of a transaction execution.
+ *
+ * @author Nikita Kirillov
+ */
+public enum TransactionStatus {
+    success,
+    error
+}


### PR DESCRIPTION
close #1146 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Micrometer metrics integration for transaction monitoring, tracking duration, status (success/error), and SQL query counts per method
  * Added optional cache metrics publishing to monitor hit/miss ratios and cache enabled/disabled status
<!-- end of auto-generated comment: release notes by coderabbit.ai -->