### PR TITLE
[SECURITY][MEDIUM] Fix CVE-2026-8723 in qs

### DIFF
--- a/master/front-end/package-lock.json
+++ b/master/front-end/package-lock.json
@@ -626,9 +626,9 @@
             }
         },
         "node_modules/@cypress/request": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.0.tgz",
-            "integrity": "sha512-wGTQfwDMMMiz/muFw4YbCLwTh0uZsXKK+6zWBzftADpitSi6iM62C8GzEhNcng2srUiGPksOriQkA8zakW2R0g==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-4.0.1.tgz",
+            "integrity": "sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -645,7 +645,7 @@
                 "json-stringify-safe": "~5.0.1",
                 "mime-types": "~2.1.19",
                 "performance-now": "^2.1.0",
-                "qs": "~6.14.1",
+                "qs": "^6.15.2",
                 "safe-buffer": "^5.1.2",
                 "tough-cookie": "^5.0.0",
                 "tunnel-agent": "^0.6.0"
@@ -8961,9 +8961,9 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {


### PR DESCRIPTION
## Summary
- fix `CVE-2026-8723` / `GHSA-q8mj-m7cp-5q26` in the master front-end dependency tree
- update the `@cypress/request` subtree in `master/front-end/package-lock.json`, which resolves `qs` from `6.14.2` to `6.15.2`
- keep the remediation patch-safe by limiting the change to a lockfile-only transitive dependency refresh with no public API or contract changes

## Test plan
- [x] `cd master/front-end && npm update @cypress/request --package-lock-only`
- [x] `cd master/front-end && npm ci`
- [x] `cd master/front-end && npm ls @cypress/request qs`
- [x] `cd master/front-end && npm exec -- cypress --version`
- [x] `cd master/front-end && node -p "require('cypress/package.json').version"`
- [x] no public API or contract changes were introduced


Made with [Cursor](https://cursor.com)