### PR TITLE
GH-1121 Develop a policy for accessing secrets in the PRs from external contributors

### DIFF
--- a/.github/actions/build-master/action.yaml
+++ b/.github/actions/build-master/action.yaml
@@ -6,8 +6,7 @@ inputs:
     default: "false"
   gradle-cache-encryption-key:
     description: Gradle configuration cache encryption key
-    required: false
-    default: ""
+    required: true
 
 runs:
   using: composite

--- a/.github/actions/build-master/action.yaml
+++ b/.github/actions/build-master/action.yaml
@@ -4,9 +4,7 @@ inputs:
     description: Whether to deploy the built JAR into Nexus or not
     required: false
     default: "false"
-  gradle-cache-enryption-key:
-    description: Gradle cache encryption key
-    required: true
+
 runs:
   using: composite
   steps:
@@ -24,8 +22,9 @@ runs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
       with:
-        # Configuration Cache in encrypted with this key
-        cache-encryption-key: ${{ inputs.gradle-cache-enryption-key }}
+        # Configuration Cache in encrypted with this key.
+        # Fallback to an empty string on fork PRs where Bitwarden secrets are unavailable.
+        cache-encryption-key: ${{ env.SANDBOX_GRADLE_CACHE_ENCRYPTION_KEY || '' }}
         # See https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#using-the-cache-read-only
         cache-read-only: false
 

--- a/.github/actions/build-master/action.yaml
+++ b/.github/actions/build-master/action.yaml
@@ -4,6 +4,10 @@ inputs:
     description: Whether to deploy the built JAR into Nexus or not
     required: false
     default: "false"
+  gradle-cache-encryption-key:
+    description: Gradle configuration cache encryption key
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -23,8 +27,7 @@ runs:
       uses: gradle/actions/setup-gradle@v4
       with:
         # Configuration Cache in encrypted with this key.
-        # Fallback to an empty string on fork PRs where Bitwarden secrets are unavailable.
-        cache-encryption-key: ${{ env.SANDBOX_GRADLE_CACHE_ENCRYPTION_KEY || '' }}
+        cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
         # See https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#using-the-cache-read-only
         cache-read-only: false
 

--- a/.github/workflows/backend_pull_requests.yaml
+++ b/.github/workflows/backend_pull_requests.yaml
@@ -59,3 +59,5 @@ jobs:
 
       - name: Build Backend
         uses: ./.github/actions/build-master
+        with:
+          gradle-cache-encryption-key: ''

--- a/.github/workflows/backend_pull_requests.yaml
+++ b/.github/workflows/backend_pull_requests.yaml
@@ -2,11 +2,28 @@ name: Backend Pull Requests
 
 on:
   pull_request:
+    branches: [ master ]
     paths:
+      # Build logic, and application modules
       - 'master/**'
+      - '!master/front-end/**'
       - 'sbs/**'
       - 'common/**'
-    branches: [ master ]
+
+      # Core Gradle build configuration
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradlew'
+      - 'gradlew.bat'
+
+      # Code quality, formatting, and license configurations
+      - 'pmd.ruleset.xml'
+      - '.editorconfig'
+      - 'LICENSE'
+      - 'LICENSE_HEADER'
 
 concurrency:
   # Unique ID of the concurrency group, which cancels an already running workflow for this PR (if any)
@@ -40,12 +57,5 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Loading Secrets
-        uses: ./.github/actions/bitwarden
-        with:
-          bw-access-token: ${{ secrets.BW_ACCESS_TOKEN }}
-
       - name: Build Backend
         uses: ./.github/actions/build-master
-        with:
-          gradle-cache-enryption-key: ${{ env.SANDBOX_GRADLE_CACHE_ENCRYPTION_KEY }}

--- a/.github/workflows/check_linked_issues_pull_requests.yaml
+++ b/.github/workflows/check_linked_issues_pull_requests.yaml
@@ -6,7 +6,6 @@ on:
       - 'master/**'
       - 'sbs/**'
       - 'common/**'
-      - 'front-end/**'
     branches: [ master ]
 
 concurrency:

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -10,15 +10,33 @@ on:
         default: 'main'
   push:
     branches: [ master ]
-    paths-ignore:
-      - 'infra/**'
+    paths:
+      # CI/CD configuration
+      - '.github/**'
+
+      # Docker
+      - 'Dockerfile'
+
+      # Build logic, and application modules
+      - 'axelix-enterprise' # Tracks changes to the Git submodule pointer (gitlink)
+      - 'common/**'
+      - 'master/**'
+      - 'sbs/**'
+
+      # Core Gradle build configuration
+      - 'buildSrc/**'
+      - 'gradle/**'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradlew'
+      - 'gradlew.bat'
+
+      # Code quality, formatting, and license configurations
+      - 'pmd.ruleset.xml'
       - '.editorconfig'
-      - '.gitignore'
-      - 'docs'
-      - 'website'
-      - '.cursor'
-      - '.coderabbit.yaml'
-      - 'CONTRIBUTING.adoc'
+      - 'LICENSE'
+      - 'LICENSE_HEADER'
 
 jobs:
   build-deploy-source:
@@ -57,7 +75,6 @@ jobs:
         uses: ./.github/actions/build-master
         with:
           deploy-to-nexus: true
-          gradle-cache-enryption-key: ${{ env.SANDBOX_GRADLE_CACHE_ENCRYPTION_KEY }}
 
       - name: Set up Docker
         uses: docker/setup-docker-action@v5

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -75,6 +75,7 @@ jobs:
         uses: ./.github/actions/build-master
         with:
           deploy-to-nexus: true
+          gradle-cache-encryption-key: ${{ env.SANDBOX_GRADLE_CACHE_ENCRYPTION_KEY }}
 
       - name: Set up Docker
         uses: docker/setup-docker-action@v5


### PR DESCRIPTION
close #1121 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined CI/CD triggers to better target backend changes and exclude front-end-only edits.
  * Converted broad ignore filters to explicit allowlists for deployment runs, reducing unnecessary pipeline executions.
  * Simplified Gradle cache encryption handling by correcting the cache-key input and removing the prior secret-loading step from automated builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->