### PR TITLE
[SECURITY][HIGH] Fix CVE-2026-44724 in systeminformation

### DIFF
--- a/master/front-end/package-lock.json
+++ b/master/front-end/package-lock.json
@@ -10393,9 +10393,9 @@
             }
         },
         "node_modules/systeminformation": {
-            "version": "5.31.5",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.5.tgz",
-            "integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
+            "version": "5.31.7",
+            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.7.tgz",
+            "integrity": "sha512-/8NC53e5nP9nmhn42/ncdOkyJnOoue/Vy+tJOyUGd1Yv66G069wK4rrziwhrqDETgk78CudTQupw5z19S5uoZw==",
             "dev": true,
             "license": "MIT",
             "os": [


### PR DESCRIPTION
## Summary
- fix `CVE-2026-44724` / `GHSA-hvx9-hwr7-wjj9` in the master front-end dependency tree
- update the resolved transitive `systeminformation` package in `master/front-end/package-lock.json` from `5.31.5` to `5.31.7`
- keep the remediation patch-safe by limiting the change to a same-major lockfile-only dependency refresh with no public API or contract changes

## Test plan
- [x] `cd master/front-end && npm update systeminformation --package-lock-only`
- [x] `cd master/front-end && npm ci`
- [x] `cd master/front-end && npm ls systeminformation`
- [x] `cd master/front-end && npm exec -- cypress --version`
- [x] `cd master/front-end && node -p "require('cypress/package.json').version"`
- [x] no public API or contract changes were introduced


Made with [Cursor](https://cursor.com)