### PR TITLE
[SECURITY][HIGH] Fix CVE-2026-4800 in lodash and lodash-es

### DIFF
--- a/master/front-end/package-lock.json
+++ b/master/front-end/package-lock.json
@@ -7837,16 +7837,16 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
             "dev": true,
             "license": "MIT"
         },


### PR DESCRIPTION
## Summary
- Fixes CVE-2026-4800 / GHSA-r5fr-rjxr-66jc for the transitive `lodash` and `lodash-es` dependencies used by `master/front-end`.
- Updates the locked `lodash` and `lodash-es` resolutions in `master/front-end/package-lock.json` from `4.17.23` to `4.18.1`, which is above the GitHub patched floor of `4.18.0`.
- This is safe for a patch release because it is a lockfile-only same-major transitive dependency update for developer tooling and does not change application code, public APIs, or public contracts.

## Test plan
- [x] `npm ci`
- [x] `npm ls lodash lodash-es`
- [x] `npm exec cypress --version`
- [x] `node -e "import('@trivago/prettier-plugin-sort-imports').then(() => console.log('plugin-ok'))"`
- [x] No public API or contract changes were introduced.

Made with [Cursor](https://cursor.com)