### PR TITLE
[SECURITY][HIGH] Fix CVE-2026-6322 in fast-uri

### DIFF
--- a/master/front-end/package-lock.json
+++ b/master/front-end/package-lock.json
@@ -5749,9 +5749,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {


### PR DESCRIPTION
## Summary
- fix `CVE-2026-6322` / `GHSA-v39h-62p7-jpjc` in the master front-end dependency tree
- update the resolved transitive `fast-uri` package in `master/front-end/package-lock.json` from `3.1.0` to `3.1.2`
- keep the remediation patch-safe by limiting the change to a same-major lockfile-only dependency refresh with no public API or contract changes

## Test plan
- [x] `cd master/front-end && npm update fast-uri --package-lock-only`
- [x] `cd master/front-end && npm ci`
- [x] `cd master/front-end && npm ls fast-uri`
- [x] `cd master/front-end && npm run lint-css`
- [x] no public API or contract changes were introduced


Made with [Cursor](https://cursor.com)