### PR TITLE
[SECURITY][BATCH] Update master backend runtime dependencies

### DIFF
--- a/master/build.gradle.kts
+++ b/master/build.gradle.kts
@@ -20,7 +20,10 @@ val nimbusJoseJwt ="10.9.1"
 val jmesPathVersion = "0.6.0"
 
 // Explicitly specified versions for security reasons (i.e. using some specific patch versions)
+val postgresqlVersion = "42.7.11"
+val nettyVersion = "4.2.15.Final"
 val tomcatVersion = "11.0.22"
+val vertxVersion = "4.5.28"
 
 dependencies {
     // Self
@@ -35,7 +38,11 @@ dependencies {
     implementation(platform("org.springframework.ai:spring-ai-bom:${springAiVersion}"))
 
     // Security Patches
+    implementation(platform("io.netty:netty-bom:${nettyVersion}"))
+    implementation(platform("io.vertx:vertx-stack-depchain:${vertxVersion}"))
+
     constraints {
+        implementation("org.postgresql:postgresql:$postgresqlVersion")
         implementation("org.apache.tomcat.embed:tomcat-embed-core:$tomcatVersion")
         implementation("org.apache.tomcat.embed:tomcat-embed-el:$tomcatVersion")
         implementation("org.apache.tomcat.embed:tomcat-embed-websocket:$tomcatVersion")

--- a/master/src/main/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcePathSanitizer.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcePathSanitizer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.filter;
+
+import org.jspecify.annotations.NonNull;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Utility class that validates the provided path (typically end-user supplied) to make sure it is safe to return.
+ *
+ * @author Mikhail Polivakha
+ */
+public class SpaStaticResourcePathSanitizer {
+
+    /**
+     * @param contextPath the path to check
+     * @return whether the path is considered safe or not.
+     */
+    public static boolean isSafe(@NonNull String contextPath) {
+        String relativePath = StringUtils.trimLeadingCharacter(contextPath, '/');
+
+        if (containsUnsafePathTokens(relativePath)) {
+            return false;
+        }
+
+        String cleanedRelativePath = StringUtils.cleanPath(relativePath);
+
+        return !isUnsafeCleanedPath(relativePath, cleanedRelativePath);
+    }
+
+    private static boolean containsUnsafePathTokens(String relativePath) {
+        return !StringUtils.hasText(relativePath)
+                || relativePath.contains("\\")
+                || relativePath.contains(":")
+                || relativePath.contains("//");
+    }
+
+    private static boolean isUnsafeCleanedPath(String relativePath, String cleanedRelativePath) {
+        return !StringUtils.hasText(cleanedRelativePath)
+                || cleanedRelativePath.startsWith("../")
+                || cleanedRelativePath.startsWith("/")
+                || !cleanedRelativePath.equals(relativePath);
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilter.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilter.java
@@ -30,7 +30,6 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.axelixlabs.axelix.master.autoconfiguration.web.WebProperties;
@@ -46,6 +45,7 @@ public class SpaStaticResourcesServingFilter extends OncePerRequestFilter {
     private final WebProperties webProperties;
     private final Resource indexHtmlLocation;
     private static final Map<String, MediaType> MEDIA_TYPES_CACHE;
+    private static final String INDEX_HTML_FILENAME = "index.html";
 
     static {
         // It is okay to just use HashMap here, there is no writing under contention here.
@@ -58,7 +58,7 @@ public class SpaStaticResourcesServingFilter extends OncePerRequestFilter {
 
     public SpaStaticResourcesServingFilter(WebProperties webProperties) throws IOException {
         this.webProperties = webProperties;
-        this.indexHtmlLocation = webProperties.getLocation().createRelative("index.html");
+        this.indexHtmlLocation = webProperties.getLocation().createRelative(INDEX_HTML_FILENAME);
     }
 
     @Override
@@ -95,45 +95,18 @@ public class SpaStaticResourcesServingFilter extends OncePerRequestFilter {
     }
 
     private Resource resolveResourceToReturn(String contextPath) throws IOException {
-        String relativePath = sanitizeRelativePath(contextPath);
-        Resource relative = webProperties.getLocation().createRelative(relativePath);
+        boolean isSafe = SpaStaticResourcePathSanitizer.isSafe(contextPath);
 
-        try {
-            return relative.exists() && relative.isReadable() ? relative : indexHtmlLocation;
-        } catch (IllegalArgumentException e) { // spring throws in certain scenarios
+        if (isSafe) {
+            Resource relative = webProperties.getLocation().createRelative(contextPath);
+
+            try {
+                return relative.exists() && relative.isReadable() ? relative : indexHtmlLocation;
+            } catch (IllegalArgumentException e) { // spring throws in certain scenarios
+                return indexHtmlLocation;
+            }
+        } else {
             return indexHtmlLocation;
         }
-    }
-
-    static String sanitizeRelativePath(String contextPath) {
-        if (!StringUtils.hasText(contextPath) || "/".equals(contextPath)) {
-            return "index.html";
-        }
-
-        String relativePath = StringUtils.trimLeadingCharacter(contextPath, '/');
-        if (containsUnsafePathTokens(relativePath)) {
-            return "index.html";
-        }
-
-        String cleanedRelativePath = StringUtils.cleanPath(relativePath);
-        if (isUnsafeCleanedPath(relativePath, cleanedRelativePath)) {
-            return "index.html";
-        }
-
-        return cleanedRelativePath;
-    }
-
-    private static boolean containsUnsafePathTokens(String relativePath) {
-        return !StringUtils.hasText(relativePath)
-                || relativePath.contains("\\")
-                || relativePath.contains(":")
-                || relativePath.contains("//");
-    }
-
-    private static boolean isUnsafeCleanedPath(String relativePath, String cleanedRelativePath) {
-        return !StringUtils.hasText(cleanedRelativePath)
-                || cleanedRelativePath.startsWith("../")
-                || cleanedRelativePath.startsWith("/")
-                || !cleanedRelativePath.equals(relativePath);
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilter.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilter.java
@@ -20,6 +20,7 @@ package com.axelixlabs.axelix.master.filter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,6 +31,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.axelixlabs.axelix.master.autoconfiguration.web.WebProperties;
@@ -42,6 +44,7 @@ import com.axelixlabs.axelix.master.autoconfiguration.web.WebProperties;
 @Order(FiltersOrder.SPA_STATIC_RESOURCES_SERVING_FILTER)
 public class SpaStaticResourcesServingFilter extends OncePerRequestFilter {
 
+    private static final Pattern SAFE_PATH_SEGMENT = Pattern.compile("[A-Za-z0-9._-]+");
     private final WebProperties webProperties;
     private final Resource indexHtmlLocation;
     private static final Map<String, MediaType> MEDIA_TYPES_CACHE;
@@ -94,12 +97,34 @@ public class SpaStaticResourcesServingFilter extends OncePerRequestFilter {
     }
 
     private Resource resolveResourceToReturn(String contextPath) throws IOException {
-        Resource relative = webProperties.getLocation().createRelative(contextPath);
+        String relativePath = sanitizeRelativePath(contextPath);
+        Resource relative = webProperties.getLocation().createRelative(relativePath);
 
         try {
             return relative.exists() && relative.isReadable() ? relative : indexHtmlLocation;
         } catch (IllegalArgumentException e) { // spring throws in certain scenarios
             return indexHtmlLocation;
         }
+    }
+
+    static String sanitizeRelativePath(String contextPath) {
+        if (!StringUtils.hasText(contextPath) || "/".equals(contextPath)) {
+            return "index.html";
+        }
+
+        String[] segments = StringUtils.delimitedListToStringArray(
+                StringUtils.trimLeadingCharacter(contextPath, '/'),
+                "/");
+
+        for (String segment : segments) {
+            if (!StringUtils.hasText(segment)
+                    || ".".equals(segment)
+                    || "..".equals(segment)
+                    || !SAFE_PATH_SEGMENT.matcher(segment).matches()) {
+                return "index.html";
+            }
+        }
+
+        return String.join("/", segments);
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilter.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilter.java
@@ -112,9 +112,8 @@ public class SpaStaticResourcesServingFilter extends OncePerRequestFilter {
             return "index.html";
         }
 
-        String[] segments = StringUtils.delimitedListToStringArray(
-                StringUtils.trimLeadingCharacter(contextPath, '/'),
-                "/");
+        String[] segments =
+                StringUtils.delimitedListToStringArray(StringUtils.trimLeadingCharacter(contextPath, '/'), "/");
 
         for (String segment : segments) {
             if (!StringUtils.hasText(segment)

--- a/master/src/main/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilter.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilter.java
@@ -20,7 +20,6 @@ package com.axelixlabs.axelix.master.filter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
@@ -44,7 +43,6 @@ import com.axelixlabs.axelix.master.autoconfiguration.web.WebProperties;
 @Order(FiltersOrder.SPA_STATIC_RESOURCES_SERVING_FILTER)
 public class SpaStaticResourcesServingFilter extends OncePerRequestFilter {
 
-    private static final Pattern SAFE_PATH_SEGMENT = Pattern.compile("[A-Za-z0-9._-]+");
     private final WebProperties webProperties;
     private final Resource indexHtmlLocation;
     private static final Map<String, MediaType> MEDIA_TYPES_CACHE;
@@ -112,18 +110,30 @@ public class SpaStaticResourcesServingFilter extends OncePerRequestFilter {
             return "index.html";
         }
 
-        String[] segments =
-                StringUtils.delimitedListToStringArray(StringUtils.trimLeadingCharacter(contextPath, '/'), "/");
-
-        for (String segment : segments) {
-            if (!StringUtils.hasText(segment)
-                    || ".".equals(segment)
-                    || "..".equals(segment)
-                    || !SAFE_PATH_SEGMENT.matcher(segment).matches()) {
-                return "index.html";
-            }
+        String relativePath = StringUtils.trimLeadingCharacter(contextPath, '/');
+        if (containsUnsafePathTokens(relativePath)) {
+            return "index.html";
         }
 
-        return String.join("/", segments);
+        String cleanedRelativePath = StringUtils.cleanPath(relativePath);
+        if (isUnsafeCleanedPath(relativePath, cleanedRelativePath)) {
+            return "index.html";
+        }
+
+        return cleanedRelativePath;
+    }
+
+    private static boolean containsUnsafePathTokens(String relativePath) {
+        return !StringUtils.hasText(relativePath)
+                || relativePath.contains("\\")
+                || relativePath.contains(":")
+                || relativePath.contains("//");
+    }
+
+    private static boolean isUnsafeCleanedPath(String relativePath, String cleanedRelativePath) {
+        return !StringUtils.hasText(cleanedRelativePath)
+                || cleanedRelativePath.startsWith("../")
+                || cleanedRelativePath.startsWith("/")
+                || !cleanedRelativePath.equals(relativePath);
     }
 }

--- a/master/src/test/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilterPathSanitizationTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilterPathSanitizationTest.java
@@ -49,6 +49,8 @@ class SpaStaticResourcesServingFilterPathSanitizationTest {
                 "/",
                 "/../secrets.txt",
                 "/assets/../../secrets.txt",
+                "/assets/./main.js",
+                "/assets//main.js",
                 "/assets\\main.js",
                 "/assets:main.js",
             })

--- a/master/src/test/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilterPathSanitizationTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilterPathSanitizationTest.java
@@ -43,14 +43,15 @@ class SpaStaticResourcesServingFilterPathSanitizationTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-        "",
-        "/",
-        "/../secrets.txt",
-        "/assets/../../secrets.txt",
-        "/assets\\main.js",
-        "/assets:main.js",
-    })
+    @ValueSource(
+            strings = {
+                "",
+                "/",
+                "/../secrets.txt",
+                "/assets/../../secrets.txt",
+                "/assets\\main.js",
+                "/assets:main.js",
+            })
     void shouldFallbackToIndexHtmlForUnsafePaths(String contextPath) {
         // given.
         String inputPath = contextPath;

--- a/master/src/test/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilterPathSanitizationTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilterPathSanitizationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.filter;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpaStaticResourcesServingFilterPathSanitizationTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "/assets/main.js,assets/main.js",
+        "/assets/main-ABC.123.js,assets/main-ABC.123.js",
+        "/wallboard,wallboard",
+    })
+    void shouldKeepSafeRelativePaths(String contextPath, String expectedRelativePath) {
+        // given.
+        String inputPath = contextPath;
+
+        // when.
+        String sanitizedPath = SpaStaticResourcesServingFilter.sanitizeRelativePath(inputPath);
+
+        // then.
+        assertThat(sanitizedPath).isEqualTo(expectedRelativePath);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "",
+        "/",
+        "/../secrets.txt",
+        "/assets/../../secrets.txt",
+        "/assets\\main.js",
+        "/assets:main.js",
+    })
+    void shouldFallbackToIndexHtmlForUnsafePaths(String contextPath) {
+        // given.
+        String inputPath = contextPath;
+
+        // when.
+        String sanitizedPath = SpaStaticResourcesServingFilter.sanitizeRelativePath(inputPath);
+
+        // then.
+        assertThat(sanitizedPath).isEqualTo("index.html");
+    }
+}

--- a/master/src/test/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilterPathSanitizationTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/filter/SpaStaticResourcesServingFilterPathSanitizationTest.java
@@ -18,28 +18,28 @@
 package com.axelixlabs.axelix.master.filter;
 
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Unit tests for {@link SpaStaticResourcePathSanitizer}.
+ *
+ * @author Mikhail Polivakha
+ */
 class SpaStaticResourcesServingFilterPathSanitizationTest {
 
     @ParameterizedTest
-    @CsvSource({
-        "/assets/main.js,assets/main.js",
-        "/assets/main-ABC.123.js,assets/main-ABC.123.js",
-        "/wallboard,wallboard",
-    })
-    void shouldKeepSafeRelativePaths(String contextPath, String expectedRelativePath) {
-        // given.
-        String inputPath = contextPath;
+    @ValueSource(
+            strings = {
+                "/assets/main.js",
+                "/assets/main-ABC.123.js",
+                "/wallboard",
+            })
+    void shouldReportSafePaths(String contextPath) {
 
-        // when.
-        String sanitizedPath = SpaStaticResourcesServingFilter.sanitizeRelativePath(inputPath);
-
-        // then.
-        assertThat(sanitizedPath).isEqualTo(expectedRelativePath);
+        // when/then.
+        assertThat(SpaStaticResourcePathSanitizer.isSafe(contextPath)).isTrue();
     }
 
     @ParameterizedTest
@@ -55,13 +55,7 @@ class SpaStaticResourcesServingFilterPathSanitizationTest {
                 "/assets:main.js",
             })
     void shouldFallbackToIndexHtmlForUnsafePaths(String contextPath) {
-        // given.
-        String inputPath = contextPath;
-
-        // when.
-        String sanitizedPath = SpaStaticResourcesServingFilter.sanitizeRelativePath(inputPath);
-
-        // then.
-        assertThat(sanitizedPath).isEqualTo("index.html");
+        // when/then.
+        assertThat(SpaStaticResourcePathSanitizer.isSafe(contextPath)).isFalse();
     }
 }


### PR DESCRIPTION
## Summary
- update the `master` backend runtime dependency surface to `org.postgresql:postgresql:42.7.11`, Netty `4.2.15.Final`, and Vert.x `4.5.28` so the Trivy `master.jar` findings resolve to patched artifacts
- harden `SpaStaticResourcesServingFilter` so unsafe request paths fall back to `index.html`, which fixes the open `java/path-injection` CodeQL alert without changing public REST or starter contracts
- add focused regression coverage for SPA path sanitization and keep the existing `master` backend API surface unchanged

## Test plan
- [x] `./gradlew spotlessApply :master:build`
- [x] `./gradlew :master:test --tests "com.axelixlabs.axelix.master.filter.SpaStaticResourcesServingFilterTest" --tests "com.axelixlabs.axelix.master.filter.SpaStaticResourcesServingFilterPathSanitizationTest" :master:bootJar`
- [x] `./gradlew :master:dependencyInsight --dependency org.postgresql:postgresql --configuration runtimeClasspath`
- [x] `./gradlew :master:dependencyInsight --dependency io.netty:netty-codec-http --configuration runtimeClasspath`
- [x] `./gradlew :master:dependencyInsight --dependency io.vertx:vertx-core --configuration runtimeClasspath`
- [x] `./gradlew :master:dependencyInsight --dependency org.apache.tomcat.embed:tomcat-embed-core --configuration runtimeClasspath`
- [x] confirmed the built `master/build/libs/master.jar` contains the patched runtime JARs
- [x] no public API or contract changes were introduced

## Attribution
- `Authored by: Cursor`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enhanced path sanitization to prevent directory traversal attacks and unsafe file access.

* **Chores**
  * Updated dependencies including PostgreSQL, Netty, Tomcat, and Vertx for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->