### PR TITLE
[SECURITY][HIGH] Fix CVE-2026-44705 in tmp

### DIFF
--- a/master/front-end/package-lock.json
+++ b/master/front-end/package-lock.json
@@ -10568,9 +10568,9 @@
             "license": "MIT"
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
             "license": "MIT",
             "engines": {


### PR DESCRIPTION
## Summary
- fix `CVE-2026-44705` / `GHSA-ph9p-34f9-6g65` in the master front-end dependency tree
- update the resolved transitive `tmp` package in `master/front-end/package-lock.json` from `0.2.5` to `0.2.7`
- keep the remediation patch-safe by limiting the change to a same-major lockfile-only dependency refresh with no public API or contract changes

## Test plan
- [x] `cd master/front-end && npm update tmp --package-lock-only`
- [x] `cd master/front-end && npm ci`
- [x] `cd master/front-end && npm ls tmp`
- [x] `cd master/front-end && node -p "require('cypress/package.json').version"`
- [x] no public API or contract changes were introduced


Made with [Cursor](https://cursor.com)