### PR TITLE
GH-1163 Fix nested REQUIRES_NEW transactions overwriting parent SQL query

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringInterceptor.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringInterceptor.java
@@ -65,7 +65,7 @@ public class TransactionMonitoringInterceptor implements MethodInterceptor {
             long startTimestampMs = System.currentTimeMillis();
             long txStartTime = System.nanoTime();
 
-            queriesCollector.clearAll();
+            queriesCollector.startNewContext();
 
             try {
                 return invocation.proceed();

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -164,15 +164,15 @@ class TransactionMonitoringAutoConfigurationTest {
     static class CustomDefaultQueriesRecorder implements QueriesRecorder {
 
         @Override
+        public void startNewContext() {}
+
+        @Override
         public void recordQuery(SqlQueryRecord query) {}
 
         @Override
         public List<SqlQueryRecord> popAllRecords() {
             return List.of();
         }
-
-        @Override
-        public void clearAll() {}
     }
 
     static class CustomTransactionMonitoringService extends DefaultTransactionMonitoringService {

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
@@ -42,6 +42,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.http.HttpMethod;
@@ -58,6 +59,7 @@ import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -369,6 +371,109 @@ class TransactionMonitoringEndpointTest {
     }
 
     @Test
+    void nestedRequiresNewPropagationIsMonitoredSeparately() {
+        // given.
+        propagationTestHelper.outerRequiredMethod("ParentOwner");
+
+        // when.
+        String responseBody = getMonitoringResponse();
+
+        // then.
+        assertThatJson(responseBody)
+                .when(IGNORING_ARRAY_ORDER)
+                .isEqualTo("{\n" + "  \"entrypoints\" : [\n"
+                        + "    {\n"
+                        + "      \"className\" : \"com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper\",\n"
+                        + "      \"methodName\" : \"saveRequiresNew\",\n"
+                        + "      \"executions\" : [\n"
+                        + "        {\n"
+                        + "          \"startTimestampMs\" : \"#{json-unit.ignore}\",\n"
+                        + "          \"endTimestampMs\" : \"#{json-unit.ignore}\",\n"
+                        + "          \"queries\" : [\n"
+                        + "            {\n"
+                        + "              \"sql\" : \"insert into owner (id, last_name) values (default, ?)\",\n"
+                        + "              \"startTimestampMs\" : \"#{json-unit.ignore}\",\n"
+                        + "              \"endTimestampMs\" : \"#{json-unit.ignore}\"\n"
+                        + "            }\n"
+                        + "          ]\n"
+                        + "        }\n"
+                        + "      ],\n"
+                        + "      \"executionStats\" : {\n"
+                        + "        \"averageDurationMs\" : \"#{json-unit.ignore}\",\n"
+                        + "        \"maxDurationMs\" : \"#{json-unit.ignore}\",\n"
+                        + "        \"medianDurationMs\" : \"#{json-unit.ignore}\"\n"
+                        + "      }\n"
+                        + "    },\n"
+                        + "    {\n"
+                        + "      \"className\" : \"com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper\",\n"
+                        + "      \"methodName\" : \"outerRequiredMethod\",\n"
+                        + "      \"executions\" : [\n"
+                        + "        {\n"
+                        + "          \"startTimestampMs\" : \"#{json-unit.ignore}\",\n"
+                        + "          \"endTimestampMs\" : \"#{json-unit.ignore}\",\n"
+                        + "          \"queries\" : [\n"
+                        + "            {\n"
+                        + "              \"sql\" : \"insert into owner (id, last_name) values (default, ?)\",\n"
+                        + "              \"startTimestampMs\" : \"#{json-unit.ignore}\",\n"
+                        + "              \"endTimestampMs\" : \"#{json-unit.ignore}\"\n"
+                        + "            },\n"
+                        + "            {\n"
+                        + "              \"sql\" : \"insert into owner (id, last_name) values (default, ?)\",\n"
+                        + "              \"startTimestampMs\" : \"#{json-unit.ignore}\",\n"
+                        + "              \"endTimestampMs\" : \"#{json-unit.ignore}\"\n"
+                        + "            }\n"
+                        + "          ]\n"
+                        + "        }\n"
+                        + "      ],\n"
+                        + "      \"executionStats\" : {\n"
+                        + "        \"averageDurationMs\" : \"#{json-unit.ignore}\",\n"
+                        + "        \"maxDurationMs\" : \"#{json-unit.ignore}\",\n"
+                        + "        \"medianDurationMs\" : \"#{json-unit.ignore}\"\n"
+                        + "      }\n"
+                        + "    }\n"
+                        + "  ]\n"
+                        + "}");
+    }
+
+    @Test
+    void nestedPropagationIsMonitored() {
+        // given.
+        propagationTestHelper.testNested();
+
+        // when.
+        String responseBody = getMonitoringResponse();
+
+        // then.
+        assertThatJson(responseBody)
+                // language=json
+                .isEqualTo("{\n" + "  \"entrypoints\" : [\n"
+                        + "    {\n"
+                        + "      \"className\" : \"com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper\",\n"
+                        + "      \"methodName\" : \"testNested\",\n"
+                        + "      \"executions\" : [\n"
+                        + "        {\n"
+                        + "          \"startTimestampMs\" : \"#{json-unit.ignore}\",\n"
+                        + "          \"endTimestampMs\" : \"#{json-unit.ignore}\",\n"
+                        + "          \"queries\" : [\n"
+                        + "            {\n"
+                        + "              \"sql\" : \"select transactio0_.id as id1_0_, transactio0_.last_name as last_nam2_0_ from owner transactio0_ where transactio0_.last_name=?\",\n"
+                        + "              \"startTimestampMs\" : \"#{json-unit.ignore}\",\n"
+                        + "              \"endTimestampMs\" : \"#{json-unit.ignore}\"\n"
+                        + "            }\n"
+                        + "          ]\n"
+                        + "        }\n"
+                        + "      ],\n"
+                        + "      \"executionStats\" : {\n"
+                        + "        \"averageDurationMs\" : \"#{json-unit.ignore}\",\n"
+                        + "        \"maxDurationMs\" : \"#{json-unit.ignore}\",\n"
+                        + "        \"medianDurationMs\" : \"#{json-unit.ignore}\"\n"
+                        + "      }\n"
+                        + "    }\n"
+                        + "  ]\n"
+                        + "}");
+    }
+
+    @Test
     void notSupportedPropagationIsNotMonitored() {
         // given.
         propagationTestHelper.testNotSupported("Rodriquez");
@@ -406,19 +511,6 @@ class TransactionMonitoringEndpointTest {
 
         // then.
         assertThatJson(responseBody).node("entrypoints").isArray().isEmpty();
-    }
-
-    @Test
-    void nestedPropagationIsMonitored() {
-        // given.
-        propagationTestHelper.testNested();
-
-        // when.
-        String responseBody = getMonitoringResponse();
-        List<String> methodNames = JsonPath.read(responseBody, "$.entrypoints[*].methodName");
-
-        // then.
-        assertThat(methodNames).contains("testNested");
     }
 
     @ProtectedEndpointTests(
@@ -473,8 +565,9 @@ class TransactionMonitoringEndpointTest {
         }
 
         @Bean
-        public PropagationTestHelper propagationTestHelper(OwnerRepository ownerRepository) {
-            return new PropagationTestHelper(ownerRepository);
+        public PropagationTestHelper propagationTestHelper(
+                OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
+            return new PropagationTestHelper(ownerRepository, self);
         }
     }
 
@@ -545,9 +638,21 @@ class TransactionMonitoringEndpointTest {
     static class PropagationTestHelper {
 
         private final OwnerRepository ownerRepository;
+        private final PropagationTestHelper self;
 
-        public PropagationTestHelper(OwnerRepository ownerRepository) {
+        public PropagationTestHelper(OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
             this.ownerRepository = ownerRepository;
+            this.self = self;
+        }
+
+        // IMPORTANT: Calling via 'self' proxy is required to properly test the REQUIRED -> REQUIRES_NEW stack behavior.
+        @Transactional(propagation = Propagation.REQUIRED)
+        public void outerRequiredMethod(String outerName) {
+            ownerRepository.save(new Owner().setLastName(outerName));
+
+            self.saveRequiresNew("SomeName");
+
+            ownerRepository.save(new Owner().setLastName(outerName));
         }
 
         @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
@@ -488,7 +488,7 @@ class TransactionMonitoringEndpointTest {
     }
 
     @Test
-    void supportsPropagationWithExistingTransaction() {
+    void supportsPropagationWithExistingTransactionShouldNotOpenATransaction() {
         // given.
         transactionTemplate.executeWithoutResult(status -> {
             propagationTestHelper.testSupports("Rodriquez");

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringInterceptor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringInterceptor.java
@@ -70,7 +70,7 @@ public class TransactionMonitoringInterceptor implements MethodInterceptor {
             long startTimestampMs = System.currentTimeMillis();
             long txStartTime = System.nanoTime();
 
-            queriesCollector.clearAll();
+            queriesCollector.startNewContext();
 
             // METRICS. Create transaction status
             TransactionStatus transactionStatus = TransactionStatus.SUCCESS;

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -164,15 +164,15 @@ class TransactionMonitoringAutoConfigurationTest {
     static class CustomDefaultQueriesRecorder implements QueriesRecorder {
 
         @Override
+        public void startNewContext() {}
+
+        @Override
         public void recordQuery(SqlQueryRecord query) {}
 
         @Override
         public List<SqlQueryRecord> popAllRecords() {
             return List.of();
         }
-
-        @Override
-        public void clearAll() {}
     }
 
     static class CustomTransactionMonitoringService extends DefaultTransactionMonitoringService {

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
@@ -47,6 +47,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.http.HttpMethod;
@@ -66,6 +67,7 @@ import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
 import static com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricNames.TRANSACTION_DURATION;
 import static com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricNames.TRANSACTION_QUERIES;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -413,6 +415,111 @@ class TransactionMonitoringEndpointTest {
     }
 
     @Test
+    void nestedRequiresNewPropagationIsMonitoredSeparately() {
+        // given.
+        propagationTestHelper.outerRequiredMethod("ParentOwner");
+
+        // when.
+        String responseBody = getMonitoringResponse();
+
+        // then.
+        assertThatJson(responseBody)
+                .when(IGNORING_ARRAY_ORDER)
+                .isEqualTo(
+                        // language=json
+                        """
+        {
+          "entrypoints" : [
+            {
+              "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+              "methodName" : "saveRequiresNew",
+              "executions" : [ {
+                "startTimestampMs" : "#{json-unit.ignore}",
+                "endTimestampMs" : "#{json-unit.ignore}",
+                "queries" : [
+                  {
+                    "sql" : "insert into owner (id, last_name) values (default, ?)",
+                    "startTimestampMs" : "#{json-unit.ignore}",
+                    "endTimestampMs" : "#{json-unit.ignore}"
+                  }
+                ]
+              } ],
+              "executionStats" : {
+                "averageDurationMs" : "#{json-unit.ignore}",
+                "maxDurationMs" : "#{json-unit.ignore}",
+                "medianDurationMs" : "#{json-unit.ignore}"
+              }
+            },
+            {
+              "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+              "methodName" : "outerRequiredMethod",
+              "executions" : [ {
+                "startTimestampMs" : "#{json-unit.ignore}",
+                "endTimestampMs" : "#{json-unit.ignore}",
+                "queries" : [
+                  {
+                    "sql" : "insert into owner (id, last_name) values (default, ?)",
+                    "startTimestampMs" : "#{json-unit.ignore}",
+                    "endTimestampMs" : "#{json-unit.ignore}"
+                  },
+                  {
+                    "sql" : "insert into owner (id, last_name) values (default, ?)",
+                    "startTimestampMs" : "#{json-unit.ignore}",
+                    "endTimestampMs" : "#{json-unit.ignore}"
+                  }
+                ]
+              } ],
+              "executionStats" : {
+                "averageDurationMs" : "#{json-unit.ignore}",
+                "maxDurationMs" : "#{json-unit.ignore}",
+                "medianDurationMs" : "#{json-unit.ignore}"
+              }
+            }
+          ]
+        }
+    """);
+    }
+
+    @Test
+    void nestedPropagationIsMonitored() {
+        // given.
+        propagationTestHelper.testNested();
+
+        // when.
+        String responseBody = getMonitoringResponse();
+
+        // then.
+        assertThatJson(responseBody)
+                .isEqualTo(
+                        // language=json
+                        """
+        {
+          "entrypoints" : [ {
+            "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+            "methodName" : "testNested",
+            "executions" : [ {
+              "startTimestampMs" : "#{json-unit.ignore}",
+              "endTimestampMs" : "#{json-unit.ignore}",
+              "queries" : [ {
+                "sql" : "select o1_0.id,o1_0.last_name from owner o1_0 where o1_0.last_name=?",
+                "startTimestampMs" : "#{json-unit.ignore}",
+                "endTimestampMs" : "#{json-unit.ignore}"
+              } ]
+            } ],
+            "executionStats" : {
+              "averageDurationMs" : "#{json-unit.ignore}",
+              "maxDurationMs" : "#{json-unit.ignore}",
+              "medianDurationMs" : "#{json-unit.ignore}"
+            }
+          } ]
+        }
+    """);
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "testNested", "success", 1);
+    }
+
+    @Test
     @Transactional
     void supportsPropagationWithExistingTransaction() {
         // given.
@@ -435,45 +542,6 @@ class TransactionMonitoringEndpointTest {
 
         // then.
         assertThatJson(responseBody).node("entrypoints").isArray().isEmpty();
-    }
-
-    @Test
-    void nestedPropagationIsMonitored() {
-        // given.
-        propagationTestHelper.testNested();
-
-        // when.
-        String responseBody = getMonitoringResponse();
-
-        // then.
-        assertThatJson(responseBody)
-                .isEqualTo(
-                        // language=json
-                        """
-                {
-                  "entrypoints" : [ {
-                    "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
-                    "methodName" : "testNested",
-                    "executions" : [ {
-                      "startTimestampMs" : "#{json-unit.ignore}",
-                      "endTimestampMs" : "#{json-unit.ignore}",
-                      "queries" : [ {
-                        "sql" : "select o1_0.id,o1_0.last_name from owner o1_0 where o1_0.last_name=?",
-                        "startTimestampMs" : "#{json-unit.ignore}",
-                        "endTimestampMs" : "#{json-unit.ignore}"
-                      } ]
-                    } ],
-                    "executionStats" : {
-                      "averageDurationMs" : "#{json-unit.ignore}",
-                      "maxDurationMs" : "#{json-unit.ignore}",
-                      "medianDurationMs" : "#{json-unit.ignore}"
-                    }
-                  } ]
-                }
-            """);
-
-        // and then. Verify that metrics were successfully published to MeterRegistry
-        checkMeterRegistry(expectedClassName, "testNested", "success", 1);
     }
 
     private void checkMeterRegistry(
@@ -558,8 +626,9 @@ class TransactionMonitoringEndpointTest {
         }
 
         @Bean
-        public PropagationTestHelper propagationTestHelper(OwnerRepository ownerRepository) {
-            return new PropagationTestHelper(ownerRepository);
+        public PropagationTestHelper propagationTestHelper(
+                OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
+            return new PropagationTestHelper(ownerRepository, self);
         }
 
         @Bean
@@ -640,9 +709,21 @@ class TransactionMonitoringEndpointTest {
     static class PropagationTestHelper {
 
         private final OwnerRepository ownerRepository;
+        private final PropagationTestHelper self;
 
-        public PropagationTestHelper(OwnerRepository ownerRepository) {
+        public PropagationTestHelper(OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
             this.ownerRepository = ownerRepository;
+            this.self = self;
+        }
+
+        // IMPORTANT: Calling via 'self' proxy is required to properly test the REQUIRED -> REQUIRES_NEW stack behavior.
+        @Transactional(propagation = Propagation.REQUIRED)
+        public void outerRequiredMethod(String outerName) {
+            ownerRepository.save(new Owner().setLastName(outerName));
+
+            self.saveRequiresNew("SomeName");
+
+            ownerRepository.save(new Owner().setLastName(outerName));
         }
 
         @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
@@ -521,7 +521,7 @@ class TransactionMonitoringEndpointTest {
 
     @Test
     @Transactional
-    void supportsPropagationWithExistingTransaction() {
+    void supportsPropagationWithExistingTransactionShouldNotOpenATransaction() {
         // given.
         propagationTestHelper.testSupports("Rodriquez");
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultQueriesRecorder.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultQueriesRecorder.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.core.transactions;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Deque;
 import java.util.List;
 
 /**

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultQueriesRecorder.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultQueriesRecorder.java
@@ -27,17 +27,18 @@ import java.util.List;
  *
  * @author Sergey Cherkasov
  * @author Nikita Kirillov
+ * @author Mikhail Polivakha
  */
 public final class DefaultQueriesRecorder implements QueriesRecorder {
 
-    private final ThreadLocal<Deque<List<SqlQueryRecord>>> threadLocalStack = new ThreadLocal<>();
+    private static final ThreadLocal<QueriesStack> threadLocalStack = new ThreadLocal<>();
 
     @Override
     public void startNewContext() {
-        Deque<List<SqlQueryRecord>> stack = threadLocalStack.get();
+        QueriesStack stack = threadLocalStack.get();
 
         if (stack == null) {
-            stack = new ArrayDeque<>();
+            stack = new QueriesStack();
             threadLocalStack.set(stack);
         }
 
@@ -46,13 +47,14 @@ public final class DefaultQueriesRecorder implements QueriesRecorder {
 
     @Override
     public void recordQuery(SqlQueryRecord query) {
-        Deque<List<SqlQueryRecord>> stack = threadLocalStack.get();
+        QueriesStack stack = threadLocalStack.get();
 
         if (stack == null) {
             return;
         }
 
         List<SqlQueryRecord> currentTxQueries = stack.peek();
+
         if (currentTxQueries != null) {
             currentTxQueries.add(query);
         }
@@ -60,7 +62,7 @@ public final class DefaultQueriesRecorder implements QueriesRecorder {
 
     @Override
     public List<SqlQueryRecord> popAllRecords() {
-        Deque<List<SqlQueryRecord>> stack = threadLocalStack.get();
+        QueriesStack stack = threadLocalStack.get();
 
         if (stack == null || stack.isEmpty()) {
             return new ArrayList<>();
@@ -73,5 +75,20 @@ public final class DefaultQueriesRecorder implements QueriesRecorder {
         }
 
         return queries;
+    }
+
+    /**
+     * A convenient type-alias for the stack-like data structure of sql queries, executed within the given transactions.
+     * <p>
+     * We need a stack to account for REQUIRES_NEW transaction isolation level.
+     *
+     * @author Mikhail Polivakha
+     * @author Nikita Kirillov
+     */
+    static class QueriesStack extends ArrayDeque<List<SqlQueryRecord>> {
+
+        public QueriesStack() {
+            super(1); // assume no REQUIRES_NEW transactions by default
+        }
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultQueriesRecorder.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultQueriesRecorder.java
@@ -17,32 +17,61 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.transactions;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 
 /**
  * Service providing access to queries in transaction monitoring data and statistics.
  *
  * @author Sergey Cherkasov
+ * @author Nikita Kirillov
  */
 public final class DefaultQueriesRecorder implements QueriesRecorder {
 
-    private final ThreadLocal<List<SqlQueryRecord>> threadLocal = ThreadLocal.withInitial(ArrayList::new);
+    private final ThreadLocal<Deque<List<SqlQueryRecord>>> threadLocalStack = new ThreadLocal<>();
+
+    @Override
+    public void startNewContext() {
+        Deque<List<SqlQueryRecord>> stack = threadLocalStack.get();
+
+        if (stack == null) {
+            stack = new ArrayDeque<>();
+            threadLocalStack.set(stack);
+        }
+
+        stack.push(new ArrayList<>());
+    }
 
     @Override
     public void recordQuery(SqlQueryRecord query) {
-        threadLocal.get().add(query);
+        Deque<List<SqlQueryRecord>> stack = threadLocalStack.get();
+
+        if (stack == null) {
+            return;
+        }
+
+        List<SqlQueryRecord> currentTxQueries = stack.peek();
+        if (currentTxQueries != null) {
+            currentTxQueries.add(query);
+        }
     }
 
     @Override
     public List<SqlQueryRecord> popAllRecords() {
-        List<SqlQueryRecord> queries = new ArrayList<>(threadLocal.get());
-        threadLocal.remove();
-        return queries;
-    }
+        Deque<List<SqlQueryRecord>> stack = threadLocalStack.get();
 
-    @Override
-    public void clearAll() {
-        threadLocal.remove();
+        if (stack == null || stack.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<SqlQueryRecord> queries = stack.pop();
+
+        if (stack.isEmpty()) {
+            threadLocalStack.remove();
+        }
+
+        return queries;
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/QueriesRecorder.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/QueriesRecorder.java
@@ -47,7 +47,7 @@ public interface QueriesRecorder {
      * Pops all query statistics collected within the particular transaction
      * (i.e. the history of queries is removed from {@link QueriesRecorder})
      *
-     * @return list ща query statistics
+     * @return list of query statistics
      */
     List<SqlQueryRecord> popAllRecords();
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/QueriesRecorder.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/QueriesRecorder.java
@@ -21,15 +21,23 @@ import java.util.List;
 
 /**
  * Recorder of the SQL queries. It assumes that all sequentially related queries
- * are executed within a single Thread.
+ * are executed within a single Thread. Implementations must support nested transaction isolation levels
+ * by treating query registration context as a stack hierarchy.
  *
  * @author Sergey Cherkasov
  * @author Mikhail Polivakha
+ * @author Nikita Kirillov
  */
 public interface QueriesRecorder {
 
     /**
-     * Records a query execution for statistics collection.
+     * Initializes a new isolated context layer for query collection.
+     * Must be called at the start of a transaction scope to protect parent transaction data from being overwritten.
+     */
+    void startNewContext();
+
+    /**
+     * Records a query execution for statistics collection within the current transaction scope.
      *
      * @param query the query execution record
      */
@@ -42,9 +50,4 @@ public interface QueriesRecorder {
      * @return list ща query statistics
      */
     List<SqlQueryRecord> popAllRecords();
-
-    /**
-     * Clears all collected query statistics.
-     */
-    void clearAll();
 }


### PR DESCRIPTION
close #1163 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction monitoring now isolates SQL query collection per transaction context, ensuring queries from nested transactions are attributed to the correct entrypoint.

* **Tests**
  * Expanded integration tests verifying nested transaction propagation (REQUIRED → REQUIRES_NEW) are reported as separate monitored entrypoints and JSON results are compared order-insensitively.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->