### PR TITLE
[SECURITY][CRITICAL] Fix CVE-2026-43512 in org.apache.tomcat.embed:tomcat-embed-core

### DIFF
--- a/master/build.gradle.kts
+++ b/master/build.gradle.kts
@@ -11,12 +11,16 @@ plugins {
 val springBootVersion = "4.1.0-RC1"
 val springCloudVersion = "2025.1.1"
 val springAiVersion = "2.0.0-M8"
+
+// Not Managed by Spring BOM
 val testcontainersVersion = "1.21.4"
 val springDocSwaggerVersion = "3.0.3"
-val tomcatVersion = "11.0.22"
 val sqliteVersion = "3.53.1.0"
 val nimbusJoseJwt ="10.9.1"
 val jmesPathVersion = "0.6.0"
+
+// Explicitly specified versions for security reasons (i.e. using some specific patch versions)
+val tomcatVersion = "11.0.22"
 
 dependencies {
     // Self
@@ -29,6 +33,8 @@ dependencies {
     implementation(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
     implementation(platform("org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"))
     implementation(platform("org.springframework.ai:spring-ai-bom:${springAiVersion}"))
+
+    // Security Patches
     constraints {
         implementation("org.apache.tomcat.embed:tomcat-embed-core:$tomcatVersion")
         implementation("org.apache.tomcat.embed:tomcat-embed-el:$tomcatVersion")

--- a/master/build.gradle.kts
+++ b/master/build.gradle.kts
@@ -13,6 +13,7 @@ val springCloudVersion = "2025.1.1"
 val springAiVersion = "2.0.0-M8"
 val testcontainersVersion = "1.21.4"
 val springDocSwaggerVersion = "3.0.3"
+val tomcatVersion = "11.0.22"
 val sqliteVersion = "3.53.1.0"
 val nimbusJoseJwt ="10.9.1"
 val jmesPathVersion = "0.6.0"
@@ -28,6 +29,11 @@ dependencies {
     implementation(platform("org.springframework.boot:spring-boot-dependencies:${springBootVersion}"))
     implementation(platform("org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"))
     implementation(platform("org.springframework.ai:spring-ai-bom:${springAiVersion}"))
+    constraints {
+        implementation("org.apache.tomcat.embed:tomcat-embed-core:$tomcatVersion")
+        implementation("org.apache.tomcat.embed:tomcat-embed-el:$tomcatVersion")
+        implementation("org.apache.tomcat.embed:tomcat-embed-websocket:$tomcatVersion")
+    }
 
     // Boot Starters
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")


### PR DESCRIPTION
## Summary
- Fixes CRITICAL `CVE-2026-43512` in `org.apache.tomcat.embed:tomcat-embed-core` for the `master` module.
- Adds a minimal Gradle dependency constraint override in `master/build.gradle.kts` to pin the embedded Tomcat artifacts to `11.0.22` instead of the Spring Boot BOM's `11.0.21`.
- This is safe for a patch release because it is a same-major Tomcat patch bump confined to the `master` module's server runtime packaging, with no public API, REST contract, starter configuration contract, or user-visible workflow changes.
- The same Tomcat `11.0.22` bump is also expected to clear the sibling CRITICAL Tomcat alerts in `master` for `CVE-2026-43515` and `CVE-2026-41293`.

## Test plan
- [x] `./gradlew :master:dependencyInsight --dependency tomcat-embed-core --configuration runtimeClasspath`
- [x] `./gradlew :master:test`
- [x] `./gradlew :master:bootJar`
- [x] Verified `master/build/libs/master.jar` now packages `BOOT-INF/lib/tomcat-embed-core-11.0.22.jar`, `BOOT-INF/lib/tomcat-embed-el-11.0.22.jar`, and `BOOT-INF/lib/tomcat-embed-websocket-11.0.22.jar`
- [x] No public API or contract changes were introduced

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned embedded Tomcat components to version 11.0.22 and introduced dependency constraints to enforce consistent versioning across all Tomcat-related artifacts. This reduces upgrade/patching risk, ensures uniform security fixes, and simplifies future maintenance without changing runtime behavior or other dependency/plugin configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->