### PR TITLE
GH-1180: Port test layer to Spring Boot 4 starter

### DIFF
--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfigurationTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfo;
+import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
+import com.axelixlabs.axelix.sbs.spring.core.beans.BeansFeedBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.beans.CachingBeansFeedBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeansFeedBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.beans.QualifiersPersistencePostProcessor;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link AxelixBeansEndpointAutoConfiguration}
+ *
+ * @author Nikita Kirillov
+ */
+class AxelixBeansEndpointAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-beans")
+            .withConfiguration(AutoConfigurations.of(AxelixBeansEndpointAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(ConditionalBeanRefBuilder.class);
+            assertThat(context).hasSingleBean(BeanMetaInfoExtractor.class);
+            assertThat(context).hasSingleBean(AxelixBeansEndpoint.class);
+            assertThat(context).hasSingleBean(QualifiersPersistencePostProcessor.class);
+
+            assertThat(context).getBeans(BeansFeedBuilder.class).hasSize(2);
+            assertThat(context).getBean("defaultBeansFeedBuilder").isExactlyInstanceOf(DefaultBeansFeedBuilder.class);
+            assertThat(context).getBean("cachingBeansFeedBuilder").isExactlyInstanceOf(CachingBeansFeedBuilder.class);
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWhenEndpointDisabled() {
+        contextRunner // Overriding the property value to test the disabled state
+                .withPropertyValues("management.endpoints.web.exposure.exclude=axelix-beans")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixBeansEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixBeansEndpoint.class);
+                    assertThat(context).doesNotHaveBean(ConditionalBeanRefBuilder.class);
+                    assertThat(context).doesNotHaveBean(BeanMetaInfoExtractor.class);
+                    assertThat(context).doesNotHaveBean(BeansFeedBuilder.class);
+                    assertThat(context).doesNotHaveBean(QualifiersPersistencePostProcessor.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
+        ApplicationContextRunner runnerWithoutCacheConfig = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(AxelixBeansEndpointAutoConfiguration.class));
+
+        runnerWithoutCacheConfig.run(context -> {
+            assertThat(context).doesNotHaveBean(AxelixBeansEndpointAutoConfiguration.class);
+            assertThat(context).doesNotHaveBean(AxelixBeansEndpoint.class);
+            assertThat(context).doesNotHaveBean(ConditionalBeanRefBuilder.class);
+            assertThat(context).doesNotHaveBean(BeanMetaInfoExtractor.class);
+            assertThat(context).doesNotHaveBean(BeansFeedBuilder.class);
+            assertThat(context).doesNotHaveBean(QualifiersPersistencePostProcessor.class);
+        });
+    }
+
+    @Test
+    void shouldHandleMultipleCustomBeans() {
+        contextRunner
+                .withUserConfiguration(
+                        CustomConditionalBeanRefBuilderConfig.class,
+                        CustomBeanMetaInfoExtractorConfig.class,
+                        CustomAxelixBeansEndpointConfig.class)
+                .run(context -> {
+                    assertThat(context.getBean(ConditionalBeanRefBuilder.class))
+                            .isExactlyInstanceOf(CustomConditionalBeanRefBuilder.class);
+                    assertThat(context.getBean(BeanMetaInfoExtractor.class))
+                            .isExactlyInstanceOf(CustomBeanMetaInfoExtractor.class);
+                    assertThat(context.getBean(AxelixBeansEndpoint.class))
+                            .isExactlyInstanceOf(CustomAxelixBeansEndpoint.class);
+                });
+    }
+
+    @TestConfiguration
+    static class CustomConditionalBeanRefBuilderConfig {
+        @Bean
+        public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
+            return new CustomConditionalBeanRefBuilder();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomBeanMetaInfoExtractorConfig {
+        @Bean
+        public BeanMetaInfoExtractor beanMetaInfoExtractor() {
+            return new CustomBeanMetaInfoExtractor();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomAxelixBeansEndpointConfig {
+        @Bean
+        public AxelixBeansEndpoint axelixBeansEndpoint() {
+            return new CustomAxelixBeansEndpoint();
+        }
+    }
+
+    static class CustomConditionalBeanRefBuilder implements ConditionalBeanRefBuilder {
+        @Override
+        public String buildBeanRefInternal(Class<?> beanClass, @Nullable String beanFactoryMethodName) {
+            return "";
+        }
+    }
+
+    static class CustomBeanMetaInfoExtractor implements BeanMetaInfoExtractor {
+        @Override
+        public BeanMetaInfo extract(String beanName, ConfigurableListableBeanFactory beanFactory) {
+            return null;
+        }
+    }
+
+    static class CustomAxelixBeansEndpoint extends AxelixBeansEndpoint {
+        public CustomAxelixBeansEndpoint() {
+            super(null);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixCachesEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixCachesEndpointAutoConfigurationTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.cache.CacheManagerBeanPostProcessor;
+import com.axelixlabs.axelix.sbs.spring.core.cache.CacheOperationsDispatcher;
+import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link AxelixCachesEndpointAutoConfiguration}
+ *
+ * @since 09.02.2026
+ * @author Nikita Kirillov
+ */
+class AxelixCachesEndpointAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-caches")
+            .withConfiguration(AutoConfigurations.of(AxelixCachesEndpointAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(CacheSizeProvider.class);
+            assertThat(context).hasSingleBean(CacheOperationsDispatcher.class);
+            assertThat(context).hasSingleBean(AxelixCachesEndpoint.class);
+            assertThat(context).hasSingleBean(CacheManagerBeanPostProcessor.class);
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWhenEndpointDisabled() {
+        contextRunner // Overriding the property value to test the disabled state
+                .withPropertyValues("management.endpoints.web.exposure.exclude=axelix-caches")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixCachesEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(CacheSizeProvider.class);
+                    assertThat(context).doesNotHaveBean(CacheOperationsDispatcher.class);
+                    assertThat(context).doesNotHaveBean(AxelixCachesEndpoint.class);
+                    assertThat(context).doesNotHaveBean(CacheManagerBeanPostProcessor.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
+        ApplicationContextRunner runnerWithoutCacheConfig = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(AxelixCachesEndpointAutoConfiguration.class));
+
+        runnerWithoutCacheConfig.run(context -> {
+            assertThat(context).doesNotHaveBean(AxelixCachesEndpointAutoConfiguration.class);
+            assertThat(context).doesNotHaveBean(CacheSizeProvider.class);
+            assertThat(context).doesNotHaveBean(CacheOperationsDispatcher.class);
+            assertThat(context).doesNotHaveBean(AxelixCachesEndpoint.class);
+            assertThat(context).doesNotHaveBean(CacheManagerBeanPostProcessor.class);
+        });
+    }
+
+    @Test
+    void shouldHandleMultipleCustomBeans() {
+        contextRunner
+                .withUserConfiguration(
+                        CustomCacheManagerBeanPostProcessorConfig.class,
+                        CustomAxelixCachesEndpointConfig.class,
+                        CustomCacheSizeProviderConfig.class)
+                .run(context -> {
+                    assertThat(context.getBean(CacheManagerBeanPostProcessor.class))
+                            .isExactlyInstanceOf(CustomCacheManagerBeanPostProcessor.class);
+                    assertThat(context.getBean(AxelixCachesEndpoint.class))
+                            .isExactlyInstanceOf(CustomAxelixCachesEndpoint.class);
+                    assertThat(context.getBean(CacheSizeProvider.class))
+                            .isExactlyInstanceOf(CustomCacheSizeProvider.class);
+                });
+    }
+
+    @TestConfiguration
+    static class CustomCacheSizeProviderConfig {
+        @Bean
+        public CacheSizeProvider cacheSizeProvider() {
+            return new CustomCacheSizeProvider();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomAxelixCachesEndpointConfig {
+        @Bean
+        public AxelixCachesEndpoint axelixCachesEndpoint(CacheOperationsDispatcher cacheOperationsDispatcher) {
+            return new CustomAxelixCachesEndpoint(cacheOperationsDispatcher);
+        }
+    }
+
+    @TestConfiguration
+    static class CustomCacheManagerBeanPostProcessorConfig {
+        @Bean
+        public CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
+                ObjectProvider<AxelixMetricsPublisher> objectProvider) {
+            return new CustomCacheManagerBeanPostProcessor(objectProvider);
+        }
+    }
+
+    static class CustomCacheSizeProvider implements CacheSizeProvider {
+
+        @Override
+        public Long getEstimatedCacheSize(Object nativeCache) {
+            return 0L;
+        }
+    }
+
+    static class CustomAxelixCachesEndpoint extends AxelixCachesEndpoint {
+        public CustomAxelixCachesEndpoint(CacheOperationsDispatcher dispatcher) {
+            super(dispatcher);
+        }
+    }
+
+    static class CustomCacheManagerBeanPostProcessor extends CacheManagerBeanPostProcessor {
+        public CustomCacheManagerBeanPostProcessor(ObjectProvider<AxelixMetricsPublisher> objectProvider) {
+            super(objectProvider);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfigurationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.sbs.spring.core.conditions.AxelixConditionsEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalFeedBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link AxelixConditionsEndpointAutoConfiguration}
+ *
+ * @author Nikita Kirillov
+ */
+class AxelixConditionsEndpointAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-conditions")
+            .withConfiguration(AutoConfigurations.of(AxelixConditionsEndpointAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(AxelixConditionsEndpoint.class);
+
+            AxelixConditionsEndpoint endpoint = context.getBean(AxelixConditionsEndpoint.class);
+            assertThat(endpoint).isNotNull();
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWhenEndpointDisabled() {
+        contextRunner // Overriding the property value to test the disabled state
+                .withPropertyValues("management.endpoints.web.exposure.exclude=axelix-conditions")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixConditionsEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixConditionsEndpoint.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
+        ApplicationContextRunner runnerWithoutRequiredConfig = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(AxelixConditionsEndpointAutoConfiguration.class));
+
+        runnerWithoutRequiredConfig.run(context -> {
+            assertThat(context).doesNotHaveBean(AxelixConditionsEndpointAutoConfiguration.class);
+            assertThat(context).doesNotHaveBean(AxelixConditionsEndpoint.class);
+        });
+    }
+
+    @Test
+    void shouldNotCreateDefaultEndpointWhenCustomBeanProvided() {
+        contextRunner
+                .withUserConfiguration(CustomAxelixConditionsEndpointConfig.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(AxelixConditionsEndpoint.class);
+                    assertThat(context.getBean(AxelixConditionsEndpoint.class))
+                            .isExactlyInstanceOf(CustomAxelixConditionsEndpoint.class);
+                });
+    }
+
+    @TestConfiguration
+    static class CustomAxelixConditionsEndpointConfig {
+        @Bean
+        public AxelixConditionsEndpoint axelixConditionsEndpoint(ConditionalFeedBuilder conditionalFeedBuilder) {
+            return new CustomAxelixConditionsEndpoint(conditionalFeedBuilder);
+        }
+    }
+
+    static class CustomAxelixConditionsEndpoint extends AxelixConditionsEndpoint {
+        public CustomAxelixConditionsEndpoint(ConditionalFeedBuilder conditionalFeedBuilder) {
+            super(conditionalFeedBuilder);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConfigurationsPropertiesEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConfigurationsPropertiesEndpointAutoConfigurationTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.context.properties.ConfigurationPropertiesReportEndpoint;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.common.api.ConfigurationPropertiesFeed;
+import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
+import com.axelixlabs.axelix.sbs.spring.core.auth.RequiredAuthorityCheckService;
+import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
+import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.AxelixConfigurationPropertiesEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesConverter;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesFlattener;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesService;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesFlattener;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesService;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
+import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link AxelixConfigurationsPropertiesEndpointAutoConfiguration}
+ *
+ * @author Nikita Kirillov
+ */
+class AxelixConfigurationsPropertiesEndpointAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    AxelixConfigurationsPropertiesEndpointAutoConfiguration.class,
+                    EndpointsConfigurationPropertiesAutoConfiguration.class))
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-configprops");
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(ConfigurationPropertiesFlattener.class);
+            assertThat(context).hasSingleBean(ConfigurationPropertiesConverter.class);
+            assertThat(context).hasSingleBean(PropertyNameNormalizer.class);
+            assertThat(context).hasSingleBean(SmartSanitizingFunction.class);
+            assertThat(context).hasSingleBean(ConfigurationPropertiesService.class);
+            assertThat(context).hasSingleBean(AxelixConfigurationPropertiesEndpoint.class);
+            assertThat(context).hasSingleBean(RequiredAuthorityCheckService.class);
+            assertThat(context).hasSingleBean(SecurityContextExecutor.class);
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWhenEndpointDisabled() {
+        contextRunner // Overriding the property value to test the disabled state
+                .withPropertyValues("management.endpoints.web.exposure.exclude=axelix-configprops")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixConfigurationsPropertiesEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixConfigurationPropertiesEndpoint.class);
+                    assertThat(context).doesNotHaveBean(ConfigurationPropertiesService.class);
+                    assertThat(context).doesNotHaveBean(SmartSanitizingFunction.class);
+                    assertThat(context).doesNotHaveBean(PropertyNameNormalizer.class);
+                    assertThat(context).doesNotHaveBean(ConfigurationPropertiesConverter.class);
+                    assertThat(context).doesNotHaveBean(ConfigurationPropertiesFlattener.class);
+                    assertThat(context).doesNotHaveBean(SecurityContextExecutor.class);
+                    assertThat(context).doesNotHaveBean(RequiredAuthorityCheckService.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
+        ApplicationContextRunner runnerWithoutRequiredConfig = new ApplicationContextRunner()
+                .withConfiguration(
+                        AutoConfigurations.of(AxelixConfigurationsPropertiesEndpointAutoConfiguration.class));
+
+        runnerWithoutRequiredConfig.run(context -> {
+            assertThat(context).doesNotHaveBean(AxelixConfigurationsPropertiesEndpointAutoConfiguration.class);
+            assertThat(context).doesNotHaveBean(AxelixConfigurationPropertiesEndpoint.class);
+            assertThat(context).doesNotHaveBean(ConfigurationPropertiesService.class);
+            assertThat(context).doesNotHaveBean(SmartSanitizingFunction.class);
+            assertThat(context).doesNotHaveBean(PropertyNameNormalizer.class);
+            assertThat(context).doesNotHaveBean(ConfigurationPropertiesConverter.class);
+            assertThat(context).doesNotHaveBean(ConfigurationPropertiesFlattener.class);
+            assertThat(context).doesNotHaveBean(SecurityContextExecutor.class);
+            assertThat(context).doesNotHaveBean(RequiredAuthorityCheckService.class);
+        });
+    }
+
+    @Test
+    void shouldHandleMultipleCustomBeans() {
+        contextRunner
+                .withUserConfiguration(
+                        CustomConfigurationPropertiesConverterConfig.class,
+                        CustomConfigurationPropertiesFlattenerConfig.class,
+                        CustomPropertyNameNormalizerConfig.class,
+                        CustomSmartSanitizingFunctionConfig.class,
+                        CustomConfigurationPropertiesServiceConfig.class,
+                        CustomAxelixConfigurationPropertiesEndpointConfig.class,
+                        CustomSecurityContextExecutorConfig.class,
+                        CustomRequiredAuthorityCheckService.class)
+                .run(context -> {
+                    assertThat(context.getBean(ConfigurationPropertiesConverter.class))
+                            .isExactlyInstanceOf(CustomConfigurationPropertiesConverter.class);
+                    assertThat(context.getBean(PropertyNameNormalizer.class))
+                            .isExactlyInstanceOf(CustomPropertyNameNormalizer.class);
+                    assertThat(context.getBean(SmartSanitizingFunction.class))
+                            .isExactlyInstanceOf(CustomSmartSanitizingFunction.class);
+                    assertThat(context.getBean(DefaultConfigurationPropertiesService.class))
+                            .isExactlyInstanceOf(CustomConfigurationPropertiesService.class);
+                    assertThat(context.getBean(AxelixConfigurationPropertiesEndpoint.class))
+                            .isExactlyInstanceOf(CustomAxelixConfigurationPropertiesEndpoint.class);
+                    assertThat(context.getBean(ConfigurationPropertiesFlattener.class))
+                            .isExactlyInstanceOf(CustomConfigurationPropertiesFlattener.class);
+                    assertThat(context.getBean(SecurityContextExecutor.class))
+                            .isExactlyInstanceOf(CustomSecurityContextExecutor.class);
+                    assertThat(context.getBean(RequiredAuthorityCheckService.class))
+                            .isExactlyInstanceOf(CustomRequiredAuthorityCheckService.class);
+                });
+    }
+
+    @TestConfiguration
+    static class CustomConfigurationPropertiesConverterConfig {
+        @Bean
+        public ConfigurationPropertiesConverter configurationPropertiesConverter() {
+            return new CustomConfigurationPropertiesConverter();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomPropertyNameNormalizerConfig {
+        @Bean
+        public PropertyNameNormalizer propertyNameNormalizer() {
+            return new CustomPropertyNameNormalizer();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomSmartSanitizingFunctionConfig {
+        @Bean
+        public SmartSanitizingFunction smartSanitizingFunction(
+                EndpointsConfigurationProperties endpointsConfigurationProperties,
+                PropertyNameNormalizer propertyNameNormalizer) {
+            return new CustomSmartSanitizingFunction(endpointsConfigurationProperties, propertyNameNormalizer);
+        }
+    }
+
+    @TestConfiguration
+    static class CustomConfigurationPropertiesServiceConfig {
+        @Bean
+        public ConfigurationPropertiesService configurationPropertiesService(
+                SmartSanitizingFunction smartSanitizingFunction,
+                ApplicationContext applicationContext,
+                ConfigurationPropertiesConverter configurationPropertiesConverter,
+                RequiredAuthorityCheckService requiredAuthorityCheckService) {
+            return new CustomConfigurationPropertiesService(
+                    smartSanitizingFunction,
+                    applicationContext,
+                    configurationPropertiesConverter,
+                    requiredAuthorityCheckService);
+        }
+    }
+
+    @TestConfiguration
+    static class CustomAxelixConfigurationPropertiesEndpointConfig {
+        @Bean
+        public AxelixConfigurationPropertiesEndpoint axelixConfigurationPropertiesEndpoint(
+                DefaultConfigurationPropertiesService configurationPropertiesService) {
+            return new CustomAxelixConfigurationPropertiesEndpoint(configurationPropertiesService);
+        }
+    }
+
+    @TestConfiguration
+    static class CustomConfigurationPropertiesFlattenerConfig {
+        @Bean
+        public ConfigurationPropertiesFlattener configurationPropertiesFlattener() {
+            return new CustomConfigurationPropertiesFlattener();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomSecurityContextExecutorConfig {
+        @Bean
+        public SecurityContextExecutor securityContextExecutor() {
+            return new CustomSecurityContextExecutor();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomRequiredAuthorityCheckServiceConfig {
+        @Bean
+        public RequiredAuthorityCheckService configurationPropertiesFlattener(
+                SecurityContextExecutor securityContextExecutor) {
+            return new CustomRequiredAuthorityCheckService(securityContextExecutor);
+        }
+    }
+
+    static class CustomConfigurationPropertiesConverter implements ConfigurationPropertiesConverter {
+        @Override
+        public ConfigurationPropertiesFeed convert(
+                ConfigurationPropertiesReportEndpoint.ConfigurationPropertiesDescriptor originalDescriptor) {
+            return null;
+        }
+    }
+
+    static class CustomSecurityContextExecutor extends ThreadLocalSecurityContextExecutor {}
+
+    static class CustomRequiredAuthorityCheckService extends RequiredAuthorityCheckService {
+        public CustomRequiredAuthorityCheckService(SecurityContextExecutor securityContextExecutor) {
+            super(securityContextExecutor);
+        }
+    }
+
+    static class CustomConfigurationPropertiesFlattener extends DefaultConfigurationPropertiesFlattener {}
+
+    static class CustomPropertyNameNormalizer implements PropertyNameNormalizer {
+
+        @Override
+        public String normalize(String propertyName) {
+            return "";
+        }
+
+        @Override
+        public <C extends Collection<String>> C normalizeAll(C propertyNames, Supplier<C> collectionFactory) {
+            return null;
+        }
+    }
+
+    static class CustomSmartSanitizingFunction extends SmartSanitizingFunction {
+        public CustomSmartSanitizingFunction(
+                EndpointsConfigurationProperties endpointsConfigurationProperties,
+                PropertyNameNormalizer propertyNameNormalizer) {
+            super(endpointsConfigurationProperties.getSanitizedProperties(), propertyNameNormalizer);
+        }
+    }
+
+    static class CustomConfigurationPropertiesService extends DefaultConfigurationPropertiesService {
+        public CustomConfigurationPropertiesService(
+                SmartSanitizingFunction smartSanitizingFunction,
+                ApplicationContext applicationContext,
+                ConfigurationPropertiesConverter configurationPropertiesConverter,
+                RequiredAuthorityCheckService requiredAuthorityCheckService) {
+            super(
+                    smartSanitizingFunction,
+                    applicationContext,
+                    configurationPropertiesConverter,
+                    requiredAuthorityCheckService);
+        }
+    }
+
+    static class CustomAxelixConfigurationPropertiesEndpoint extends AxelixConfigurationPropertiesEndpoint {
+        public CustomAxelixConfigurationPropertiesEndpoint(
+                DefaultConfigurationPropertiesService configurationPropertiesService) {
+            super(configurationPropertiesService);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixEnvironmentEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixEnvironmentEndpointAutoConfigurationTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.actuate.env.EnvironmentEndpoint;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+
+import com.axelixlabs.axelix.common.api.env.EnvironmentFeed;
+import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
+import com.axelixlabs.axelix.sbs.spring.core.auth.RequiredAuthorityCheckService;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
+import com.axelixlabs.axelix.sbs.spring.core.env.AxelixEnvironmentEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.env.DefaultEnvironmentService;
+import com.axelixlabs.axelix.sbs.spring.core.env.EnvPropertyEnricher;
+import com.axelixlabs.axelix.sbs.spring.core.env.EnvironmentService;
+import com.axelixlabs.axelix.sbs.spring.core.env.PropertyMetadata;
+import com.axelixlabs.axelix.sbs.spring.core.env.PropertyMetadataExtractor;
+import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
+import com.axelixlabs.axelix.sbs.spring.core.env.ValueInjectionTrackerBeanPostProcessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AxelixEnvironmentEndpointAutoConfiguration}
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ */
+class AxelixEnvironmentEndpointAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-env")
+            .withConfiguration(AutoConfigurations.of(
+                    AxelixEnvironmentEndpointAutoConfiguration.class,
+                    EndpointsConfigurationPropertiesAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(PropertyNameNormalizer.class);
+            assertThat(context).hasSingleBean(PropertyMetadataExtractor.class);
+            assertThat(context).hasSingleBean(SmartSanitizingFunction.class);
+            assertThat(context).hasSingleBean(EnvPropertyEnricher.class);
+            assertThat(context).hasSingleBean(AxelixEnvironmentEndpoint.class);
+            assertThat(context).hasSingleBean(ValueInjectionTrackerBeanPostProcessor.class);
+            assertThat(context).hasSingleBean(EnvironmentService.class);
+            assertThat(context).hasSingleBean(RequiredAuthorityCheckService.class);
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
+        new ApplicationContextRunner()
+                .withPropertyValues("management.endpoints.web.exposure.exclude=axelix-env")
+                .withConfiguration(AutoConfigurations.of(AxelixEnvironmentEndpointAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixEnvironmentEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(PropertyNameNormalizer.class);
+                    assertThat(context).doesNotHaveBean(PropertyMetadataExtractor.class);
+                    assertThat(context).doesNotHaveBean(EnvPropertyEnricher.class);
+                    assertThat(context).doesNotHaveBean(SmartSanitizingFunction.class);
+                    assertThat(context).doesNotHaveBean(AxelixEnvironmentEndpoint.class);
+                    assertThat(context).doesNotHaveBean(ValueInjectionTrackerBeanPostProcessor.class);
+                    assertThat(context).doesNotHaveBean(EnvironmentService.class);
+                    assertThat(context).doesNotHaveBean(RequiredAuthorityCheckService.class);
+                });
+    }
+
+    @Test
+    void shouldHandleMultipleCustomBeans() {
+        contextRunner
+                .withUserConfiguration(
+                        CustomPropertyMetadataExtractorConfig.class,
+                        CustomEnvPropertyEnricherConfig.class,
+                        CustomPropertyNameNormalizerConfig.class,
+                        CustomAxelixEnvironmentEndpointConfig.class,
+                        CustomValueInjectionTrackerBeanPostProcessorConfig.class,
+                        CustomRequiredAuthorityCheckServiceConfig.class,
+                        CustomEnvironmentServiceConfig.class)
+                .run(context -> {
+                    assertThat(context.getBean(PropertyMetadataExtractor.class))
+                            .isExactlyInstanceOf(CustomPropertyMetadataExtractor.class);
+                    assertThat(context.getBean(EnvPropertyEnricher.class))
+                            .isExactlyInstanceOf(CustomEnvPropertyEnricher.class);
+                    assertThat(context.getBean(PropertyNameNormalizer.class))
+                            .isExactlyInstanceOf(CustomPropertyNameNormalizer.class);
+                    assertThat(context.getBean(AxelixEnvironmentEndpoint.class))
+                            .isExactlyInstanceOf(CustomAxelixEnvironmentEndpoint.class);
+                    assertThat(context.getBean(ValueInjectionTrackerBeanPostProcessor.class))
+                            .isExactlyInstanceOf(CustomValueInjectionTrackerBeanPostProcessor.class);
+                    assertThat(context.getBean(RequiredAuthorityCheckService.class))
+                            .isExactlyInstanceOf(CustomRequiredAuthorityCheckService.class);
+                    assertThat(context.getBean(EnvironmentService.class))
+                            .isExactlyInstanceOf(CustomEnvironmentService.class);
+                });
+    }
+
+    @TestConfiguration
+    static class CustomPropertyMetadataExtractorConfig {
+        @Bean
+        public PropertyMetadataExtractor propertyMetadataExtractor() {
+            return new CustomPropertyMetadataExtractor();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomEnvPropertyEnricherConfig {
+        @Bean
+        public EnvPropertyEnricher envPropertyEnricher() {
+            return new CustomEnvPropertyEnricher();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomPropertyNameNormalizerConfig {
+        @Bean
+        public PropertyNameNormalizer propertyNameNormalizer() {
+            return new CustomPropertyNameNormalizer();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomAxelixEnvironmentEndpointConfig {
+        @Bean
+        public AxelixEnvironmentEndpoint axelixEnvironmentEndpoint(EnvironmentService environmentService) {
+            return new CustomAxelixEnvironmentEndpoint(environmentService);
+        }
+    }
+
+    @TestConfiguration
+    static class CustomValueInjectionTrackerBeanPostProcessorConfig {
+        @Bean
+        public ValueInjectionTrackerBeanPostProcessor valueInjectionTrackerBeanPostProcessor() {
+            return new CustomValueInjectionTrackerBeanPostProcessor(null);
+        }
+    }
+
+    @TestConfiguration
+    static class CustomRequiredAuthorityCheckServiceConfig {
+        @Bean
+        public RequiredAuthorityCheckService requiredAuthorityCheckService(
+                SecurityContextExecutor securityContextExecutor) {
+            return new CustomRequiredAuthorityCheckService(securityContextExecutor);
+        }
+    }
+
+    @TestConfiguration
+    static class CustomEnvironmentServiceConfig {
+        @Bean
+        public EnvironmentService environmentService(
+                Environment environment,
+                SmartSanitizingFunction smartSanitizingFunction,
+                EnvPropertyEnricher envPropertyEnricher,
+                RequiredAuthorityCheckService requiredAuthorityCheckService) {
+            return new CustomEnvironmentService(
+                    environment, smartSanitizingFunction, envPropertyEnricher, requiredAuthorityCheckService);
+        }
+    }
+
+    static class CustomPropertyMetadataExtractor implements PropertyMetadataExtractor {
+        @Override
+        public @Nullable PropertyMetadata getMetadata(String propertyName) {
+            return null;
+        }
+    }
+
+    static class CustomEnvPropertyEnricher implements EnvPropertyEnricher {
+        @Override
+        public EnvironmentFeed enrich(EnvironmentEndpoint.EnvironmentDescriptor originalDescriptor) {
+            return null;
+        }
+    }
+
+    static class CustomPropertyNameNormalizer implements PropertyNameNormalizer {
+        @Override
+        public String normalize(String propertyName) {
+            return propertyName;
+        }
+
+        @Override
+        public <C extends Collection<String>> C normalizeAll(C propertyNames, Supplier<C> collectionFactory) {
+            return null;
+        }
+    }
+
+    static class CustomAxelixEnvironmentEndpoint extends AxelixEnvironmentEndpoint {
+        public CustomAxelixEnvironmentEndpoint(EnvironmentService environmentService) {
+            super(environmentService);
+        }
+    }
+
+    static class CustomValueInjectionTrackerBeanPostProcessor extends ValueInjectionTrackerBeanPostProcessor {
+        public CustomValueInjectionTrackerBeanPostProcessor(PropertyNameNormalizer propertyNameNormalizer) {
+            super(propertyNameNormalizer);
+        }
+    }
+
+    static class CustomRequiredAuthorityCheckService extends RequiredAuthorityCheckService {
+        public CustomRequiredAuthorityCheckService(SecurityContextExecutor securityContextExecutor) {
+            super(securityContextExecutor);
+        }
+    }
+
+    static class CustomEnvironmentService extends DefaultEnvironmentService {
+        public CustomEnvironmentService(
+                Environment environment,
+                SmartSanitizingFunction smartSanitizingFunction,
+                EnvPropertyEnricher envPropertyEnricher,
+                RequiredAuthorityCheckService requiredAuthorityCheckService) {
+            super(environment, smartSanitizingFunction, envPropertyEnricher, requiredAuthorityCheckService);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixGcEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixGcEndpointAutoConfigurationTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.sbs.spring.core.gclog.AxelixGcEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.gclog.DefaultGcLogService;
+import com.axelixlabs.axelix.sbs.spring.core.gclog.GcLogService;
+import com.axelixlabs.axelix.sbs.spring.core.gclog.JcmdExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AxelixGcEndpointAutoConfiguration}
+ *
+ * @author Nikita Kirillov
+ */
+class AxelixGcEndpointAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-gc")
+            .withConfiguration(AutoConfigurations.of(AxelixGcEndpointAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(JcmdExecutor.class);
+            assertThat(context).hasSingleBean(GcLogService.class);
+            assertThat(context).hasSingleBean(AxelixGcEndpoint.class);
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWhenEndpointDisabled() {
+        contextRunner // Overriding the property value to test the disabled state
+                .withPropertyValues("management.endpoint.axelix-gc.enabled=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixGcEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(JcmdExecutor.class);
+                    assertThat(context).doesNotHaveBean(GcLogService.class);
+                    assertThat(context).doesNotHaveBean(AxelixGcEndpoint.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(AxelixGcEndpointAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixGcEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixGcEndpoint.class);
+                    assertThat(context).doesNotHaveBean(JcmdExecutor.class);
+                    assertThat(context).doesNotHaveBean(GcLogService.class);
+                });
+    }
+
+    @Test
+    void shouldHandleMultipleCustomBeans() {
+        contextRunner
+                .withUserConfiguration(
+                        CustomJcmdExecutorConfig.class,
+                        CustomGcLogServiceConfig.class,
+                        CustomAxelixGcEndpointConfig.class)
+                .run(context -> {
+                    assertThat(context.getBean(JcmdExecutor.class)).isExactlyInstanceOf(CustomJcmdExecutor.class);
+                    assertThat(context.getBean(GcLogService.class)).isExactlyInstanceOf(CustomGcLogService.class);
+                    assertThat(context.getBean(AxelixGcEndpoint.class))
+                            .isExactlyInstanceOf(CustomAxelixGcEndpoint.class);
+                });
+    }
+
+    @TestConfiguration
+    static class CustomJcmdExecutorConfig {
+        @Bean
+        public JcmdExecutor jcmdExecutor() {
+            return new CustomJcmdExecutor();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomGcLogServiceConfig {
+        @Bean
+        public GcLogService gcLogService(JcmdExecutor jcmdExecutor) {
+            return new CustomGcLogService(jcmdExecutor);
+        }
+    }
+
+    @TestConfiguration
+    static class CustomAxelixGcEndpointConfig {
+        @Bean
+        public AxelixGcEndpoint axelixGcEndpoint(GcLogService gcLogService) {
+            return new CustomAxelixGcEndpoint(gcLogService);
+        }
+    }
+
+    static class CustomJcmdExecutor extends JcmdExecutor {}
+
+    static class CustomGcLogService extends DefaultGcLogService {
+        public CustomGcLogService(JcmdExecutor jcmdExecutor) {
+            super(jcmdExecutor);
+        }
+    }
+
+    static class CustomAxelixGcEndpoint extends AxelixGcEndpoint {
+        public CustomAxelixGcEndpoint(GcLogService gcLogService) {
+            super(gcLogService);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfigurationTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AxelixHeapDumpEndpointAutoConfiguration}
+ *
+ * @author Nikita Kirillov
+ */
+class AxelixHeapDumpEndpointAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-heap-dump")
+            .withConfiguration(AutoConfigurations.of(AxelixHeapDumpEndpointAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> assertThat(context).hasSingleBean(AxelixHeapDumpEndpoint.class));
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWhenEndpointDisabled() {
+        contextRunner // Overriding the property value to test the disabled state
+                .withPropertyValues("management.endpoint.axelix-heap-dump.enabled=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixHeapDumpEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixHeapDumpEndpoint.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(AxelixHeapDumpEndpointAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixHeapDumpEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixHeapDumpEndpoint.class);
+                });
+    }
+
+    @Test
+    void shouldNotCreateDefaultAxelixHeapDumpEndpoint_whenCustomBeanProvided() {
+        contextRunner
+                .withUserConfiguration(CustomAxelixHeapDumpEndpointConfig.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(AxelixHeapDumpEndpoint.class);
+                    var beans = context.getBeansOfType(AxelixHeapDumpEndpoint.class);
+                    assertThat(beans).hasSize(1);
+                    assertThat(beans.values().iterator().next())
+                            .isExactlyInstanceOf(CustomAxelixHeapDumpEndpoint.class);
+                });
+    }
+
+    @TestConfiguration
+    static class CustomAxelixHeapDumpEndpointConfig {
+        @Bean
+        public AxelixHeapDumpEndpoint customAxelixHeapDumpEndpoint() {
+            return new CustomAxelixHeapDumpEndpoint();
+        }
+    }
+
+    static class CustomAxelixHeapDumpEndpoint extends AxelixHeapDumpEndpoint {
+        public CustomAxelixHeapDumpEndpoint() {
+            super();
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/GitInformationProviderAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/GitInformationProviderAutoConfigurationTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import com.axelixlabs.axelix.sbs.spring.core.master.CommitIdPluginGitInformationProvider;
+import com.axelixlabs.axelix.sbs.spring.core.master.GitInformationProvider;
+import com.axelixlabs.axelix.sbs.spring.core.master.NoOpGitInformationProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link GitInformationProviderAutoConfiguration}
+ *
+ * @author Nikita Kirillov
+ */
+class GitInformationProviderAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    GitInformationProviderAutoConfiguration.class, ProjectInfoAutoConfiguration.class));
+
+    @Test
+    void shouldCreateCommitIdPluginGitInformationProviderWhenGitPropertiesAvailable() {
+        contextRunner
+                .withPropertyValues(
+                        "management.info.git.enabled=true", "spring.info.git.location=classpath:other/git.properties")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(GitProperties.class);
+                    assertThat(context).hasSingleBean(GitInformationProvider.class);
+                    assertThat(context.getBean(GitInformationProvider.class))
+                            .isExactlyInstanceOf(CommitIdPluginGitInformationProvider.class);
+                    assertThat(context).doesNotHaveBean(NoOpGitInformationProvider.class);
+                });
+    }
+
+    @Test
+    void shouldCreateNoOpGitInformationProviderWhenGitPropertiesFileNotExist() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.info.git.location=classpath:not-exist-git.properties",
+                        "management.info.git.enabled=true")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(GitInformationProvider.class);
+                    assertThat(context.getBean(GitInformationProvider.class))
+                            .isExactlyInstanceOf(NoOpGitInformationProvider.class);
+                    assertThat(context).doesNotHaveBean(GitProperties.class);
+                    assertThat(context).doesNotHaveBean(CommitIdPluginGitInformationProvider.class);
+                });
+    }
+
+    @Test
+    void shouldCreateNoOpGitInformationProviderWhenGitInfoDisabled() {
+        contextRunner.withPropertyValues("management.info.git.enabled=false").run(context -> {
+            assertThat(context).hasSingleBean(GitInformationProvider.class);
+            assertThat(context.getBean(GitInformationProvider.class))
+                    .isExactlyInstanceOf(NoOpGitInformationProvider.class);
+            assertThat(context).doesNotHaveBean(GitProperties.class);
+            assertThat(context).doesNotHaveBean(CommitIdPluginGitInformationProvider.class);
+        });
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/JwtAuthAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/JwtAuthAutoConfigurationTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import java.util.Optional;
+
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.common.auth.core.Authority;
+import com.axelixlabs.axelix.common.auth.core.JwtAlgorithm;
+import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
+import com.axelixlabs.axelix.common.auth.service.AuthorityResolver;
+import com.axelixlabs.axelix.common.auth.service.Authorizer;
+import com.axelixlabs.axelix.common.auth.service.DefaultAuthorizer;
+import com.axelixlabs.axelix.common.auth.service.DefaultJwtDecoderService;
+import com.axelixlabs.axelix.common.auth.service.JwtDecoderService;
+import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
+import com.axelixlabs.axelix.common.auth.service.WebIdentityAccessManager;
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthorizationFilter;
+import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link JwtAuthAutoConfiguration}
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ */
+class JwtAuthAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues(
+                    "axelix.sbs.auth.jwt",
+                    "axelix.sbs.auth.jwt.algorithm=HMAC512",
+                    "axelix.sbs.auth.jwt.signing-key=secret")
+            .withConfiguration(AutoConfigurations.of(JwtAuthAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(JwtAuthAutoConfiguration.class);
+            assertThat(context).hasSingleBean(JwtDecoderService.class);
+            assertThat(context).hasSingleBean(JwtEncoderService.class);
+            assertThat(context).hasSingleBean(AuthorityResolver.class);
+            assertThat(context).hasSingleBean(Authorizer.class);
+            assertThat(context).hasSingleBean(WebIdentityAccessManager.class);
+            assertThat(context).hasSingleBean(FilterRegistrationBean.class);
+            assertThat(context).hasSingleBean(SecurityContextExecutor.class);
+        });
+    }
+
+    @Test
+    void shouldFail_whenAlgorithmPropertyIsMissing() {
+        new ApplicationContextRunner()
+                // "axelix.sbs.auth.jwt.algorithm" is missing
+                .withPropertyValues("axelix.sbs.auth.jwt", "axelix.sbs.auth.jwt.signing-key=secret")
+                .withConfiguration(AutoConfigurations.of(JwtAuthAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).isInstanceOf(BeanCreationException.class);
+                });
+    }
+
+    @Test
+    void shouldFail_whenSigningKeyPropertyIsMissing() {
+        new ApplicationContextRunner()
+                // "axelix.sbs.auth.jwt.signing-key" is missing
+                .withPropertyValues("axelix.sbs.auth.jwt", "axelix.sbs.auth.jwt.algorithm=HMAC512")
+                .withConfiguration(AutoConfigurations.of(JwtAuthAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).isInstanceOf(BeanCreationException.class);
+                });
+    }
+
+    @Test
+    void shouldFail_whenAlgorithmIsNotSupported() {
+        new ApplicationContextRunner()
+                // "axelix.sbs.auth.jwt.algorithm=RSA512" algorithm not supported
+                .withPropertyValues(
+                        "axelix.sbs.auth.jwt",
+                        "axelix.sbs.auth.jwt.algorithm=RSA512",
+                        "axelix.sbs.auth.jwt.signing-key=secret")
+                .withConfiguration(AutoConfigurations.of(JwtAuthAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).isInstanceOf(BeanCreationException.class);
+                });
+    }
+
+    @Test
+    void shouldHandleMultipleCustomBeans() {
+        contextRunner
+                .withUserConfiguration(
+                        CustomJwtDecoderServiceConfig.class,
+                        CustomAuthorityResolverConfig.class,
+                        CustomAuthorizerConfig.class,
+                        CustomSecurityContextExecutorConfig.class)
+                .run(context -> {
+                    assertThat(context.getBean(JwtDecoderService.class))
+                            .isExactlyInstanceOf(CustomJwtDecoderService.class);
+                    assertThat(context.getBean(AuthorityResolver.class))
+                            .isExactlyInstanceOf(CustomAuthorityResolver.class);
+                    assertThat(context.getBean(Authorizer.class)).isExactlyInstanceOf(CustomAuthorizer.class);
+                    assertThat(context.getBean(SecurityContextExecutor.class))
+                            .isExactlyInstanceOf(CustomSecurityContextExecutor.class);
+                });
+    }
+
+    @TestConfiguration
+    static class CustomJwtDecoderServiceConfig {
+        @Bean
+        public JwtDecoderService jwtDecoderService() {
+            return new CustomJwtDecoderService();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomAuthorityResolverConfig {
+        @Bean
+        public AuthorityResolver authorityResolver() {
+            return new CustomAuthorityResolver();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomAuthorizerConfig {
+        @Bean
+        public Authorizer authorizer() {
+            return new CustomAuthorizer();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomSecurityContextExecutorConfig {
+        @Bean
+        public SecurityContextExecutor securityContextExecutor() {
+            return new CustomSecurityContextExecutor();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomJwtAuthorizationFilterConfig {
+        @Bean
+        public JwtAuthorizationFilter jwtAuthorizationFilter(
+                WebIdentityAccessManager webIdentityAccessManager,
+                SecurityContextExecutor securityContextExecutor,
+                WebEndpointProperties webEndpointProperties) {
+            return new CustomJwtAuthorizationFilter(
+                    webIdentityAccessManager, securityContextExecutor, webEndpointProperties.getBasePath());
+        }
+    }
+
+    static class CustomJwtDecoderService extends DefaultJwtDecoderService {
+        public CustomJwtDecoderService() {
+            super(JwtAlgorithm.HMAC512, "secret");
+        }
+    }
+
+    @NullMarked
+    static class CustomAuthorityResolver implements AuthorityResolver {
+
+        @Override
+        public Optional<Authority> resolve(String relativeRequestPath, HttpMethod httpMethod) {
+            return Optional.empty();
+        }
+    }
+
+    static class CustomAuthorizer extends DefaultAuthorizer {}
+
+    static class CustomSecurityContextExecutor extends ThreadLocalSecurityContextExecutor {}
+
+    static class CustomJwtAuthorizationFilter extends JwtAuthorizationFilter {
+
+        public CustomJwtAuthorizationFilter(
+                WebIdentityAccessManager webIdentityAccessManager,
+                SecurityContextExecutor securityContextExecutor,
+                String baseActuatorPath) {
+
+            super(webIdentityAccessManager, securityContextExecutor, baseActuatorPath);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
+
+import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.scheduled.DefaultScheduledTasksAssembler;
+import com.axelixlabs.axelix.sbs.spring.core.scheduled.IntervalBasedTaskRescheduler;
+import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTaskService;
+import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksAssembler;
+import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksRegistry;
+import com.axelixlabs.axelix.sbs.spring.core.scheduled.TaskRescheduler;
+import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskRescheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ScheduledTaskManagementAutoConfiguration}
+ *
+ * @author Nikita Kirillov
+ */
+class ScheduledTaskManagementAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
+            .withUserConfiguration(EnableSchedulingConfig.class)
+            .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(ScheduledTasksRegistry.class);
+            assertThat(context).hasSingleBean(ScheduledTaskService.class);
+            assertThat(context).hasSingleBean(ScheduledTasksAssembler.class);
+            assertThat(context).hasSingleBean(AxelixScheduledTasksEndpoint.class);
+
+            assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
+            assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
+            assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfiguration_withoutRequiredProperty() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(EnableSchedulingConfig.class)
+                .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(ScheduledTaskManagementAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(ScheduledTasksRegistry.class);
+                    assertThat(context).doesNotHaveBean(ScheduledTaskService.class);
+                    assertThat(context).doesNotHaveBean(AxelixScheduledTasksEndpoint.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfiguration_whenEndpointDisabled() {
+        new ApplicationContextRunner()
+                .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
+                .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(ScheduledTaskManagementAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(ScheduledTasksRegistry.class);
+                    assertThat(context).doesNotHaveBean(ScheduledTaskService.class);
+                    assertThat(context).doesNotHaveBean(AxelixScheduledTasksEndpoint.class);
+                });
+    }
+
+    @Test
+    void shouldHandleMultipleCustomBeans() {
+        contextRunner
+                .withUserConfiguration(
+                        CustomAxelixScheduledTasksEndpointConfig.class,
+                        CustomScheduledTasksAssemblerConfig.class,
+                        CustomScheduledTasksRegistryConfig.class)
+                .run(context -> {
+                    assertThat(context.getBean(ScheduledTasksRegistry.class))
+                            .isExactlyInstanceOf(CustomScheduledTasksRegistry.class);
+                    assertThat(context.getBean(ScheduledTasksAssembler.class))
+                            .isExactlyInstanceOf(CustomScheduledTasksAssembler.class);
+                    assertThat(context.getBean(AxelixScheduledTasksEndpoint.class))
+                            .isExactlyInstanceOf(CustomAxelixScheduledTasksEndpoint.class);
+                });
+    }
+
+    @TestConfiguration
+    @EnableScheduling
+    static class EnableSchedulingConfig {
+
+        @Bean
+        public TaskScheduler taskScheduler() {
+            return new ThreadPoolTaskScheduler();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomScheduledTasksRegistryConfig {
+        @Bean
+        public ScheduledTasksRegistry scheduledTasksRegistry(ObjectProvider<ScheduledTaskHolder> taskHolders) {
+            return new CustomScheduledTasksRegistry(taskHolders.orderedStream().toList());
+        }
+    }
+
+    @TestConfiguration
+    static class CustomScheduledTasksAssemblerConfig {
+        @Bean
+        public ScheduledTasksAssembler scheduledTasksAssembler(ScheduledTasksRegistry registry) {
+            return new CustomScheduledTasksAssembler(registry);
+        }
+    }
+
+    @TestConfiguration
+    static class CustomAxelixScheduledTasksEndpointConfig {
+        @Bean
+        public AxelixScheduledTasksEndpoint axelixScheduledTasksEndpoint(
+                ScheduledTaskService service, ScheduledTasksAssembler assembler) {
+            return new CustomAxelixScheduledTasksEndpoint(service, assembler);
+        }
+    }
+
+    static class CustomScheduledTasksRegistry extends ScheduledTasksRegistry {
+        public CustomScheduledTasksRegistry(List<ScheduledTaskHolder> taskHolders) {
+            super(taskHolders);
+        }
+    }
+
+    static class CustomScheduledTasksAssembler extends DefaultScheduledTasksAssembler {
+        public CustomScheduledTasksAssembler(ScheduledTasksRegistry registry) {
+            super(registry);
+        }
+    }
+
+    static class CustomAxelixScheduledTasksEndpoint extends AxelixScheduledTasksEndpoint {
+        public CustomAxelixScheduledTasksEndpoint(ScheduledTaskService service, ScheduledTasksAssembler assembler) {
+            super(service, assembler);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ShortBuildInfoProviderAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ShortBuildInfoProviderAutoConfigurationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import com.axelixlabs.axelix.sbs.spring.core.master.CommitIdPluginShortBuildInfoProvider;
+import com.axelixlabs.axelix.sbs.spring.core.master.NoOpShortBuildInfoProvider;
+import com.axelixlabs.axelix.sbs.spring.core.master.ShortBuildInfoProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ShortBuildInfoProviderAutoConfiguration}
+ *
+ * @author Nikita Kirillov
+ */
+class ShortBuildInfoProviderAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("spring.info.git.location=classpath:other/git.properties")
+            .withConfiguration(AutoConfigurations.of(
+                    ShortBuildInfoProviderAutoConfiguration.class, ProjectInfoAutoConfiguration.class));
+
+    @Test
+    void shouldCreateCommitIdPluginProviderWhenGitPropertiesBeanExists() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(ShortBuildInfoProvider.class);
+            assertThat(context)
+                    .getBean(ShortBuildInfoProvider.class)
+                    .isInstanceOf(CommitIdPluginShortBuildInfoProvider.class);
+            assertThat(context).doesNotHaveBean(NoOpShortBuildInfoProvider.class);
+        });
+    }
+
+    @Test
+    void shouldCreateNoOpProvider_whenRequiredFileNotExist() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        ShortBuildInfoProviderAutoConfiguration.class, ProjectInfoAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).hasSingleBean(ShortBuildInfoProvider.class);
+                    assertThat(context)
+                            .getBean(ShortBuildInfoProvider.class)
+                            .isInstanceOf(NoOpShortBuildInfoProvider.class);
+                    assertThat(context).doesNotHaveBean(CommitIdPluginShortBuildInfoProvider.class);
+                });
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ThreadDumpManagementEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ThreadDumpManagementEndpointAutoConfigurationTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.sbs.spring.core.threaddump.DefaultThreadDumpContentionMonitoringManagement;
+import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpContentionMonitoringManagement;
+import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpManagementEndpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ThreadDumpManagementEndpointAutoConfiguration}
+ *
+ * @author Nikita Kirillov
+ */
+class ThreadDumpManagementEndpointAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-thread-dump")
+            .withConfiguration(AutoConfigurations.of(ThreadDumpManagementEndpointAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(ThreadDumpManagementEndpointAutoConfiguration.class);
+            assertThat(context).hasSingleBean(ThreadDumpContentionMonitoringManagement.class);
+            assertThat(context).hasSingleBean(ThreadDumpManagementEndpoint.class);
+            assertThat(context.getBean(ThreadDumpContentionMonitoringManagement.class))
+                    .isExactlyInstanceOf(DefaultThreadDumpContentionMonitoringManagement.class);
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfiguration_whenEndpointDisabled() {
+        contextRunner
+                .withPropertyValues("management.endpoints.web.exposure.exclude=axelix-thread-dump")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(ThreadDumpManagementEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(ThreadDumpContentionMonitoringManagement.class);
+                    assertThat(context).doesNotHaveBean(ThreadDumpManagementEndpoint.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(ThreadDumpManagementEndpointAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(ThreadDumpManagementEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(ThreadDumpContentionMonitoringManagement.class);
+                    assertThat(context).doesNotHaveBean(ThreadDumpManagementEndpoint.class);
+                });
+    }
+
+    @Test
+    void shouldNotCreateDefaultThreadDumpContentionMonitoringManagement_whenCustomBeanProvided() {
+        contextRunner
+                .withUserConfiguration(CustomThreadDumpManagementConfig.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(ThreadDumpContentionMonitoringManagement.class);
+                    assertThat(context.getBean(ThreadDumpContentionMonitoringManagement.class))
+                            .isExactlyInstanceOf(CustomThreadDumpContentionMonitoringManagement.class);
+
+                    // Endpoint should still be created with custom management bean
+                    assertThat(context).hasSingleBean(ThreadDumpManagementEndpoint.class);
+                });
+    }
+
+    @Test
+    void shouldNotCreateDefaultThreadDumpManagementEndpoint_whenCustomBeanProvided() {
+        contextRunner
+                .withUserConfiguration(CustomThreadDumpEndpointConfig.class)
+                .run(context -> {
+                    assertThat(context).hasSingleBean(ThreadDumpManagementEndpoint.class);
+                    assertThat(context.getBean(ThreadDumpManagementEndpoint.class))
+                            .isExactlyInstanceOf(CustomThreadDumpManagementEndpoint.class);
+                });
+    }
+
+    @TestConfiguration
+    static class CustomThreadDumpManagementConfig {
+        @Bean
+        public ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement() {
+            return new CustomThreadDumpContentionMonitoringManagement();
+        }
+    }
+
+    @TestConfiguration
+    static class CustomThreadDumpEndpointConfig {
+        @Bean
+        public ThreadDumpManagementEndpoint threadDumpManagementEndpoint(
+                ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement) {
+            return new CustomThreadDumpManagementEndpoint(threadDumpContentionMonitoringManagement);
+        }
+    }
+
+    static class CustomThreadDumpContentionMonitoringManagement implements ThreadDumpContentionMonitoringManagement {
+        @Override
+        public void enable() {}
+
+        @Override
+        public void disable() {}
+    }
+
+    static class CustomThreadDumpManagementEndpoint extends ThreadDumpManagementEndpoint {
+        public CustomThreadDumpManagementEndpoint(
+                ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement) {
+            super(threadDumpContentionMonitoringManagement);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.sbs.spring.core.transactions.DefaultTransactionMonitoringService;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.DefaultTransactionStatsCollector;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.ProxyingDataSourceBeanPostProcessor;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.QueriesRecorder;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.SqlQueryRecord;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringBeanPostProcessor;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringService;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionStatsCollector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link TransactionMonitoringAutoConfiguration}
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ */
+class TransactionMonitoringAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-transactions-monitoring")
+            .withConfiguration(AutoConfigurations.of(TransactionMonitoringAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(TransactionMonitoringAutoConfiguration.class);
+            assertThat(context).hasSingleBean(TransactionStatsCollector.class);
+            assertThat(context).hasSingleBean(QueriesRecorder.class);
+            assertThat(context).hasSingleBean(TransactionMonitoringService.class);
+            assertThat(context).hasSingleBean(TransactionMonitoringEndpoint.class);
+            assertThat(context).hasSingleBean(TransactionMonitoringBeanPostProcessor.class);
+            assertThat(context).hasSingleBean(ProxyingDataSourceBeanPostProcessor.class);
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfiguration_whenEndpointDisabled() {
+        contextRunner // Overriding the property value to test the disabled state
+                .withPropertyValues("management.endpoints.web.exposure.exclude=axelix-transactions-monitoring")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(TransactionMonitoringAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(TransactionStatsCollector.class);
+                    assertThat(context).doesNotHaveBean(QueriesRecorder.class);
+                    assertThat(context).doesNotHaveBean(TransactionMonitoringService.class);
+                    assertThat(context).doesNotHaveBean(TransactionMonitoringEndpoint.class);
+                    assertThat(context).doesNotHaveBean(TransactionMonitoringBeanPostProcessor.class);
+                    assertThat(context).doesNotHaveBean(ProxyingDataSourceBeanPostProcessor.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfiguration_withoutRequiredProperty() {
+        ApplicationContextRunner runnerWithoutRequiredProperty = new ApplicationContextRunner()
+                .withConfiguration(
+                        AutoConfigurations.of(AxelixConfigurationsPropertiesEndpointAutoConfiguration.class));
+
+        runnerWithoutRequiredProperty.run(context -> {
+            assertThat(context).doesNotHaveBean(TransactionMonitoringAutoConfiguration.class);
+            assertThat(context).doesNotHaveBean(TransactionStatsCollector.class);
+            assertThat(context).doesNotHaveBean(QueriesRecorder.class);
+            assertThat(context).doesNotHaveBean(TransactionMonitoringService.class);
+            assertThat(context).doesNotHaveBean(TransactionMonitoringEndpoint.class);
+            assertThat(context).doesNotHaveBean(TransactionMonitoringBeanPostProcessor.class);
+            assertThat(context).doesNotHaveBean(ProxyingDataSourceBeanPostProcessor.class);
+        });
+    }
+
+    @Test
+    void shouldHandleMultipleCustomBeans() {
+        contextRunner
+                .withUserConfiguration(CustomTransactionConfiguration.class)
+                .run(context -> {
+                    assertThat(context.getBean(TransactionStatsCollector.class))
+                            .isExactlyInstanceOf(CustomTransactionStatsCollector.class);
+                    assertThat(context.getBean(QueriesRecorder.class))
+                            .isExactlyInstanceOf(CustomDefaultQueriesRecorder.class);
+                    assertThat(context.getBean(TransactionMonitoringService.class))
+                            .isExactlyInstanceOf(CustomTransactionMonitoringService.class);
+                    assertThat(context.getBean(TransactionMonitoringEndpoint.class))
+                            .isExactlyInstanceOf(CustomTransactionMonitoringEndpoint.class);
+                    assertThat(context.getBean(TransactionMonitoringBeanPostProcessor.class))
+                            .isExactlyInstanceOf(CustomTransactionMonitoringBeanPostProcessor.class);
+                    assertThat(context.getBean(ProxyingDataSourceBeanPostProcessor.class))
+                            .isExactlyInstanceOf(CustomProxyingDataSourceBeanPostProcessor.class);
+                });
+    }
+
+    @TestConfiguration
+    static class CustomTransactionConfiguration {
+
+        @Bean
+        public TransactionStatsCollector transactionStatsCollector() {
+            return new CustomTransactionStatsCollector();
+        }
+
+        @Bean
+        public TransactionMonitoringService transactionMonitoringService(
+                TransactionStatsCollector transactionStatsCollector) {
+            return new CustomTransactionMonitoringService(transactionStatsCollector);
+        }
+
+        @Bean
+        public QueriesRecorder testQueriesRecorder() {
+            return new CustomDefaultQueriesRecorder();
+        }
+
+        @Bean
+        public TransactionMonitoringEndpoint transactionMonitoringEndpoint(
+                TransactionMonitoringService transactionMonitoringService) {
+            return new CustomTransactionMonitoringEndpoint(transactionMonitoringService);
+        }
+
+        @Bean
+        public TransactionMonitoringBeanPostProcessor transactionMonitoringBeanPostProcessor(
+                TransactionStatsCollector transactionStatsCollector, QueriesRecorder queriesCollector) {
+            return new CustomTransactionMonitoringBeanPostProcessor(transactionStatsCollector, queriesCollector);
+        }
+
+        @Bean
+        public ProxyingDataSourceBeanPostProcessor transactionMonitoringDataSourceBeanPostProcessor(
+                QueriesRecorder queriesCollector) {
+            return new CustomProxyingDataSourceBeanPostProcessor(queriesCollector);
+        }
+    }
+
+    static class CustomTransactionStatsCollector extends DefaultTransactionStatsCollector {
+
+        public CustomTransactionStatsCollector() {
+            super(1000);
+        }
+    }
+
+    static class CustomDefaultQueriesRecorder implements QueriesRecorder {
+
+        @Override
+        public void startNewContext() {}
+
+        @Override
+        public void recordQuery(SqlQueryRecord query) {}
+
+        @Override
+        public List<SqlQueryRecord> popAllRecords() {
+            return List.of();
+        }
+    }
+
+    static class CustomTransactionMonitoringService extends DefaultTransactionMonitoringService {
+
+        public CustomTransactionMonitoringService(TransactionStatsCollector transactionStatsCollector) {
+            super(transactionStatsCollector);
+        }
+    }
+
+    static class CustomTransactionMonitoringEndpoint extends TransactionMonitoringEndpoint {
+
+        public CustomTransactionMonitoringEndpoint(TransactionMonitoringService transactionMonitoringService) {
+            super(transactionMonitoringService);
+        }
+    }
+
+    static class CustomTransactionMonitoringBeanPostProcessor extends TransactionMonitoringBeanPostProcessor {
+
+        public CustomTransactionMonitoringBeanPostProcessor(
+                TransactionStatsCollector transactionStatsCollector, QueriesRecorder queriesCollector) {
+            super(transactionStatsCollector, queriesCollector, null);
+        }
+    }
+
+    static class CustomProxyingDataSourceBeanPostProcessor extends ProxyingDataSourceBeanPostProcessor {
+        public CustomProxyingDataSourceBeanPostProcessor(QueriesRecorder queriesCollector) {
+            super(queriesCollector);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -19,13 +19,56 @@ package com.axelixlabs.axelix.sbs.spring.core;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixEnvironmentEndpointAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointsConfigurationPropertiesAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.GitInformationProviderAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.JwtAuthAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ScheduledTaskManagementAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.SelfRegistrationAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProviderAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.
  *
- * @author Sergey Cherkasov
+ * @author Nikita Kirillov
  */
-@SpringBootApplication
+@SpringBootApplication(
+        exclude = {
+            AxelixBeansEndpointAutoConfiguration.class,
+            AxelixCachesEndpointAutoConfiguration.class,
+            AxelixConditionsEndpointAutoConfiguration.class,
+            AxelixConfigurationsPropertiesEndpointAutoConfiguration.class,
+            AxelixDetailsEndpointAutoConfiguration.class,
+            AxelixEnvironmentEndpointAutoConfiguration.class,
+            AxelixHeapDumpEndpointAutoConfiguration.class,
+            AxelixMetadataEndpointConfiguration.class,
+            AxelixMetricsAutoConfiguration.class,
+            AxelixGcEndpointAutoConfiguration.class,
+            GitInformationProviderAutoConfiguration.class,
+            JwtAuthAutoConfiguration.class,
+            SelfRegistrationAutoConfiguration.class,
+            ScheduledTaskManagementAutoConfiguration.class,
+            ShortBuildInfoProviderAutoConfiguration.class,
+            ThreadDumpManagementEndpointAutoConfiguration.class,
+            TransactionMonitoringAutoConfiguration.class,
+            EndpointsConfigurationPropertiesAutoConfiguration.class,
+            AxelixLoggersEndpointAutoConfiguration.class
+        })
+@EnableCaching
 public class Main {
     public static void main(String[] args) {
         SpringApplication.run(Main.class, args);

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthTestConfiguration.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthTestConfiguration.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.auth;
+
+import java.time.Duration;
+
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.server.PathContainer;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
+import com.axelixlabs.axelix.common.auth.service.AuthorityResolver;
+import com.axelixlabs.axelix.common.auth.service.Authorizer;
+import com.axelixlabs.axelix.common.auth.service.DefaultAuthorizer;
+import com.axelixlabs.axelix.common.auth.service.DefaultJwtDecoderService;
+import com.axelixlabs.axelix.common.auth.service.DefaultJwtEncoderService;
+import com.axelixlabs.axelix.common.auth.service.DefaultWebIdentityAccessManager;
+import com.axelixlabs.axelix.common.auth.service.JwtDecoderService;
+import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
+import com.axelixlabs.axelix.common.auth.service.WebIdentityAccessManager;
+import com.axelixlabs.axelix.sbs.spring.core.config.AuthProperties;
+
+/**
+ * JwtAuth test configuration.
+ *
+ * @author Nikita Kirillov
+ */
+@TestConfiguration
+public class JwtAuthTestConfiguration {
+
+    @Bean
+    @ConfigurationProperties(prefix = "axelix.sbs.auth")
+    public AuthProperties authProperties() {
+        return new AuthProperties();
+    }
+
+    @Bean
+    public JwtEncoderService jwtEncoderService(AuthProperties authProperties) {
+        return new DefaultJwtEncoderService(
+                authProperties.getJwt().getAlgorithm(), authProperties.getJwt().getSigningKey(), Duration.ofHours(1));
+    }
+
+    @Bean
+    public JwtDecoderService jwtDecoderService(AuthProperties authProperties) {
+        return new DefaultJwtDecoderService(
+                authProperties.getJwt().getAlgorithm(), authProperties.getJwt().getSigningKey());
+    }
+
+    @Bean
+    public AuthorityResolver authorityResolver() {
+        return new DefaultAuthorityResolver((pathTemplate, actualPath) -> {
+            PathPattern parse = new PathPatternParser().parse(pathTemplate);
+            return parse.matchAndExtract(PathContainer.parsePath(actualPath)) != null;
+        });
+    }
+
+    @Bean
+    public Authorizer authorizer() {
+        return new DefaultAuthorizer();
+    }
+
+    @Bean
+    public WebIdentityAccessManager securityManager(
+            JwtDecoderService jwtDecoderService, AuthorityResolver authorityResolver, Authorizer authorizer) {
+        return new DefaultWebIdentityAccessManager(jwtDecoderService, authorityResolver, authorizer);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SecurityContextExecutor securityContextExecutor() {
+        return new ThreadLocalSecurityContextExecutor();
+    }
+
+    @Bean
+    public FilterRegistrationBean<JwtAuthorizationFilter> jwtAuthorizationFilterRegistration(
+            WebIdentityAccessManager webIdentityAccessManager,
+            SecurityContextExecutor securityContextExecutor,
+            WebEndpointProperties webEndpointProperties) {
+
+        var registration = new FilterRegistrationBean<>(new JwtAuthorizationFilter(
+                webIdentityAccessManager, securityContextExecutor, webEndpointProperties.getBasePath()));
+        registration.setName("jwtAuthorizationFilter");
+        return registration;
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
@@ -1,0 +1,472 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.auth;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+
+import com.axelixlabs.axelix.common.api.BeansFeed;
+import com.axelixlabs.axelix.common.auth.core.AuthenticationSchemes;
+import com.axelixlabs.axelix.common.auth.core.Authority;
+import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
+import com.axelixlabs.axelix.common.auth.core.DefaultRole;
+import com.axelixlabs.axelix.common.auth.core.DefaultUser;
+import com.axelixlabs.axelix.common.auth.core.JwtAlgorithm;
+import com.axelixlabs.axelix.common.auth.core.Role;
+import com.axelixlabs.axelix.common.auth.core.User;
+import com.axelixlabs.axelix.common.auth.service.DefaultJwtEncoderService;
+import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthorizationFilterTest.JwtAuthorizationFilterTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
+import com.axelixlabs.axelix.sbs.spring.core.beans.BeansFeedBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeanMetaInfoExtractor;
+import com.axelixlabs.axelix.sbs.spring.core.beans.QualifiersPersistencePostProcessor;
+import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.cache.CacheManagerBeanPostProcessor;
+import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
+import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheOperationsDispatcher;
+import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheSizeProvider;
+import com.axelixlabs.axelix.sbs.spring.core.cache.EnhancedCacheManager;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRefBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
+import com.axelixlabs.axelix.sbs.spring.core.env.AxelixEnvironmentEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.env.EnvironmentService;
+import com.axelixlabs.axelix.sbs.spring.core.env.EnvironmentTestConfig;
+import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link JwtAuthorizationFilter}.
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
+@TestPropertySource(
+        properties = {
+            "axelix.prop.test.name=axelix-beans",
+        })
+@Import({
+    JwtAuthorizationFilterTestConfiguration.class,
+    AxelixCachesEndpoint.class,
+    DefaultCacheOperationsDispatcher.class,
+    EnvironmentTestConfig.class,
+    JwtAuthTestConfiguration.class
+})
+class JwtAuthorizationFilterTest {
+
+    private static final String USER_NAME = "testUser";
+    private static final String PASSWORD = "testPassword";
+
+    // Cache and CacheManager names under test
+    private static final String TEST_CACHE_1 = "cache";
+    private static final String MAIN_CACHE_MANAGER = "mainCacheManager";
+
+    private EnhancedCacheManager cacheManager;
+
+    @Autowired
+    // The bean definition in the context for cache manager has a type of CacheManager,
+    // so we cannot do simple field injection via EnhancedCacheManager class.
+    public JwtAuthorizationFilterTest setCacheManager(org.springframework.cache.CacheManager cacheManager) {
+        this.cacheManager = (EnhancedCacheManager) cacheManager;
+        return this;
+    }
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @BeforeEach
+    void setUp() {
+        cacheManager.enableAll();
+        for (String cacheName : cacheManager.getCacheNames()) {
+            cacheManager.getCache(cacheName).invalidate();
+        }
+    }
+
+    @Value("${axelix.sbs.auth.jwt.lifespan}")
+    private Duration lifespan;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private JwtEncoderService jwtEncoderService;
+
+    @ParameterizedTest
+    @MethodSource("adminEndpoints")
+    void shouldAllowAccess_ForUserWithRoleAdmin(String path, HttpMethod httpMethod) {
+        buildCache();
+        User user = new DefaultUser(USER_NAME, PASSWORD, Set.of(DefaultRole.ADMIN));
+        HttpEntity<Void> entity = defaultEntity(jwtEncoderService.generateToken(user));
+
+        ResponseEntity<Void> response = testRestTemplate.exchange(path, httpMethod, entity, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @ParameterizedTest
+    @MethodSource("adminEndpoints")
+    void shouldAllowAccess_MultipleRoles(String path, HttpMethod httpMethod) {
+        buildCache();
+        User user =
+                new DefaultUser(USER_NAME, PASSWORD, Set.of(DefaultRole.ADMIN, DefaultRole.EDITOR, DefaultRole.VIEWER));
+        HttpEntity<Void> entity = defaultEntity(jwtEncoderService.generateToken(user));
+
+        ResponseEntity<Void> response = testRestTemplate.exchange(path, httpMethod, entity, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @ParameterizedTest
+    @MethodSource("editorEndpoints")
+    void shouldAllowAccess_ForUserWithRoleEditor(String path, HttpMethod httpMethod) {
+        buildCache();
+        User user = new DefaultUser(USER_NAME, PASSWORD, Set.of(DefaultRole.EDITOR));
+        HttpEntity<Void> entity = defaultEntity(jwtEncoderService.generateToken(user));
+
+        ResponseEntity<Void> response = testRestTemplate.exchange(path, httpMethod, entity, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @ParameterizedTest
+    @MethodSource("viewerEndpoints")
+    void shouldAllowAccess_ForUserWithRoleViewer(String path, HttpMethod httpMethod) {
+        buildCache();
+        User user = new DefaultUser(USER_NAME, PASSWORD, Set.of(DefaultRole.VIEWER));
+        HttpEntity<Void> entity = defaultEntity(jwtEncoderService.generateToken(user));
+
+        ResponseEntity<Void> response = testRestTemplate.exchange(path, httpMethod, entity, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @ParameterizedTest
+    @MethodSource("viewerEndpoints")
+    void shouldAllowAccess_UserWithEmptyRoles(String path, HttpMethod httpMethod) {
+        buildCache();
+        User user = new DefaultUser(USER_NAME, PASSWORD, Set.of());
+        HttpEntity<Void> entity = defaultEntity(jwtEncoderService.generateToken(user));
+
+        ResponseEntity<String> response = restTemplate.exchange(path, httpMethod, entity, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @ParameterizedTest
+    @MethodSource("notAuthorityForRole")
+    void shouldReturnForbidden_UserWithoutRequiredAuthority_ForUserWithRoleViewer(String path, HttpMethod httpMethod) {
+        buildCache();
+        User user = new DefaultUser(USER_NAME, PASSWORD, Set.of(DefaultRole.VIEWER));
+        HttpEntity<Void> entity = defaultEntity(jwtEncoderService.generateToken(user));
+
+        ResponseEntity<Void> response = testRestTemplate.exchange(path, httpMethod, entity, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @ParameterizedTest
+    @MethodSource("notAuthorityForRole")
+    void shouldReturnForbidden_UserWithEmptyRoles(String path, HttpMethod httpMethod) {
+        buildCache();
+        User user = new DefaultUser(USER_NAME, PASSWORD, Set.of());
+        HttpEntity<Void> entity = defaultEntity(jwtEncoderService.generateToken(user));
+
+        ResponseEntity<String> response = restTemplate.exchange(path, httpMethod, entity, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void shouldReturnUnauthorized_AuthorizationHeaderIsMalformed() {
+        User user = new DefaultUser(USER_NAME, PASSWORD, Set.of(DefaultRole.VIEWER));
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "BearerToken" + jwtEncoderService.generateToken(user));
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response =
+                restTemplate.exchange("/actuator/axelix-beans", HttpMethod.GET, entity, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void shouldReturnForbidden_UserHasRoleWithInvalidAuthority() {
+        Role role = new DefaultRole("VIEWER", Set.of(UnrecognizedAuthority.UNRECOGNIZED_AUTHORITY));
+        User user = new DefaultUser(USER_NAME, PASSWORD, Set.of(role));
+        String token = jwtEncoderService.generateToken(user);
+        buildCache();
+
+        ResponseEntity<Void> response = testRestTemplate.exchange(
+                path(TEST_CACHE_1 + "/clear?key=key1"), HttpMethod.DELETE, defaultEntity(token), Void.class);
+
+        assertThat(response).returns(HttpStatus.FORBIDDEN, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldReturnUnauthorized_TokenIsTampered() {
+        User user = new DefaultUser(USER_NAME, PASSWORD, Set.of(DefaultRole.ADMIN));
+        String token = jwtEncoderService.generateToken(user);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/actuator/axelix-beans", HttpMethod.GET, defaultEntity(token + "x"), String.class);
+
+        assertThat(response).returns(HttpStatus.UNAUTHORIZED, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldReturnUnauthorized_TokenSigningKeyIsTampered() {
+        String wrongSecret = "MX3TNBx0j8bGCjGWCvq1JffIqqzXLIV-URlKFLX4mfA";
+        JwtEncoderService encoderWithWrongSecret =
+                new DefaultJwtEncoderService(JwtAlgorithm.HMAC256, wrongSecret, lifespan);
+
+        User user = new DefaultUser(USER_NAME, PASSWORD, Set.of());
+        String token = encoderWithWrongSecret.generateToken(user);
+
+        ResponseEntity<String> response =
+                restTemplate.exchange("/actuator/axelix-beans", HttpMethod.GET, defaultEntity(token), String.class);
+
+        assertThat(response).returns(HttpStatus.UNAUTHORIZED, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldReturnUnauthorized_TokenIsExpired() {
+        User user = new DefaultUser(USER_NAME, PASSWORD, Set.of(DefaultRole.ADMIN));
+        String token = jwtEncoderService.generateToken(user, Duration.ofDays(0));
+
+        ResponseEntity<String> response =
+                restTemplate.exchange("/actuator/axelix-beans", HttpMethod.GET, defaultEntity(token), String.class);
+
+        assertThat(response).returns(HttpStatus.UNAUTHORIZED, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldReturnUnauthorized_TokenIsMissing() {
+        ResponseEntity<String> response =
+                restTemplate.exchange("/actuator/axelix-beans", HttpMethod.GET, defaultEntity(""), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void shouldReturnAllowNonAxelixActuatorEndpointToBeInvokedWithoutToken() {
+        ResponseEntity<String> response = restTemplate.getForEntity("/actuator/health", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void shouldReturnForbidden_TokenWithNullNameRoles() {
+        Role role = new DefaultRole(null, Set.of(DefaultAuthority.CACHES_CLEAR));
+        User user = new DefaultUser(USER_NAME, PASSWORD, Set.of(role));
+        String token = jwtEncoderService.generateToken(user);
+
+        ResponseEntity<String> response =
+                restTemplate.exchange("/actuator/axelix-beans", HttpMethod.GET, defaultEntity(token), String.class);
+
+        assertThat(response).returns(HttpStatus.UNAUTHORIZED, ResponseEntity::getStatusCode);
+    }
+
+    static Stream<Arguments> adminEndpoints() {
+        return Stream.of(
+                Arguments.of("/actuator/axelix-caches", HttpMethod.GET),
+                Arguments.of(path(TEST_CACHE_1), HttpMethod.GET),
+                Arguments.of(path(TEST_CACHE_1 + "/clear?key=key1"), HttpMethod.DELETE),
+                Arguments.of(path(TEST_CACHE_1 + "/clear"), HttpMethod.DELETE),
+                Arguments.of(path("/clear-all"), HttpMethod.DELETE),
+                Arguments.of(path("/disable"), HttpMethod.POST),
+                Arguments.of(path("/enable"), HttpMethod.POST),
+                Arguments.of(path(TEST_CACHE_1 + "/disable"), HttpMethod.POST),
+                Arguments.of(path(TEST_CACHE_1 + "/enable"), HttpMethod.POST),
+                Arguments.of("/actuator/axelix-env", HttpMethod.GET),
+                Arguments.of("/actuator/axelix-beans", HttpMethod.GET));
+    }
+
+    static Stream<Arguments> editorEndpoints() {
+        return Stream.of(
+                Arguments.of("/actuator/axelix-caches", HttpMethod.GET),
+                Arguments.of(path(TEST_CACHE_1), HttpMethod.GET),
+                Arguments.of(path(TEST_CACHE_1 + "/clear?key=key1"), HttpMethod.DELETE),
+                Arguments.of(path(TEST_CACHE_1 + "/clear"), HttpMethod.DELETE),
+                Arguments.of(path("/clear-all"), HttpMethod.DELETE),
+                Arguments.of(path("/disable"), HttpMethod.POST),
+                Arguments.of(path("/enable"), HttpMethod.POST),
+                Arguments.of(path(TEST_CACHE_1 + "/disable"), HttpMethod.POST),
+                Arguments.of(path(TEST_CACHE_1 + "/enable"), HttpMethod.POST),
+                Arguments.of("/actuator/axelix-beans", HttpMethod.GET));
+    }
+
+    static Stream<Arguments> viewerEndpoints() {
+        return Stream.of(
+                Arguments.of("/actuator/axelix-caches", HttpMethod.GET),
+                Arguments.of(path(TEST_CACHE_1), HttpMethod.GET),
+                Arguments.of("/actuator/axelix-beans", HttpMethod.GET));
+    }
+
+    static Stream<Arguments> notAuthorityForRole() {
+        return Stream.of(
+                Arguments.of(path(TEST_CACHE_1 + "/clear?key=key1"), HttpMethod.DELETE),
+                Arguments.of(path(TEST_CACHE_1 + "/clear"), HttpMethod.DELETE),
+                Arguments.of(path("/clear-all"), HttpMethod.DELETE),
+                Arguments.of(path("/disable"), HttpMethod.POST),
+                Arguments.of(path("/enable"), HttpMethod.POST),
+                Arguments.of(path(TEST_CACHE_1 + "/disable"), HttpMethod.POST),
+                Arguments.of(path(TEST_CACHE_1 + "/enable"), HttpMethod.POST));
+    }
+
+    private HttpEntity<Void> defaultEntity(String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, AuthenticationSchemes.BEARER.prefix() + token);
+
+        return new HttpEntity<>(headers);
+    }
+
+    private static String path(String relative) {
+        return path(MAIN_CACHE_MANAGER, relative);
+    }
+
+    private static String path(String cacheManagerName, String relative) {
+        relative = prefixPathIfNeeded(relative);
+        cacheManagerName = prefixPathIfNeeded(cacheManagerName);
+
+        return "/actuator/axelix-caches" + cacheManagerName + relative;
+    }
+
+    private static String prefixPathIfNeeded(String path) {
+        return (path.isEmpty() || path.charAt(0) == '/') ? path : "/" + path;
+    }
+
+    private void buildCache() {
+        cacheManager.getCache(TEST_CACHE_1).put("key1", "value1");
+    }
+
+    enum UnrecognizedAuthority implements Authority {
+        UNRECOGNIZED_AUTHORITY;
+
+        @Override
+        public String getName() {
+            return name();
+        }
+    }
+
+    @TestConfiguration
+    static class JwtAuthorizationFilterTestConfiguration {
+
+        @Bean
+        public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
+            return new DefaultConditionalBeanRefBuilder();
+        }
+
+        @Bean
+        public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
+            return new QualifiersPersistencePostProcessor();
+        }
+
+        @Bean
+        public BeanMetaInfoExtractor beanMetaInfoExtractor(
+                ConfigurableApplicationContext configurableApplicationContext,
+                ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
+            return new DefaultBeanMetaInfoExtractor(configurableApplicationContext, conditionalBeanRefBuilder);
+        }
+
+        @Bean
+        public BeansFeedBuilder noOpBeanFeedBuilder() {
+            return () -> new BeansFeed(List.of());
+        }
+
+        @Bean
+        public AxelixBeansEndpoint axelixBeansEndpoint(BeansFeedBuilder noOpBeanFeedBuilder) {
+            return new AxelixBeansEndpoint(noOpBeanFeedBuilder);
+        }
+
+        @Bean
+        public EndpointsConfigurationProperties endpointsConfigurationProperties() {
+            return new EndpointsConfigurationProperties();
+        }
+
+        @Bean
+        public AxelixEnvironmentEndpoint axelixEnvironmentEndpoint(EnvironmentService environmentService) {
+            return new AxelixEnvironmentEndpoint(environmentService);
+        }
+
+        @Bean
+        public SmartSanitizingFunction smartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
+            return new SmartSanitizingFunction(
+                    List.of("axelix.env.test.toBeSanitized", "AXELIX_FOR_SANITIZATION"), propertyNameNormalizer);
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public CacheSizeProvider cacheSizeProvider() {
+            return new DefaultCacheSizeProvider();
+        }
+
+        @Bean
+        public static CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
+                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
+            return new CacheManagerBeanPostProcessor(axelixMetricsPublisherObjectProvider);
+        }
+
+        @Bean
+        public AxelixMetricsPublisher axelixMetricsPublisher() {
+            return new DefaultAxelixMetricsPublisher(new SimpleMeterRegistry());
+        }
+
+        @Bean(name = MAIN_CACHE_MANAGER)
+        public org.springframework.cache.CacheManager testSubjectCacheManager() {
+            return new ConcurrentMapCacheManager(TEST_CACHE_1);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpointTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.beans;
+
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.condition.ConditionsReportEndpoint;
+import org.springframework.boot.actuate.beans.BeansEndpoint;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+
+import com.axelixlabs.axelix.common.api.BeansFeed;
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRefBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
+
+/**
+ * Integration tests for {@link AxelixBeansEndpoint}.
+ *
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest(
+        classes = AxelixBeansEndpointTest.CurrentConfiguration.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"axelix.prop.test.name=axelix-beans"})
+@Import({BeansEndpoint.class, AxelixBeansEndpoint.class, ConditionsReportEndpoint.class, JwtAuthTestConfiguration.class
+})
+class AxelixBeansEndpointTest {
+
+    @Autowired
+    private TestRestTemplateBuilder testRestTemplate;
+
+    @TestConfiguration(value = "testCurrentConfiguration")
+    @EnableConfigurationProperties(AxelixPropTest.class)
+    static class CurrentConfiguration {
+
+        static final String QUALIFIERS_PERSISTENCE_POST_PROCESSOR = "qualifiersPersistencePostProcessor";
+        static final String BEAN_META_INFO_EXTRACTOR = "beanMetaInfoExtractor";
+        static final String CUSTOM_SUPPLIER = "customSupplier";
+
+        @Bean
+        public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
+            return new DefaultConditionalBeanRefBuilder();
+        }
+
+        @Bean
+        public BeansFeedBuilder testBeansFeedBuilder(
+                BeanMetaInfoExtractor beanMetaInfoExtractor,
+                ConfigurableApplicationContext configurableApplicationContext) {
+            return new DefaultBeansFeedBuilder(beanMetaInfoExtractor, configurableApplicationContext);
+        }
+
+        @Bean(BEAN_META_INFO_EXTRACTOR)
+        public BeanMetaInfoExtractor beanMetaInfoExtractor(
+                ConfigurableApplicationContext configurableApplicationContext,
+                ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
+            return new DefaultBeanMetaInfoExtractor(configurableApplicationContext, conditionalBeanRefBuilder);
+        }
+
+        @Bean(QUALIFIERS_PERSISTENCE_POST_PROCESSOR)
+        public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
+            return new QualifiersPersistencePostProcessor();
+        }
+
+        @Bean(CUSTOM_SUPPLIER)
+        public Supplier<String> customSupplier() {
+            return () -> "value";
+        }
+    }
+
+    @ConfigurationProperties(prefix = "axelix.prop.test")
+    static class AxelixPropTest {
+
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    void shouldReturnEnrichedBeansFeed() {
+
+        // when.
+        ResponseEntity<BeansFeed> response =
+                testRestTemplate.asViewer().getForEntity("/actuator/axelix-beans", BeansFeed.class);
+
+        // then.
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+
+        BeansFeed beanNameToBeanProfile = response.getBody();
+
+        assertQualifiersPostProcessorBean(beanNameToBeanProfile);
+        assertBeanMetaInfoExtractor(beanNameToBeanProfile);
+        assertCustomBeanSupplier(beanNameToBeanProfile);
+        assertConfigPropsBeanName(beanNameToBeanProfile);
+    }
+
+    @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-beans")
+    void negativeAuthTests() {}
+
+    private static void assertQualifiersPostProcessorBean(BeansFeed beanNameToBeanFeed) {
+        BeansFeed.Bean bean = getBean(beanNameToBeanFeed, CurrentConfiguration.QUALIFIERS_PERSISTENCE_POST_PROCESSOR);
+
+        assertThat(bean.getBeanSource()).isInstanceOf(BeansFeed.BeanMethod.class);
+        assertThat(bean.getBeanSource())
+                .asInstanceOf(type(BeansFeed.BeanMethod.class))
+                .satisfies(beanMethod -> {
+                    assertThat(beanMethod.getMethodName())
+                            .isEqualTo(CurrentConfiguration.QUALIFIERS_PERSISTENCE_POST_PROCESSOR);
+                    assertThat(beanMethod.getEnclosingClassName()).isEqualTo("CurrentConfiguration");
+                });
+        assertThat(bean.isConfigPropsBean()).isFalse();
+        assertThat(bean.getAutoConfigurationRef()).isNull();
+        assertThat(bean.getAliases()).isEmpty();
+        assertThat(bean.getDependencies()).isEmpty();
+        assertThat(bean.isLazyInit()).isFalse();
+        assertThat(bean.isPrimary()).isFalse();
+        assertThat(bean.getQualifiers()).isEmpty();
+        assertThat(bean.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+        assertThat(bean.getClassName()).isEqualTo(QualifiersPersistencePostProcessor.class.getName());
+    }
+
+    private static void assertBeanMetaInfoExtractor(BeansFeed beanNameToBeanFeed) {
+        BeansFeed.Bean bean = getBean(beanNameToBeanFeed, CurrentConfiguration.BEAN_META_INFO_EXTRACTOR);
+
+        assertThat(bean.getBeanSource()).isInstanceOf(BeansFeed.BeanMethod.class);
+        assertThat(bean.getBeanSource())
+                .asInstanceOf(type(BeansFeed.BeanMethod.class))
+                .satisfies(beanMethod -> {
+                    assertThat(beanMethod.getMethodName()).isEqualTo(CurrentConfiguration.BEAN_META_INFO_EXTRACTOR);
+                    assertThat(beanMethod.getEnclosingClassName()).isEqualTo("CurrentConfiguration");
+                });
+        assertThat(bean.isConfigPropsBean()).isFalse();
+        assertThat(bean.getAutoConfigurationRef()).isNull();
+        assertThat(bean.getAliases()).isEmpty();
+        assertThat(bean.getDependencies())
+                .hasSize(2)
+                .contains(new BeansFeed.BeanDependency(
+                        "conditionalBeanRefBuilder", false)); // second bean is the application context itself
+        assertThat(bean.isLazyInit()).isFalse();
+        assertThat(bean.isPrimary()).isFalse();
+        assertThat(bean.getQualifiers()).isEmpty();
+        assertThat(bean.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+        assertThat(bean.getClassName()).isEqualTo(DefaultBeanMetaInfoExtractor.class.getName());
+    }
+
+    private static void assertCustomBeanSupplier(BeansFeed beanNameToBeanFeed) {
+        BeansFeed.Bean bean = getBean(beanNameToBeanFeed, CurrentConfiguration.CUSTOM_SUPPLIER);
+
+        assertThat(bean.getBeanSource()).isInstanceOf(BeansFeed.BeanMethod.class);
+        assertThat(bean.getBeanSource())
+                .asInstanceOf(type(BeansFeed.BeanMethod.class))
+                .satisfies(beanMethod -> {
+                    assertThat(beanMethod.getMethodName()).isEqualTo(CurrentConfiguration.CUSTOM_SUPPLIER);
+                    assertThat(beanMethod.getEnclosingClassName()).isEqualTo("CurrentConfiguration");
+                });
+        assertThat(bean.isConfigPropsBean()).isFalse();
+        assertThat(bean.getAutoConfigurationRef()).isNull();
+        assertThat(bean.getAliases()).isEmpty();
+        assertThat(bean.getDependencies()).isEmpty();
+        assertThat(bean.isLazyInit()).isFalse();
+        assertThat(bean.isPrimary()).isFalse();
+        assertThat(bean.getQualifiers()).isEmpty();
+        assertThat(bean.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+        assertThat(bean.getClassName()).isEqualTo(Supplier.class.getName());
+    }
+
+    private static void assertConfigPropsBeanName(BeansFeed beanNameToBeanFeed) {
+        BeansFeed.Bean bean = getBean(beanNameToBeanFeed, AxelixPropTest.class.getName());
+
+        assertThat(bean.getClassName()).isEqualTo(AxelixPropTest.class.getName());
+        assertThat(bean.getBeanSource()).isNotNull();
+        assertThat(bean.isConfigPropsBean()).isTrue();
+        assertThat(bean.getAutoConfigurationRef()).isNull();
+        assertThat(bean.getAliases()).isEmpty();
+        assertThat(bean.getDependencies()).isEmpty();
+        assertThat(bean.isLazyInit()).isFalse();
+        assertThat(bean.isPrimary()).isFalse();
+        assertThat(bean.getQualifiers()).isEmpty();
+        assertThat(bean.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+    }
+
+    private static BeansFeed.Bean getBean(BeansFeed beanNameToBeanFeed, String beanName) {
+        return beanNameToBeanFeed.getBeans().stream()
+                .filter(bean -> bean.getBeanName().equals(beanName))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeanMetaInfoExtractorTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeanMetaInfoExtractorTest.java
@@ -1,0 +1,503 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.beans;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.sql.DataSource;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.boot.cache.autoconfigure.CacheAutoConfiguration;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.axelixlabs.axelix.common.api.BeansFeed;
+import com.axelixlabs.axelix.common.api.BeansFeed.ComponentVariant;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRefBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link DefaultBeanMetaInfoExtractor}.
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest(classes = DefaultBeanMetaInfoExtractorTest.DefaultBeanAnalyzerTestConfig.class)
+class DefaultBeanMetaInfoExtractorTest {
+
+    @Autowired
+    private BeanMetaInfoExtractor metaInfoExtractor;
+
+    @Autowired
+    private ConfigurableListableBeanFactory testBeanFactory;
+
+    @Test
+    void shouldExtractForSimpleServiceBean() {
+        BeanMetaInfo beanMetaInfo =
+                metaInfoExtractor.extract(DefaultBeanAnalyzerTestConfig.REGULAR_COMPONENT, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+            assertThat(it.getQualifiers()).isEmpty();
+            assertThat(it.getBeanSource()).isInstanceOf(ComponentVariant.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+        });
+    }
+
+    @Test
+    void shouldExtractForAutoConfigurationBeanClass() {
+        BeanMetaInfo beanMetaInfo = metaInfoExtractor.extract(CacheAutoConfiguration.class.getName(), testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+            assertThat(it.getQualifiers()).isEmpty();
+            assertThat(it.getAutoConfigurationRef()).isEqualTo("CacheAutoConfiguration");
+            assertThat(it.getBeanSource()).isInstanceOf(ComponentVariant.class);
+        });
+    }
+
+    @Test
+    void shouldExtractForAutoConfigurationBeanMethod() {
+        BeanMetaInfo beanMetaInfo = metaInfoExtractor.extract("cacheManagerCustomizers", testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+            assertThat(it.getQualifiers()).isEmpty();
+            assertThat(it.getAutoConfigurationRef()).isEqualTo("CacheAutoConfiguration#cacheManagerCustomizers");
+            assertThat(it.getBeanSource()).isInstanceOf(BeansFeed.BeanMethod.class);
+            assertThat((BeansFeed.BeanMethod) it.getBeanSource()).satisfies(beanMethod -> {
+                assertThat(beanMethod.getEnclosingClassFullName()).isEqualTo(CacheAutoConfiguration.class.getName());
+                assertThat(beanMethod.getMethodName()).isEqualTo("cacheManagerCustomizers");
+            });
+        });
+    }
+
+    @Test
+    void shouldExtractLazyServiceBean() {
+        BeanMetaInfo beanMetaInfo =
+                metaInfoExtractor.extract(DefaultBeanAnalyzerTestConfig.LAZY_COMPONENT, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isTrue();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+            assertThat(it.getQualifiers()).isEmpty();
+            assertThat(it.getBeanSource()).isInstanceOf(ComponentVariant.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+        });
+    }
+
+    @Test
+    void shouldExtractPrimaryComponentBean() {
+        BeanMetaInfo beanMetaInfo =
+                metaInfoExtractor.extract(DefaultBeanAnalyzerTestConfig.PRIMARY_COMPONENT, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isTrue();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+            assertThat(it.getQualifiers()).isEmpty();
+            assertThat(it.getBeanSource()).isInstanceOf(ComponentVariant.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+        });
+    }
+
+    @Test
+    void shouldExtractQualifiedServiceBean() {
+        BeanMetaInfo beanMetaInfo =
+                metaInfoExtractor.extract(DefaultBeanAnalyzerTestConfig.QUALIFIED_COMPONENT, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+            assertThat(it.getQualifiers()).contains(DefaultBeanAnalyzerTestConfig.QUALIFIED_COMPONENT);
+            assertThat(it.getBeanSource()).isInstanceOf(ComponentVariant.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+        });
+    }
+
+    @Test
+    void shouldExtractLazyPrimaryBeanMethod() {
+        BeanMetaInfo beanMetaInfo =
+                metaInfoExtractor.extract(DefaultBeanAnalyzerTestConfig.LAZY_PRIMARY_BEAN_METHOD, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isTrue();
+            assertThat(it.isPrimary()).isTrue();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+            assertThat(it.getQualifiers()).isEmpty();
+            assertThat(it.getBeanSource()).isInstanceOf(BeansFeed.BeanMethod.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+            assertThat((BeansFeed.BeanMethod) it.getBeanSource()).satisfies(bs -> {
+                assertThat(bs.getEnclosingClassName()).isEqualTo(DefaultBeanAnalyzerTestConfig.class.getSimpleName());
+                assertThat(bs.getEnclosingClassFullName()).isEqualTo(DefaultBeanAnalyzerTestConfig.class.getName());
+                assertThat(bs.getMethodName()).isEqualTo("lazyPrimaryBean");
+            });
+        });
+    }
+
+    @Test
+    void shouldExtractQualifiedBeanMethod() {
+        BeanMetaInfo beanMetaInfo =
+                metaInfoExtractor.extract(DefaultBeanAnalyzerTestConfig.QUALIFIED_BEAN_METHOD, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+            assertThat(it.getQualifiers()).contains(DefaultBeanAnalyzerTestConfig.QUALIFIED_BEAN_METHOD);
+            assertThat(it.getBeanSource()).isInstanceOf(BeansFeed.BeanMethod.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+            assertThat((BeansFeed.BeanMethod) it.getBeanSource()).satisfies(bs -> {
+                assertThat(bs.getEnclosingClassName()).isEqualTo(DefaultBeanAnalyzerTestConfig.class.getSimpleName());
+                assertThat(bs.getEnclosingClassFullName()).isEqualTo(DefaultBeanAnalyzerTestConfig.class.getName());
+                assertThat(bs.getMethodName()).isEqualTo(DefaultBeanAnalyzerTestConfig.QUALIFIED_BEAN_METHOD);
+            });
+        });
+    }
+
+    @Test
+    void shouldExtractSpringDataRepositoryBean() {
+        BeanMetaInfo beanMetaInfo =
+                metaInfoExtractor.extract(DefaultBeanAnalyzerTestConfig.SPRING_DATA_REPOSITORY, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.JDK_PROXY);
+            assertThat(it.getQualifiers()).isEmpty();
+            assertThat(it.getBeanSource()).isInstanceOf(BeansFeed.FactoryBean.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+            assertThat((BeansFeed.FactoryBean) it.getBeanSource()).satisfies(bs -> {
+                assertThat(bs.getFactoryBeanName()).isEqualTo(JpaRepositoryFactoryBean.class.getName());
+            });
+        });
+    }
+
+    @Test
+    void shouldExtractCustomQualifierAnnotations() {
+        BeanMetaInfo beanMetaInfo = metaInfoExtractor.extract(
+                DefaultBeanAnalyzerTestConfig.CUSTOM_DATABASE_QUALIFIER_BEAN, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+            assertThat(it.getQualifiers()).contains(DefaultBeanAnalyzerTestConfig.CUSTOM_DATABASE_QUALIFIER_BEAN);
+            assertThat(it.getBeanSource()).isInstanceOf(ComponentVariant.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+        });
+    }
+
+    @Test
+    void shouldExtractConfigurationBean() {
+        BeanMetaInfo beanMetaInfo =
+                metaInfoExtractor.extract(DefaultBeanAnalyzerTestConfig.CONFIGURATION_BEAN, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.CGLIB);
+            assertThat(it.getBeanSource()).isInstanceOf(ComponentVariant.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+        });
+    }
+
+    @Test
+    void shouldExtractTransactionalBean() {
+        BeanMetaInfo beanMetaInfo =
+                metaInfoExtractor.extract(DefaultBeanAnalyzerTestConfig.TRANSACTIONAL_BEAN, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.CGLIB);
+            assertThat(it.getBeanSource()).isInstanceOf(ComponentVariant.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+        });
+    }
+
+    @Test
+    void shouldExtractBeanFromAnonymousClass() {
+        BeanMetaInfo beanMetaInfo =
+                metaInfoExtractor.extract(DefaultBeanAnalyzerTestConfig.ANONYMOUS_BEAN, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+            assertThat(it.getBeanSource()).isInstanceOf(BeansFeed.BeanMethod.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+
+            BeansFeed.BeanMethod source = (BeansFeed.BeanMethod) it.getBeanSource();
+            assertThat(source.getEnclosingClassName()).isEqualTo(DefaultBeanAnalyzerTestConfig.class.getSimpleName());
+            assertThat(source.getEnclosingClassFullName()).isEqualTo(DefaultBeanAnalyzerTestConfig.class.getName());
+            assertThat(source.getMethodName()).isEqualTo(DefaultBeanAnalyzerTestConfig.ANONYMOUS_BEAN);
+        });
+    }
+
+    @Test
+    void shouldExtractInfoForStaticBeanFactoryPostProcessorBean() {
+        BeanMetaInfo beanMetaInfo =
+                metaInfoExtractor.extract(DefaultBeanAnalyzerTestConfig.STATIC_BFPP_BEAN, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getBeanSource()).isInstanceOf(BeansFeed.BeanMethod.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+
+            BeansFeed.BeanMethod source = (BeansFeed.BeanMethod) it.getBeanSource();
+            assertThat(source.getEnclosingClassName()).isEqualTo(DefaultBeanAnalyzerTestConfig.class.getSimpleName());
+            assertThat(source.getEnclosingClassFullName()).isEqualTo(DefaultBeanAnalyzerTestConfig.class.getName());
+            assertThat(source.getMethodName()).isEqualTo(DefaultBeanAnalyzerTestConfig.STATIC_BFPP_BEAN);
+        });
+    }
+
+    @Test
+    void shouldExtractInfoForSyntheticallyGeneratedBean() {
+        BeanMetaInfo beanMetaInfo =
+                metaInfoExtractor.extract(DefaultBeanAnalyzerTestConfig.SYNTHETIC_BEAN_DEFINITION, testBeanFactory);
+
+        assertThat(beanMetaInfo).satisfies(it -> {
+            assertThat(it.getProxyType()).isEqualTo(BeansFeed.ProxyType.NO_PROXYING);
+            assertThat(it.isLazyInit()).isFalse();
+            assertThat(it.isPrimary()).isFalse();
+            assertThat(it.getBeanSource()).isInstanceOf(BeansFeed.SyntheticBean.class);
+            assertThat(it.getAutoConfigurationRef()).isNull();
+        });
+    }
+
+    @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Qualifier(DefaultBeanAnalyzerTestConfig.CUSTOM_DATABASE_QUALIFIER_BEAN)
+    public @interface CustomDatabaseQualifier {}
+
+    /**
+     * Static nested configuration class for {@link DefaultBeanMetaInfoExtractorTest}.
+     */
+    @TestConfiguration
+    @EnableJpaRepositories(
+            basePackageClasses = DefaultBeanAnalyzerTestConfig.MyRepository.class,
+            considerNestedRepositories = true)
+    @EntityScan(basePackageClasses = DefaultBeanAnalyzerTestConfig.MyEntity.class)
+    public static class DefaultBeanAnalyzerTestConfig {
+
+        static final String PRIMARY_COMPONENT = "primaryComponent";
+
+        static final String LAZY_COMPONENT = "lazyComponentAnnotation";
+
+        static final String REGULAR_COMPONENT = "fromServiceAnnotation";
+
+        static final String QUALIFIED_COMPONENT = "qualifiedService";
+
+        static final String LAZY_PRIMARY_BEAN_METHOD = "lazyPrimaryBeanMethod";
+
+        static final String QUALIFIED_BEAN_METHOD = "qualifiedBeanMethod";
+
+        static final String CONFIGURATION_BEAN = "configurationBean";
+
+        static final String TRANSACTIONAL_BEAN = "transactionalBean";
+
+        static final String SPRING_DATA_REPOSITORY = "MyRepository";
+
+        static final String CUSTOM_DATABASE_QUALIFIER_BEAN = "CustomDatabaseQualifierBean";
+
+        static final String ANONYMOUS_BEAN = "anonymousBean";
+
+        static final String STATIC_BFPP_BEAN = "staticBFPPBean";
+
+        static final String BEAN_DEFINITION_REGISTRY_BEAN = "BEAN_DEFINITION_REGISTRY_BEAN";
+
+        static final String SYNTHETIC_BEAN_DEFINITION = "SYNTHETIC_BEAN_DEFINITION";
+
+        @Service(REGULAR_COMPONENT)
+        static class FromServiceAnnotation {}
+
+        @Component(LAZY_COMPONENT)
+        @Lazy
+        static class LazyComponentAnnotation {}
+
+        @Component(PRIMARY_COMPONENT)
+        @Primary
+        static class PrimaryComponent {}
+
+        @Service(QUALIFIED_COMPONENT)
+        @Qualifier(QUALIFIED_COMPONENT)
+        static class QualifiedService {}
+
+        @Bean(LAZY_PRIMARY_BEAN_METHOD)
+        @Lazy
+        @Primary
+        public String lazyPrimaryBean() {
+            return LAZY_PRIMARY_BEAN_METHOD;
+        }
+
+        @Bean
+        public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
+            return new QualifiersPersistencePostProcessor();
+        }
+
+        @Bean
+        public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
+            LocalContainerEntityManagerFactoryBean emf = new LocalContainerEntityManagerFactoryBean();
+            emf.setDataSource(dataSource);
+            emf.setPackagesToScan(MyEntity.class.getPackageName());
+
+            JpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+            emf.setJpaVendorAdapter(vendorAdapter);
+
+            emf.getJpaPropertyMap().put("hibernate.hbm2ddl.auto", "create-drop");
+            return emf;
+        }
+
+        @Bean
+        public PlatformTransactionManager transactionManager(EntityManagerFactory emf) {
+            return new JpaTransactionManager(emf);
+        }
+
+        @Bean
+        public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
+            return new DefaultConditionalBeanRefBuilder();
+        }
+
+        @Bean
+        public BeanMetaInfoExtractor beanMetaInfoExtractor(
+                ConfigurableApplicationContext configurableApplicationContext,
+                ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
+            return new DefaultBeanMetaInfoExtractor(configurableApplicationContext, conditionalBeanRefBuilder);
+        }
+
+        @Entity
+        @Table(name = "my_entity")
+        public static class MyEntity {
+            @Id
+            @GeneratedValue(strategy = GenerationType.AUTO)
+            private Long id;
+        }
+
+        @Repository(SPRING_DATA_REPOSITORY)
+        public interface MyRepository extends JpaRepository<MyEntity, Long> {}
+
+        @Bean
+        @Qualifier(QUALIFIED_BEAN_METHOD)
+        public String qualifiedBeanMethod() {
+            return QUALIFIED_BEAN_METHOD;
+        }
+
+        @Configuration(CONFIGURATION_BEAN)
+        public static class ConfigurationBean {}
+
+        @Service(TRANSACTIONAL_BEAN)
+        public static class TransactionalClass {
+
+            @Autowired
+            private JdbcTemplate jdbcTemplate;
+
+            @Transactional
+            public void execute() {
+                // code
+            }
+        }
+
+        @Service(CUSTOM_DATABASE_QUALIFIER_BEAN)
+        @CustomDatabaseQualifier
+        static class CustomDatabaseQualifierBean {}
+
+        // IMPORTANT! Intentionally using explicit anonymous class `new Runnable()`
+        // instead of lambda to ensure Class.isAnonymousClass() returns true.
+        @Bean(ANONYMOUS_BEAN)
+        public Runnable anonymousBean() {
+            return new Runnable() {
+                @Override
+                public void run() {}
+            };
+        }
+
+        @Bean(STATIC_BFPP_BEAN)
+        public static BeanFactoryPostProcessor staticBFPPBean() {
+            return beanFactory -> {};
+        }
+
+        @Bean(BEAN_DEFINITION_REGISTRY_BEAN)
+        public static BeanDefinitionRegistryPostProcessor beanDefinitionRegistryPostProcessor() {
+
+            return new BeanDefinitionRegistryPostProcessor() {
+
+                @Override
+                public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+                    RootBeanDefinition beanDefinition = new RootBeanDefinition();
+                    beanDefinition.setSynthetic(true);
+                    beanDefinition.setBeanClass(Object.class);
+                    registry.registerBeanDefinition(SYNTHETIC_BEAN_DEFINITION, beanDefinition);
+                }
+
+                @Override
+                public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {}
+            };
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/QualifiersPersistencePostProcessorTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/QualifiersPersistencePostProcessorTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.beans;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+/**
+ * Integration test for {@link QualifiersPersistencePostProcessor}.
+ *
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest
+@Import({
+    QualifiersPersistencePostProcessorTest.BeanMethodDeclarations.class,
+    QualifiersPersistencePostProcessorTest.ComponentMethodDeclarations.class,
+    QualifiersPersistencePostProcessorTest.ConfigurationClassesDeclarations.class,
+    QualifiersPersistencePostProcessor.class
+})
+class QualifiersPersistencePostProcessorTest {
+
+    @Test
+    void shouldDetectAnnotationQualifiers() {
+        DefaultQualifiersRegistry registry = DefaultQualifiersRegistry.INSTANCE;
+
+        SoftAssertions.assertSoftly(sa -> {
+            sa.assertThat(registry.getQualifiers("noQualifiersBeanName")).isEmpty();
+            sa.assertThat(registry.getQualifiers("builtInTypeQualifierBeanName"))
+                    .containsOnly("builtInTypeQualifier");
+            sa.assertThat(registry.getQualifiers("customTypeQualifierBeanName")).containsOnly("customQualifier");
+            sa.assertThat(registry.getQualifiers("mixedTypeQualifierBeanName"))
+                    .containsOnly("builtInTypeQualifier", "customQualifier");
+        });
+
+        SoftAssertions.assertSoftly(sa -> {
+            sa.assertThat(registry.getQualifiers("beanMethodNoQualifiersBeanName"))
+                    .isEmpty();
+            sa.assertThat(registry.getQualifiers("beanMethodBuiltInTypeQualifierBeanName"))
+                    .containsOnly("builtInTypeQualifier");
+            sa.assertThat(registry.getQualifiers("beanMethodCustomTypeQualifierBeanName"))
+                    .containsOnly("customQualifier");
+            sa.assertThat(registry.getQualifiers("beanMethodMixedTypeQualifierBeanName"))
+                    .containsOnly("builtInTypeQualifier", "customQualifier");
+        });
+
+        SoftAssertions.assertSoftly(sa -> {
+            sa.assertThat(registry.getQualifiers("noQualifiersConfigBeanName")).isEmpty();
+            sa.assertThat(registry.getQualifiers("builtInTypeQualifierConfigBeanName"))
+                    .containsOnly("builtInTypeQualifier");
+            sa.assertThat(registry.getQualifiers("customTypeQualifierConfigBeanName"))
+                    .containsOnly("customQualifier");
+            sa.assertThat(registry.getQualifiers("mixedTypeQualifierConfigBeanName"))
+                    .containsOnly("builtInTypeQualifier", "customQualifier");
+        });
+    }
+
+    @Documented
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Qualifier("customQualifier")
+    @interface CustomQualifier {}
+
+    @TestConfiguration
+    static class ComponentMethodDeclarations {
+
+        @Component("noQualifiersBeanName")
+        static class NoQualifiers {}
+
+        @Service("builtInTypeQualifierBeanName")
+        @Qualifier("builtInTypeQualifier")
+        static class BuiltInTypeQualifier {}
+
+        @Service("customTypeQualifierBeanName")
+        @CustomQualifier
+        static class CustomTypeQualifier {}
+
+        @Service("mixedTypeQualifierBeanName")
+        @CustomQualifier
+        @Qualifier("builtInTypeQualifier")
+        static class MixedTypeQualifier {}
+    }
+
+    @TestConfiguration
+    static class BeanMethodDeclarations {
+
+        static class BeanMethodNoQualifiers {}
+
+        static class BeanMethodBuiltInTypeQualifier {}
+
+        static class BeanMethodCustomTypeQualifier {}
+
+        static class BeanMethodMixedTypeQualifier {}
+
+        @Bean("beanMethodNoQualifiersBeanName")
+        public BeanMethodNoQualifiers beanMethodNoQualifiers() {
+            return new BeanMethodNoQualifiers();
+        }
+
+        @Bean("beanMethodBuiltInTypeQualifierBeanName")
+        @Qualifier("builtInTypeQualifier")
+        public BeanMethodBuiltInTypeQualifier builtInTypeQualifier() {
+            return new BeanMethodBuiltInTypeQualifier();
+        }
+
+        @Bean("beanMethodCustomTypeQualifierBeanName")
+        @CustomQualifier
+        public BeanMethodCustomTypeQualifier customTypeQualifier() {
+            return new BeanMethodCustomTypeQualifier();
+        }
+
+        @Bean("beanMethodMixedTypeQualifierBeanName")
+        @CustomQualifier
+        @Qualifier("builtInTypeQualifier")
+        public BeanMethodMixedTypeQualifier mixedTypeQualifier() {
+            return new BeanMethodMixedTypeQualifier();
+        }
+    }
+
+    @Configuration
+    static class ConfigurationClassesDeclarations {
+
+        @Configuration("noQualifiersConfigBeanName")
+        static class NoQualifiers {}
+
+        @Configuration("builtInTypeQualifierConfigBeanName")
+        @Qualifier("builtInTypeQualifier")
+        static class BuiltInTypeQualifier {}
+
+        @Configuration("customTypeQualifierConfigBeanName")
+        @CustomQualifier
+        static class CustomTypeQualifier {}
+
+        @Configuration("mixedTypeQualifierConfigBeanName")
+        @CustomQualifier
+        @Qualifier("builtInTypeQualifier")
+        static class MixedTypeQualifier {}
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
@@ -1,0 +1,565 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.cache;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import com.axelixlabs.axelix.common.api.caches.CachesFeed;
+import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheDto;
+import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheManagerDto;
+import com.axelixlabs.axelix.sbs.spring.core.Main;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AxelixCachesEndpoint}.
+ * <p>
+ * TODO:
+ *  Gosh, we need to refactor this test to use String Templates if
+ *  the Java Language designers team will descend to us finally and
+ *  deliver this. Come on Brian, I know you can do this! Push, push,
+ *  push, push! We're praying for you and the team!
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ * @author Sergey Cherkasov
+ * @since 24.06.2025
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Main.class)
+@Import({
+    AxelixCachesEndpoint.class,
+    DefaultCacheOperationsDispatcher.class,
+    AxelixCachesEndpointTest.CacheDispatcherEndpointTestConfiguration.class
+})
+class AxelixCachesEndpointTest {
+
+    // Cache names under test
+    private static final String TEST_CACHE_1 = "cache1";
+    private static final String TEST_CACHE_2 = "cache2";
+
+    private static final String MAIN_CACHE_MANAGER = "mainCacheManager";
+    private static final String CLEAR_CACHE_MANAGER = "clearCacheManager";
+    private static final String ENABLE_CACHE_MANAGER = "enableCacheManager";
+    private static final String DISABLE_CACHE_MANAGER = "disableCacheManager";
+
+    private EnhancedCacheManager mainCacheManager;
+    private EnhancedCacheManager clearCacheManager;
+    private EnhancedCacheManager enableCacheManager;
+    private EnhancedCacheManager disableCacheManager;
+
+    // The bean definition in the context for cache manager has a type of CacheManager,
+    // so we cannot do simple field injection via EnhancedCacheManager class.
+    @Autowired
+    public AxelixCachesEndpointTest setMainCacheManager(CacheManager mainCacheManager) {
+        this.mainCacheManager = (EnhancedCacheManager) mainCacheManager;
+        return this;
+    }
+
+    @Autowired
+    public AxelixCachesEndpointTest setClearCacheManager(@Qualifier(CLEAR_CACHE_MANAGER) CacheManager cacheManager) {
+        this.clearCacheManager = (EnhancedCacheManager) cacheManager;
+        return this;
+    }
+
+    @Autowired
+    public AxelixCachesEndpointTest setEnableCacheManager(@Qualifier(ENABLE_CACHE_MANAGER) CacheManager cacheManager) {
+        this.enableCacheManager = (EnhancedCacheManager) cacheManager;
+        return this;
+    }
+
+    @Autowired
+    public AxelixCachesEndpointTest setDisableCacheManager(
+            @Qualifier(DISABLE_CACHE_MANAGER) CacheManager cacheManager) {
+        this.disableCacheManager = (EnhancedCacheManager) cacheManager;
+        return this;
+    }
+
+    @Autowired
+    private Map<String, CacheManager> allCacheManagers;
+
+    @Autowired
+    private TestRestTemplateBuilder testRestTemplate;
+
+    @BeforeEach
+    void setUp() {
+        for (CacheManager cacheManager : allCacheManagers.values()) {
+            if (cacheManager instanceof EnhancedCacheManager enhancedCacheManager) {
+                enhancedCacheManager.enableAll();
+                for (String cacheName : enhancedCacheManager.getCacheNames()) {
+                    Cache cache = enhancedCacheManager.getCache(cacheName);
+                    if (cache != null) {
+                        cache.clear();
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void get_shouldReturnSingleCacheByName() {
+        // when.
+        ResponseEntity<String> response =
+                testRestTemplate.asViewer().getForEntity(path(MAIN_CACHE_MANAGER, TEST_CACHE_1), String.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        JsonAssertions.assertThatJson(response.getBody())
+                .isEqualTo(
+                        // language=json
+                        """
+                {
+                    "cacheManager" : "%s",
+                    "name" : "%s",
+                    "target" : "java.util.concurrent.ConcurrentHashMap",
+                    "enabled" : true,
+                    "estimatedEntrySize" : 0,
+                    "lookupHistory" : []
+                }
+                """.formatted(MAIN_CACHE_MANAGER, TEST_CACHE_1));
+    }
+
+    @Test
+    void get_shouldReturnCacheInformation() {
+        Cache cache1 = mainCacheManager.getCache(TEST_CACHE_1);
+        cache1.put("key1", "value1");
+        cache1.put("key2", "value2");
+        cache1.put("key3", "value3");
+        cache1.get("key1");
+        cache1.get("key2");
+
+        Cache cache2 = mainCacheManager.getCache(TEST_CACHE_2);
+        cache2.put("key", "value");
+        cache2.get("key");
+        cache2.get("notCache1");
+        cache2.get("notCache2");
+
+        ResponseEntity<CachesFeed> response = testRestTemplate.asEditor().getForEntity(rootPath(), CachesFeed.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        CacheManagerDto cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
+        assertThat(cacheManager.getCaches()).hasSize(2);
+
+        assertThat(cacheManager.getCaches().stream()
+                        .filter(c -> TEST_CACHE_1.equals(c.getName()))
+                        .findFirst())
+                .hasValueSatisfying(c -> {
+                    assertThat(c.isEnabled()).isTrue();
+                    assertThat(c.getTarget()).isNotNull();
+                    assertThat(c.isContainsStats()).isTrue();
+                });
+
+        assertThat(cacheManager.getCaches().stream()
+                        .filter(c -> TEST_CACHE_2.equals(c.getName()))
+                        .findFirst())
+                .hasValueSatisfying(c -> {
+                    assertThat(c.isEnabled()).isTrue();
+                    assertThat(c.getTarget()).isNotNull();
+                    assertThat(c.isContainsStats()).isTrue();
+                });
+    }
+
+    @Test
+    void clear_shouldEvictSingleEntry() {
+        String key1 = "key1", key2 = "key2";
+        Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
+        cache.put(key1, "value1");
+        cache.put(key2, "value2");
+
+        ResponseEntity<Void> response = testRestTemplate
+                .asEditor()
+                .exchange(
+                        path(CLEAR_CACHE_MANAGER, TEST_CACHE_1 + "/clear?key=key2"),
+                        HttpMethod.DELETE,
+                        null,
+                        Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(cache.get(key2)).isNull();
+        assertThat(cache.get(key1)).isNotNull();
+    }
+
+    @Test
+    void clear_shouldClearEntireCache() {
+        String key1 = "key1", key2 = "key2";
+        Cache cache = clearCacheManager.getCache(TEST_CACHE_1);
+        cache.put(key1, "value1");
+        cache.put(key2, "value2");
+
+        ResponseEntity<Void> response = testRestTemplate
+                .asEditor()
+                .exchange(path(CLEAR_CACHE_MANAGER, TEST_CACHE_1 + "/clear"), HttpMethod.DELETE, null, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(cache.get(key1)).isNull();
+        assertThat(cache.get(key2)).isNull();
+    }
+
+    @Test
+    void clearAll_shouldClearAllCaches() {
+        String key1 = "key1", key2 = "key2";
+        Cache cache1 = clearCacheManager.getCache(TEST_CACHE_1);
+        Cache cache2 = clearCacheManager.getCache(TEST_CACHE_2);
+        cache1.put(key1, "value1");
+        cache2.put(key2, "value2");
+
+        ResponseEntity<Void> response = testRestTemplate
+                .asEditor()
+                .exchange(path(CLEAR_CACHE_MANAGER, "/clear-all"), HttpMethod.DELETE, null, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(cache1.get(key1)).isNull();
+        assertThat(cache2.get(key2)).isNull();
+    }
+
+    @Test
+    void disable_onDisableAllCacheManager() {
+        // given.
+        Cache cache1 = disableCacheManager.getCache(TEST_CACHE_1);
+        Cache cache2 = disableCacheManager.getCache(TEST_CACHE_2);
+        cache1.put("key1", "value1");
+        cache2.put("key2", "value2");
+
+        // when.
+        testRestTemplate.asEditor().postForObject(path(DISABLE_CACHE_MANAGER, "/disable"), defaultEntity(), Void.class);
+        cache1.put("key3", "value2");
+        cache2.put("key4", "value2");
+
+        // then.
+        assertThat(cache1.get("key1")).isNull();
+        assertThat(cache1.get("key3")).isNull();
+        assertThat(cache2.get("key2")).isNull();
+        assertThat(cache2.get("key4")).isNull();
+        assertThat(disableCacheManager.getCacheNames()).containsOnly(TEST_CACHE_1, TEST_CACHE_2);
+    }
+
+    @Test
+    void enable_shouldEnableCacheManager() {
+        Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
+
+        // when.
+        testRestTemplate.asAdmin().postForObject(path(ENABLE_CACHE_MANAGER, "/disable"), defaultEntity(), Void.class);
+        testRestTemplate.asEditor().postForObject(path(ENABLE_CACHE_MANAGER, "/enable"), defaultEntity(), Void.class);
+        cache.put("key", "value");
+
+        // then.
+        assertThat(cache.get("key")).isNotNull();
+    }
+
+    @Test
+    void enable_shouldEnableOnlySpecificCache() {
+        Cache cache = enableCacheManager.getCache(TEST_CACHE_1);
+
+        // when.
+        testRestTemplate
+                .asAdmin()
+                .postForObject(path(ENABLE_CACHE_MANAGER, TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
+        testRestTemplate
+                .asEditor()
+                .postForObject(path(ENABLE_CACHE_MANAGER, TEST_CACHE_1 + "/enable"), defaultEntity(), Void.class);
+
+        // then.
+        cache.put("key", "value");
+        assertThat(cache.get("key")).isNotNull();
+    }
+
+    @Test
+    void disable_shouldDisableSpecifiedCache() {
+        String targetEnabledCache = TEST_CACHE_1;
+        String targetDisabledCache = TEST_CACHE_2;
+        Cache enabledCache = disableCacheManager.getCache(targetEnabledCache);
+        Cache disabledCache = disableCacheManager.getCache(targetDisabledCache);
+        enabledCache.put("key1", "value");
+        disabledCache.put("key1", "value");
+
+        testRestTemplate
+                .asAdmin()
+                .postForObject(
+                        path(DISABLE_CACHE_MANAGER, targetDisabledCache + "/disable"), defaultEntity(), Void.class);
+
+        enabledCache.put("key2", "value2");
+        disabledCache.put("key2", "value2");
+
+        assertThat(enabledCache.get("key2")).isNotNull();
+        assertThat(enabledCache.get("key1")).isNotNull();
+        assertThat(disabledCache.get("key2")).isNull();
+        assertThat(disabledCache.get("key1")).isNull();
+    }
+
+    @Test
+    void caches_shouldReturnAllCachesWithEnabledStatus() {
+        ResponseEntity<CachesFeed> response = testRestTemplate.asViewer().getForEntity(rootPath(), CachesFeed.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        CacheManagerDto cacheManager = getCacheManager(response.getBody(), MAIN_CACHE_MANAGER);
+
+        assertThat(cacheManager.getCaches()).hasSize(2);
+
+        CacheDto cache1Info = cacheManager.getCaches().stream()
+                .filter(c -> TEST_CACHE_1.equals(c.getName()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(cache1Info.isEnabled()).isTrue();
+        assertThat(cache1Info.getTarget()).isNotNull();
+        assertThat(cache1Info.isContainsStats()).isFalse();
+
+        CacheDto cache2Info = cacheManager.getCaches().stream()
+                .filter(c -> TEST_CACHE_2.equals(c.getName()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(cache2Info.isEnabled()).isTrue();
+        assertThat(cache2Info.getTarget()).isNotNull();
+        assertThat(cache2Info.isContainsStats()).isFalse();
+    }
+
+    @Test
+    void caches_shouldShowDisableEnabledCache() {
+        mainCacheManager.getCache(TEST_CACHE_1);
+
+        testRestTemplate
+                .asEditor()
+                .postForObject(path(ENABLE_CACHE_MANAGER, TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
+
+        ResponseEntity<CachesFeed> afterDisablingResponse =
+                testRestTemplate.asEditor().getForEntity(rootPath(), CachesFeed.class);
+        assertThat(afterDisablingResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        CacheDto disabledCache =
+                getCacheManager(afterDisablingResponse.getBody(), ENABLE_CACHE_MANAGER).getCaches().stream()
+                        .filter(c -> TEST_CACHE_1.equals(c.getName()))
+                        .findFirst()
+                        .orElseThrow();
+        assertThat(disabledCache.isEnabled()).isFalse();
+
+        testRestTemplate
+                .asEditor()
+                .postForObject(path(ENABLE_CACHE_MANAGER, TEST_CACHE_1 + "/enable"), defaultEntity(), Void.class);
+
+        ResponseEntity<CachesFeed> afterEnablingResponse =
+                testRestTemplate.asEditor().getForEntity(rootPath(), CachesFeed.class);
+        assertThat(afterEnablingResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        CacheDto enabledCache =
+                getCacheManager(afterEnablingResponse.getBody(), ENABLE_CACHE_MANAGER).getCaches().stream()
+                        .filter(c -> TEST_CACHE_1.equals(c.getName()))
+                        .findFirst()
+                        .orElseThrow();
+        assertThat(enabledCache.isEnabled()).isTrue();
+    }
+
+    @Test
+    void disable_shouldShowAllCachesDisabledWhenManagerIsDisabled() {
+        testRestTemplate.asEditor().postForObject(path(DISABLE_CACHE_MANAGER, "/disable"), defaultEntity(), Void.class);
+
+        ResponseEntity<CachesFeed> response = testRestTemplate.asEditor().getForEntity(rootPath(), CachesFeed.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        CacheManagerDto cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
+
+        assertThat(cacheManager.getCaches())
+                .allSatisfy(cacheInfo -> assertThat(cacheInfo.isEnabled()).isFalse());
+    }
+
+    @Test
+    void disable_shouldShowMixedEnabledStatusWhenSomeCachesAreDisabled() {
+        testRestTemplate
+                .asEditor()
+                .postForObject(path(DISABLE_CACHE_MANAGER, TEST_CACHE_1 + "/disable"), defaultEntity(), Void.class);
+
+        ResponseEntity<CachesFeed> response = testRestTemplate.asAdmin().getForEntity(rootPath(), CachesFeed.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        CacheManagerDto cacheManager = getCacheManager(response.getBody(), DISABLE_CACHE_MANAGER);
+
+        CacheDto cache1Info = cacheManager.getCaches().stream()
+                .filter(c -> TEST_CACHE_1.equals(c.getName()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(cache1Info.isEnabled()).isFalse();
+
+        CacheDto cache2Info = cacheManager.getCaches().stream()
+                .filter(c -> TEST_CACHE_2.equals(c.getName()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(cache2Info.isEnabled()).isTrue();
+    }
+
+    // TODO: I'm not sure that this return 200 OK is the correct way of handling the non existent cache
+    @Test
+    @Disabled
+    void enableCache_shouldHandleNonExistentCache() {
+        ResponseEntity<Void> response = testRestTemplate
+                .asEditor()
+                .postForEntity(path(ENABLE_CACHE_MANAGER, "/nonExistentCache/enable"), defaultEntity(), Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void disableCache_shouldHandleNonExistentCache() {
+        ResponseEntity<Void> response = testRestTemplate
+                .asEditor()
+                .postForEntity(path(DISABLE_CACHE_MANAGER, "/nonExistentCache/disable"), defaultEntity(), Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonExistentManagerPaths")
+    void managerOperation_shouldThrowExceptionForNonExistentManager(String cacheManagerName, String relativePath) {
+        ResponseEntity<String> response = testRestTemplate
+                .asEditor()
+                .postForEntity(path(cacheManagerName, relativePath), defaultEntity(), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private static Stream<Arguments> nonExistentManagerPaths() {
+        return Stream.of(
+                Arguments.of("nonExistentManager", "/enable"), Arguments.of("/nonExistentManager", "/disable"));
+    }
+
+    @Test
+    @Disabled // TODO: Uncomment once we solve the exception handling on the starter side
+    void clearAll_shouldReturnFalse_cacheManagerDoesNotExist() {
+        ResponseEntity<Void> response = testRestTemplate
+                .asEditor()
+                .exchange(path("/nonExistentManager/clear-all", ""), HttpMethod.DELETE, defaultEntity(), Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonExistentManagerAndCachePaths")
+    void cacheOperation_shouldThrowExceptionForNonExistentManager(String cacheManagerName, String relativePath) {
+        ResponseEntity<String> response = testRestTemplate
+                .asEditor()
+                .postForEntity(path(cacheManagerName, relativePath), defaultEntity(), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    private static Stream<Arguments> nonExistentManagerAndCachePaths() {
+        return Stream.of(
+                Arguments.of("/nonExistentManager", "/nonExistentCache/enable"),
+                Arguments.of("/nonExistentManager", "/nonExistentCache/disable"));
+    }
+
+    private HttpEntity<Void> defaultEntity() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return new HttpEntity<>(headers);
+    }
+
+    private String rootPath() {
+        return path("", "");
+    }
+
+    private String path(String cacheManagerName, String relative) {
+        relative = prefixPathIfNeeded(relative);
+        cacheManagerName = prefixPathIfNeeded(cacheManagerName);
+
+        return "/actuator/axelix-caches" + cacheManagerName + relative;
+    }
+
+    private static String prefixPathIfNeeded(String path) {
+        return (path.isEmpty() || path.charAt(0) == '/') ? path : "/" + path;
+    }
+
+    private CacheManagerDto getCacheManager(CachesFeed source, String cacheManagerName) {
+        return source.getCacheManagers().stream()
+                .filter(cm -> cacheManagerName.equals(cm.getName()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    @TestConfiguration
+    public static class CacheDispatcherEndpointTestConfiguration {
+
+        @Bean
+        @ConditionalOnMissingBean
+        public CacheSizeProvider cacheSizeProvider() {
+            return new DefaultCacheSizeProvider();
+        }
+
+        @Bean
+        public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
+            return new DefaultAxelixMetricsPublisher(meterRegistry);
+        }
+
+        @Bean
+        public static CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
+                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
+            return new CacheManagerBeanPostProcessor(axelixMetricsPublisherObjectProvider);
+        }
+
+        @Bean(name = MAIN_CACHE_MANAGER)
+        @Primary
+        public CacheManager testSubjectCacheManager() {
+            return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
+        }
+
+        @Bean(name = CLEAR_CACHE_MANAGER)
+        public CacheManager clearSubjectCacheManager() {
+            return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
+        }
+
+        @Bean(name = ENABLE_CACHE_MANAGER)
+        public CacheManager enableSubjectCacheManager() {
+            return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
+        }
+
+        @Bean(name = DISABLE_CACHE_MANAGER)
+        public CacheManager disableSubjectCacheManager() {
+            return new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.cache;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+
+import com.axelixlabs.axelix.common.api.caches.CachesFeed;
+import com.axelixlabs.axelix.common.api.caches.SingleCache;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link DefaultCacheOperationsDispatcher}.
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ * @author Sergey Cherkasov
+ * @since 24.06.2025
+ */
+class DefaultCacheOperationsDispatcherTest {
+
+    // Cache Manager 1
+    private static final String TEST_CACHE_MANAGER_1 = "cacheManager1";
+    private static final String TEST_CACHE_1 = "cache1";
+    private static final String TEST_CACHE_2 = "cache2";
+
+    // Cache Manager 2
+    private static final String TEST_CACHE_MANAGER_2 = "cacheManager2";
+
+    private CacheManager cacheManager1;
+    private CacheManager cacheManager2;
+    private CacheOperationsDispatcher dispatcher;
+
+    @BeforeEach
+    void setUp() {
+        AxelixMetricsPublisher axelixMetricsPublisher = new DefaultAxelixMetricsPublisher(new SimpleMeterRegistry());
+        Map<String, CacheManager> managers = new HashMap<>();
+
+        cacheManager1 = new DefaultEnhancedCacheManager(
+                TEST_CACHE_MANAGER_1,
+                new ConcurrentMapCacheManager(TEST_CACHE_1, TEST_CACHE_2),
+                axelixMetricsPublisher);
+        cacheManager2 = new DefaultEnhancedCacheManager(
+                TEST_CACHE_MANAGER_2, new ConcurrentMapCacheManager(TEST_CACHE_2), axelixMetricsPublisher);
+        managers.put(TEST_CACHE_MANAGER_1, cacheManager1);
+        managers.put(TEST_CACHE_MANAGER_2, cacheManager2);
+
+        CacheSizeProvider cacheSizeProvider = new DefaultCacheSizeProvider();
+        dispatcher = new DefaultCacheOperationsDispatcher(managers, cacheSizeProvider);
+    }
+
+    @Test
+    void clear_shouldRemoveAllEntriesInCache() {
+        // given.
+        String key = "key";
+        String cacheName = TEST_CACHE_1;
+        Cache cache = cacheManager1.getCache(cacheName);
+        assertThat(cache).isNotNull();
+
+        cache.put(key, "value");
+        assertThat(cache.get(key)).isNotNull();
+
+        // when.
+        dispatcher.clear(TEST_CACHE_MANAGER_1, cacheName);
+
+        // then.
+        assertThat(cache.get(key)).isNull();
+    }
+
+    @Test
+    void shouldNoOpOnClearingNonExistentCacheManager() {
+        assertThatThrownBy(() -> dispatcher.clear("nonExistentCacheManager", "cache"))
+                .isInstanceOf(CacheManagerNotFoundException.class);
+    }
+
+    @Test
+    void clearKey_shouldEvictSingleEntry() {
+        // given.
+        String cacheName = TEST_CACHE_1;
+        String keyToRemove = "keyToRemove", keyToKeep = "keyToKeep";
+        Cache cache = cacheManager1.getCache(cacheName);
+        assertThat(cache).isNotNull();
+
+        cache.put(keyToRemove, "value1");
+        cache.put(keyToKeep, "value2");
+        assertThat(cache.get(keyToRemove)).isNotNull();
+        assertThat(cache.get(keyToKeep)).isNotNull();
+
+        // when.
+        dispatcher.clear(TEST_CACHE_MANAGER_1, cacheName, keyToRemove);
+
+        // then.
+        assertThat(cache.get(keyToRemove)).isNull();
+        assertThat(cache.get(keyToKeep))
+                .isNotNull()
+                .satisfies(cacheValue -> assertThat(cacheValue.get()).isEqualTo("value2"));
+    }
+
+    @Test
+    void clearAll_shouldClearAllCaches() {
+        // given.
+        String key1 = "key1", key2 = "key2";
+        Cache cache1 = cacheManager1.getCache(TEST_CACHE_1);
+        Cache cache2 = cacheManager1.getCache(TEST_CACHE_2);
+        cache1.put(key1, "value1");
+        cache2.put(key2, "value2");
+
+        // when.
+        dispatcher.clear(TEST_CACHE_MANAGER_1);
+
+        // then.
+        assertThat(cache1.get(key1)).isNull();
+        assertThat(cache2.get(key2)).isNull();
+    }
+
+    @Test
+    void disableCacheManager_shouldDisableSpecificManager() {
+        Cache cache1 = cacheManager1.getCache(TEST_CACHE_1);
+
+        cache1.put("key1", "value1");
+        assertThat(cache1.get("key1")).isNotNull();
+
+        dispatcher.disableCacheManager(TEST_CACHE_MANAGER_1);
+
+        cache1.put("key2", "value2");
+        assertThat(cache1.get("key2")).isNull();
+    }
+
+    @Test
+    void enableCacheManager_shouldEnableSpecificManager() {
+        Cache cache = cacheManager1.getCache(TEST_CACHE_1);
+
+        dispatcher.disableCacheManager(TEST_CACHE_MANAGER_1);
+
+        cache.put("key", "value");
+        assertThat(cache.get("key")).isNull();
+
+        dispatcher.enableCacheManager(TEST_CACHE_MANAGER_1);
+
+        cache.put("key2", "value2");
+        assertThat(cache.get("key2")).isNotNull();
+    }
+
+    @Test
+    void disableCache_shouldDisableSpecificCache() {
+        Cache cache1 = cacheManager1.getCache(TEST_CACHE_1);
+
+        cache1.put("key1", "value1");
+        assertThat(cache1.get("key1")).isNotNull();
+
+        dispatcher.disableCache(TEST_CACHE_MANAGER_1, TEST_CACHE_1);
+
+        cache1.put("key2", "value2");
+        assertThat(cache1.get("key2")).isNull();
+    }
+
+    @Test
+    void enableCache_shouldEnableSpecificCache() {
+        Cache cache1 = cacheManager1.getCache(TEST_CACHE_1);
+        cache1.put("key", "value");
+        dispatcher.disableCache(TEST_CACHE_MANAGER_1, TEST_CACHE_1);
+
+        cache1.put("key", "value");
+        assertThat(cache1.get("key")).isNull();
+
+        dispatcher.enableCache(TEST_CACHE_MANAGER_1, TEST_CACHE_1);
+
+        cache1.put("key2", "value2");
+        assertThat(cache1.get("key2")).isNotNull();
+    }
+
+    @Test
+    void disableCache_shouldNotAffectOtherCachesInSameManager() {
+        Cache cache1 = cacheManager1.getCache(TEST_CACHE_1);
+        Cache cache2 = cacheManager1.getCache(TEST_CACHE_2);
+
+        cache1.put("key1", "value1");
+        cache2.put("key2", "value2");
+        assertThat(cache1.get("key1")).isNotNull();
+        assertThat(cache2.get("key2")).isNotNull();
+
+        dispatcher.disableCache(TEST_CACHE_MANAGER_1, TEST_CACHE_1);
+
+        cache1.put("key3", "value3");
+        cache2.put("key4", "value4");
+
+        assertThat(cache1.get("key3")).isNull();
+        assertThat(cache2.get("key4")).isNotNull();
+    }
+
+    @Test
+    void disableCacheManager_shouldNotAffectOtherManagers() {
+        Cache cache1 = cacheManager1.getCache(TEST_CACHE_1);
+        Cache cache2 = cacheManager2.getCache(TEST_CACHE_2);
+
+        cache1.put("key1", "value1");
+        cache2.put("key2", "value2");
+        assertThat(cache1.get("key1")).isNotNull();
+        assertThat(cache2.get("key2")).isNotNull();
+
+        dispatcher.disableCacheManager(TEST_CACHE_MANAGER_1);
+
+        cache1.put("key3", "value3");
+        cache2.put("key4", "value4");
+
+        assertThat(cache1.get("key3")).isNull();
+        assertThat(cache2.get("key4")).isNotNull();
+    }
+
+    @Test
+    void isCacheEnabled_shouldReturnTrueForEnabledCache() {
+        assertThat(dispatcher.get(TEST_CACHE_MANAGER_1, TEST_CACHE_1).isEnabled())
+                .isTrue();
+    }
+
+    @Test
+    void isCacheEnabled_shouldReturnFalseForDisabledCache() {
+        // given.
+        String cacheManagerName = TEST_CACHE_MANAGER_1;
+        String cacheName = TEST_CACHE_1;
+
+        // when.
+        dispatcher.disableCache(cacheManagerName, cacheName);
+
+        // then.
+        assertThat(dispatcher.get(cacheManagerName, cacheName).isEnabled()).isFalse();
+    }
+
+    @Test
+    void isCacheEnabled_shouldReturnTrueAfterDisableEnableCache() {
+        // given.
+        String cacheManagerName = TEST_CACHE_MANAGER_1;
+        String cacheName = TEST_CACHE_1;
+
+        // when.
+        dispatcher.disableCache(cacheManagerName, cacheName);
+        dispatcher.enableCache(cacheManagerName, cacheName);
+
+        // then.
+        assertThat(dispatcher.get(cacheManagerName, cacheName).isEnabled()).isTrue();
+    }
+
+    @Test
+    void isCacheEnabled_shouldReturnFalseWhenCacheManagerDisabled() {
+        // given.
+        String cacheManagerName = TEST_CACHE_MANAGER_1;
+
+        // when.
+        dispatcher.disableCacheManager(cacheManagerName);
+
+        // then.
+        assertThat(dispatcher.get(cacheManagerName, TEST_CACHE_1).isEnabled()).isFalse();
+        assertThat(dispatcher.get(cacheManagerName, TEST_CACHE_2).isEnabled()).isFalse();
+    }
+
+    @Test
+    void isCacheEnabled_shouldReturnTrueWhenCacheManagerDisableEnable() {
+        // given.
+        String cacheManagerName = TEST_CACHE_MANAGER_1;
+        String cacheName = TEST_CACHE_1;
+
+        dispatcher.get(cacheManagerName, cacheName); // to initialize the cache
+
+        // when.
+        dispatcher.disableCacheManager(cacheManagerName);
+
+        // then.
+        assertThat(dispatcher.get(cacheManagerName, cacheName).isEnabled()).isFalse();
+
+        // and also when.
+        dispatcher.enableCacheManager(cacheManagerName);
+
+        // then.
+        assertThat(dispatcher.get(cacheManagerName, cacheName).isEnabled()).isTrue();
+    }
+
+    @Test
+    void shouldReturnCacheInformation_FromDifferentManagers() {
+        // given.
+        Cache cache1 = cacheManager1.getCache(TEST_CACHE_2);
+        cache1.put("key1", "value");
+        cache1.put("key2", "value");
+        cache1.get("key1");
+        cache1.get("key2");
+        cache1.get("notCache");
+        cache1.get("notCache");
+
+        // when.
+        SingleCache first = dispatcher.get(TEST_CACHE_MANAGER_1, TEST_CACHE_2);
+
+        // then.
+        assertThat(first.getEstimatedEntrySize()).isEqualTo(2L);
+        assertThat(first.getLookupHistory().stream()
+                        .filter(it -> SingleCache.LookupOutcome.MISS.equals(it.getOutcome())))
+                .hasSize(2);
+        assertThat(first.getLookupHistory().stream()
+                        .filter(it -> SingleCache.LookupOutcome.HIT.equals(it.getOutcome())))
+                .hasSize(2);
+
+        // given.
+        Cache cache2 = cacheManager2.getCache(TEST_CACHE_2);
+        cache2.put("key3", "value");
+        cache2.get("key3");
+        cache2.get("notCache2");
+
+        // when.
+        SingleCache second = dispatcher.get(TEST_CACHE_MANAGER_2, TEST_CACHE_2);
+
+        // then.
+        assertThat(second.getEstimatedEntrySize()).isEqualTo(1L);
+        assertThat(second.getLookupHistory().stream()
+                        .filter(it -> SingleCache.LookupOutcome.MISS.equals(it.getOutcome())))
+                .hasSize(1);
+        assertThat(second.getLookupHistory().stream()
+                        .filter(it -> SingleCache.LookupOutcome.HIT.equals(it.getOutcome())))
+                .hasSize(1);
+    }
+
+    @Test
+    void shouldIsTrueContainsStats() {
+        // given.
+        Cache cache1 = cacheManager1.getCache(TEST_CACHE_1);
+        cache1.put("key1", "value");
+        cache1.get("key1");
+        cache1.get("notCache");
+
+        // when.
+        CachesFeed cachesFeed = dispatcher.getAll();
+
+        // then.
+        CachesFeed.CacheDto cache = cachesFeed.getCacheManagers().stream()
+                .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
+                .findFirst()
+                .orElseThrow()
+                .getCaches()
+                .stream()
+                .filter(it -> TEST_CACHE_1.equals(it.getName()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(cache.isContainsStats()).isTrue();
+    }
+
+    @Test
+    void shouldIsFalseContainsStats() {
+        // given.
+        Cache cache1 = cacheManager1.getCache(TEST_CACHE_1);
+        cache1.put("key1", "value");
+
+        // when.
+        CachesFeed cachesFeed = dispatcher.getAll();
+
+        // then.
+        CachesFeed.CacheDto cache = cachesFeed.getCacheManagers().stream()
+                .filter(cacheManager -> TEST_CACHE_MANAGER_1.equals(cacheManager.getName()))
+                .findFirst()
+                .orElseThrow()
+                .getCaches()
+                .stream()
+                .filter(it -> TEST_CACHE_1.equals(it.getName()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(cache.isContainsStats()).isFalse();
+    }
+
+    @Test
+    void shouldReturnNull_ForNonExistentManager() {
+        assertThatThrownBy(() -> dispatcher.get("nonExistentManager", TEST_CACHE_1))
+                .isInstanceOf(CacheManagerNotFoundException.class);
+    }
+
+    @Test
+    void enableCacheManager_shouldThrowExceptionForNonExistentManager() {
+        assertThatThrownBy(() -> dispatcher.enableCacheManager("nonExistentManager"))
+                .isInstanceOf(CacheManagerNotFoundException.class)
+                .hasMessageContaining("nonExistentManager");
+    }
+
+    @Test
+    void disableCacheManager_shouldThrowExceptionForNonExistentManager() {
+        assertThatThrownBy(() -> dispatcher.disableCacheManager("nonExistentManager"))
+                .isInstanceOf(CacheManagerNotFoundException.class)
+                .hasMessageContaining("nonExistentManager");
+    }
+
+    @Test
+    void enableCache_shouldThrowExceptionForNonExistentManager() {
+        assertThatThrownBy(() -> dispatcher.enableCache("nonExistentManager", TEST_CACHE_1))
+                .isInstanceOf(CacheManagerNotFoundException.class)
+                .hasMessageContaining("nonExistentManager");
+    }
+
+    @Test
+    void disableCache_shouldThrowExceptionForNonExistentManager() {
+        assertThatThrownBy(() -> dispatcher.disableCache("nonExistentManager", TEST_CACHE_1))
+                .isInstanceOf(CacheManagerNotFoundException.class)
+                .hasMessageContaining("nonExistentManager");
+    }
+
+    @Test
+    void enableCache_shouldWorkWhenCacheDoesNotExist() {
+        assertThatNoException().isThrownBy(() -> dispatcher.enableCache(TEST_CACHE_MANAGER_1, "nonExistentCache"));
+    }
+
+    @Test
+    void disableCache_shouldWorkWhenCacheDoesNotExist() {
+        assertThatNoException().isThrownBy(() -> dispatcher.disableCache(TEST_CACHE_MANAGER_1, "nonExistentCache"));
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheSizeProviderTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheSizeProviderTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.cache;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link DefaultCacheSizeProvider}
+ *
+ * @author Sergey Cherkasov
+ */
+public class DefaultCacheSizeProviderTest {
+    private final CacheSizeProvider provider = new DefaultCacheSizeProvider();
+
+    @Test
+    void caffeineCache_shouldReturnEstimatedSize() {
+        Cache<Object, Object> cache = Caffeine.newBuilder().maximumSize(3).build();
+        cache.put("key1", "value");
+        cache.put("key2", "value");
+        cache.put("key3", "value");
+        cache.put("key4", "value");
+        cache.put("key5", "value");
+        cache.cleanUp();
+
+        assertThat(provider.getEstimatedCacheSize(cache)).isEqualTo(3L);
+    }
+
+    @Test
+    void concurrentHashMap_shouldReturnEstimatedSize() {
+        ConcurrentHashMap<String, String> map = new ConcurrentHashMap<>();
+        map.put("key1", "value");
+        map.put("key2", "value");
+        map.put("key3", "value");
+
+        assertThat(provider.getEstimatedCacheSize(map)).isEqualTo(3L);
+    }
+
+    @Test
+    void unsupportedCacheProvider_shouldReturnNull() {
+        Object unknownCacheProvider = new Object();
+
+        assertThat(provider.getEstimatedCacheSize(unknownCacheProvider)).isNull();
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheTest.java
@@ -1,0 +1,602 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.cache;
+
+import java.util.concurrent.Callable;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+
+import static com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricNames.CACHE_ENABLED;
+import static com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricNames.CACHE_REQUESTS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DefaultEnhancedCache}.
+ *
+ * @author Mikhail Polivakha
+ * @author Nikita Kirillov
+ */
+@ExtendWith(MockitoExtension.class)
+class DefaultEnhancedCacheTest {
+
+    private static final String KEY = "testKey";
+    private static final String VALUE = "testValue";
+    private static final String CACHE_NAME = "testCacheName";
+
+    private MeterRegistry meterRegistry;
+    private AxelixMetricsPublisher axelixMetricsPublisher;
+
+    @Mock
+    private Cache delegate;
+
+    private EnhancedCache enhancedCache;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        axelixMetricsPublisher = new DefaultAxelixMetricsPublisher(meterRegistry);
+
+        Mockito.lenient().when(delegate.getName()).thenReturn(CACHE_NAME);
+        enhancedCache = new DefaultEnhancedCache(delegate, axelixMetricsPublisher);
+    }
+
+    @Nested
+    class EnableDisable {
+
+        @BeforeEach
+        void setUp() {
+            EnhancedCacheManager enhancedCacheManager = new DefaultEnhancedCacheManager(
+                    "cacheManager", new ConcurrentMapCacheManager(CACHE_NAME), axelixMetricsPublisher);
+            enhancedCache = enhancedCacheManager.getCache(CACHE_NAME);
+        }
+
+        @Test
+        void shouldBeEnabledByDefault() {
+            // given.
+            // cache is created in setUp
+
+            // when.
+            boolean isEnabled = enhancedCache.isEnabled();
+
+            // then.
+            assertThat(isEnabled).isTrue();
+            checkMeterRegistryCacheStatusGauge(isEnabled);
+        }
+
+        @Test
+        void shouldDisableCache() {
+            // given.
+            assertThat(enhancedCache.isEnabled()).isTrue();
+            checkMeterRegistryCacheStatusGauge(true);
+
+            // when.
+            enhancedCache.disable();
+
+            // then.
+            assertThat(enhancedCache.isEnabled()).isFalse();
+            checkMeterRegistryCacheStatusGauge(false);
+        }
+
+        @Test
+        void shouldReEnableCache() {
+            // given.
+            enhancedCache.disable();
+            assertThat(enhancedCache.isEnabled()).isFalse();
+            checkMeterRegistryCacheStatusGauge(false);
+
+            // when.
+            enhancedCache.enable();
+
+            // then.
+            assertThat(enhancedCache.isEnabled()).isTrue();
+            checkMeterRegistryCacheStatusGauge(true);
+        }
+
+        @Test
+        void shouldBeNoOpWhenCacheIsAlreadyEnabled() {
+            // given.
+            assertThat(enhancedCache.isEnabled()).isTrue();
+            checkMeterRegistryCacheStatusGauge(true);
+
+            // when.
+            enhancedCache.enable();
+
+            // then.
+            assertThat(enhancedCache.isEnabled()).isTrue();
+            checkMeterRegistryCacheStatusGauge(true);
+        }
+
+        @Test
+        void shouldBeNoOpWhenCacheIsAlreadyDisabled() {
+            // given.
+            enhancedCache.disable();
+            assertThat(enhancedCache.isEnabled()).isFalse();
+            checkMeterRegistryCacheStatusGauge(false);
+
+            // when.
+            enhancedCache.disable();
+
+            // then.
+            assertThat(enhancedCache.isEnabled()).isFalse();
+            checkMeterRegistryCacheStatusGauge(false);
+        }
+    }
+
+    @Nested
+    class SimpleGet {
+
+        @Test
+        void shouldReturnValueWhenCacheIsEnabled() {
+            // given.
+            when(delegate.get(KEY)).thenReturn(() -> VALUE);
+
+            // when.
+            Cache.ValueWrapper result = enhancedCache.get(KEY);
+
+            // then.
+            assertThat(result).isNotNull();
+            assertThat(result.get()).isEqualTo(VALUE);
+            verify(delegate).get(KEY);
+        }
+
+        @Test
+        void shouldReturnNullWhenCacheIsDisabled() {
+            // given.
+            enhancedCache.disable();
+
+            // when.
+            Cache.ValueWrapper result = enhancedCache.get(KEY);
+
+            // then.
+            assertThat(result).isNull();
+            verify(delegate, never()).get(any());
+        }
+
+        @Test
+        void shouldTrackHitWhenValueIsFound() {
+            // given.
+            when(delegate.get(KEY)).thenReturn(() -> VALUE);
+
+            // when.
+            enhancedCache.get(KEY);
+
+            // then.
+            assertThat(enhancedCache.getCacheLookups()).hasSize(1);
+            assertThat(enhancedCache.getCacheLookups().get(0).outcome()).isEqualTo(CacheLookup.Outcome.HIT);
+        }
+
+        @Test
+        void shouldTrackMissWhenValueIsNotFound() {
+            // given.
+            when(delegate.get(KEY)).thenReturn(null);
+
+            // when.
+            enhancedCache.get(KEY);
+
+            // then.
+            assertThat(enhancedCache.getCacheLookups()).hasSize(1);
+            assertThat(enhancedCache.getCacheLookups().get(0).outcome()).isEqualTo(CacheLookup.Outcome.MISS);
+        }
+    }
+
+    @Nested
+    class GetWithType {
+
+        @Test
+        void shouldReturnValueWhenCacheIsEnabled() {
+            // given.
+            when(delegate.get(KEY, String.class)).thenReturn(VALUE);
+
+            // when.
+            String result = enhancedCache.get(KEY, String.class);
+
+            // then.
+            assertThat(result).isEqualTo(VALUE);
+            verify(delegate).get(KEY, String.class);
+        }
+
+        @Test
+        void shouldReturnNullWhenCacheIsDisabled() {
+            // given.
+            enhancedCache.disable();
+
+            // when.
+            String result = enhancedCache.get(KEY, String.class);
+
+            // then.
+            assertThat(result).isNull();
+            verify(delegate, never()).get(any(), any(Class.class));
+        }
+    }
+
+    @Nested
+    class GetWithValueLoader {
+
+        @Test
+        void getWithValueLoader_shouldReturnValueWhenCacheIsEnabled() {
+            // given.
+            when(delegate.get(eq(KEY), any(Callable.class))).thenAnswer(invocation -> {
+                Callable<String> loader = invocation.getArgument(1);
+                return loader.call();
+            });
+
+            // when.
+            String result = enhancedCache.get(KEY, () -> VALUE);
+
+            // then.
+            assertThat(result).isEqualTo(VALUE);
+            verify(delegate).get(eq(KEY), any(Callable.class));
+        }
+
+        @Test
+        void shouldReturnNullWhenCacheIsDisabled() {
+            // given.
+            enhancedCache.disable();
+
+            // when.
+            String result = enhancedCache.get(KEY, () -> VALUE);
+
+            // then.
+            assertThat(result).isNull();
+            verify(delegate, never()).get(any(), any(Callable.class));
+        }
+
+        @Test
+        void shouldTrackHitWhenValueExistsInCache() {
+            // given.
+            when(delegate.get(eq(KEY), any(Callable.class))).thenReturn(VALUE);
+
+            // when.
+            enhancedCache.get(KEY, () -> VALUE);
+
+            // then.
+            assertThat(enhancedCache.getCacheLookups()).hasSize(1);
+            assertThat(enhancedCache.getCacheLookups().get(0).outcome()).isEqualTo(CacheLookup.Outcome.HIT);
+        }
+
+        @Test
+        void shouldTrackMissWhenValueLoaderIsCalled() {
+            // given.
+            when(delegate.get(eq(KEY), any(Callable.class))).thenAnswer(invocation -> {
+                Callable<String> loader = invocation.getArgument(1);
+                return loader.call();
+            });
+
+            // when.
+            enhancedCache.get(KEY, () -> VALUE);
+
+            // then.
+            assertThat(enhancedCache.getCacheLookups()).hasSize(1);
+            assertThat(enhancedCache.getCacheLookups().get(0).outcome()).isEqualTo(CacheLookup.Outcome.MISS);
+        }
+    }
+
+    @Nested
+    class Put {
+
+        @Test
+        void shouldDelegateToUnderlyingCacheWhenEnabled() {
+            // given.
+            // cache is enabled by default
+
+            // when.
+            enhancedCache.put(KEY, VALUE);
+
+            // then.
+            verify(delegate).put(KEY, VALUE);
+        }
+
+        @Test
+        void shouldNotDelegateWhenCacheIsDisabled() {
+            // given.
+            enhancedCache.disable();
+
+            // when.
+            enhancedCache.put(KEY, VALUE);
+
+            // then.
+            verify(delegate, never()).put(any(), any());
+        }
+
+        @Test
+        void shouldHandleNullValue() {
+            // given.
+            // cache is enabled by default
+
+            // when.
+            enhancedCache.put(KEY, null);
+
+            // then.
+            verify(delegate).put(KEY, null);
+        }
+    }
+
+    @Nested
+    class Evict {
+
+        @Test
+        void shouldDelegateToUnderlyingCacheWhenEnabled() {
+            // given.
+            // cache is enabled by default
+
+            // when.
+            enhancedCache.evict(KEY);
+
+            // then.
+            verify(delegate).evict(KEY);
+        }
+
+        @Test
+        void shouldNotDelegateWhenCacheIsDisabled() {
+            // given.
+            enhancedCache.disable();
+
+            // when.
+            enhancedCache.evict(KEY);
+
+            // then.
+            verify(delegate, never()).evict(any());
+        }
+    }
+
+    @Nested
+    class Clear {
+
+        @Test
+        void shouldDelegateToUnderlyingCacheWhenEnabled() {
+            // given.
+            // cache is enabled by default
+
+            // when.
+            enhancedCache.clear();
+
+            // then.
+            verify(delegate).clear();
+        }
+
+        @Test
+        void shouldNotDelegateWhenCacheIsDisabled() {
+            // given.
+            enhancedCache.disable();
+
+            // when.
+            enhancedCache.clear();
+
+            // then.
+            verify(delegate, never()).clear();
+        }
+    }
+
+    @Nested
+    class Invalidate {
+
+        @Test
+        void shouldDelegateToUnderlyingCacheWhenEnabled() {
+            // given.
+            when(delegate.invalidate()).thenReturn(true);
+
+            // when.
+            boolean result = enhancedCache.invalidate();
+
+            // then.
+            assertThat(result).isTrue();
+            verify(delegate).invalidate();
+        }
+
+        @Test
+        void shouldReturnFalseWhenCacheIsDisabled() {
+            // given.
+            enhancedCache.disable();
+
+            // when.
+            boolean result = enhancedCache.invalidate();
+
+            // then.
+            assertThat(result).isFalse();
+            verify(delegate, never()).invalidate();
+        }
+    }
+
+    @Nested
+    class EvictIfPresent {
+
+        @Test
+        void shouldDelegateToUnderlyingCacheWhenEnabled() {
+            // given.
+            when(delegate.evictIfPresent(KEY)).thenReturn(true);
+
+            // when.
+            boolean result = enhancedCache.evictIfPresent(KEY);
+
+            // then.
+            assertThat(result).isTrue();
+            verify(delegate).evictIfPresent(KEY);
+        }
+
+        @Test
+        void shouldReturnFalseWhenCacheIsDisabled() {
+            // given.
+            enhancedCache.disable();
+
+            // when.
+            boolean result = enhancedCache.evictIfPresent(KEY);
+
+            // then.
+            assertThat(result).isFalse();
+            verify(delegate, never()).evictIfPresent(any());
+        }
+
+        @Test
+        void shouldReturnFalseWhenDelegateReturnsFalse() {
+            // given.
+            when(delegate.evictIfPresent(KEY)).thenReturn(false);
+
+            // when.
+            boolean result = enhancedCache.evictIfPresent(KEY);
+
+            // then.
+            assertThat(result).isFalse();
+            verify(delegate).evictIfPresent(KEY);
+        }
+    }
+
+    @Nested
+    class HitsMisses {
+
+        @Test
+        void shouldReturnOnlyHits() {
+            // given.
+            Cache.ValueWrapper hitWrapper = () -> VALUE;
+            when(delegate.get("key1")).thenReturn(hitWrapper);
+            when(delegate.get("key2")).thenReturn(hitWrapper);
+            when(delegate.get("key3")).thenReturn(hitWrapper);
+
+            // when.
+            enhancedCache.get("key1");
+            enhancedCache.get("key2");
+            enhancedCache.get("key3");
+
+            // then.
+            assertThat(enhancedCache.getCacheLookups()).hasSize(3);
+            assertThat(enhancedCache.getCacheLookups())
+                    .extracting(CacheLookup::outcome)
+                    .containsOnly(CacheLookup.Outcome.HIT);
+            // and then.
+            checkMeterRegistryCacheLookup(3d, 0d);
+        }
+
+        @Test
+        void getMisses_shouldReturnOnlyMisses() {
+            // given.
+            when(delegate.get("key1")).thenReturn(null);
+            when(delegate.get("key2")).thenReturn(null);
+            when(delegate.get("key3")).thenReturn(null);
+
+            // when.
+            enhancedCache.get("key1");
+            enhancedCache.get("key2");
+            enhancedCache.get("key3");
+
+            // then.
+            assertThat(enhancedCache.getCacheLookups()).hasSize(3);
+            assertThat(enhancedCache.getCacheLookups())
+                    .extracting(CacheLookup::outcome)
+                    .containsOnly(CacheLookup.Outcome.MISS);
+            // and then.
+            checkMeterRegistryCacheLookup(0d, 3d);
+        }
+
+        @Test
+        void shouldNotTrackWhenCacheIsDisabled() {
+            // given.
+            enhancedCache.disable();
+
+            // when.
+            enhancedCache.get(KEY);
+
+            // then.
+            assertThat(enhancedCache.getCacheLookups()).isEmpty();
+        }
+
+        @Test
+        void multipleOperations_shouldTrackHitsAndMissesCorrectly() {
+            // given.
+            Cache.ValueWrapper hitWrapper = () -> VALUE;
+            when(delegate.get("hit1")).thenReturn(hitWrapper);
+            when(delegate.get("miss1")).thenReturn(null);
+            when(delegate.get("hit2")).thenReturn(hitWrapper);
+            when(delegate.get("miss2")).thenReturn(null);
+            when(delegate.get("hit3")).thenReturn(hitWrapper);
+
+            // when.
+            enhancedCache.get("hit1");
+            enhancedCache.get("miss1");
+            enhancedCache.get("hit2");
+            enhancedCache.get("miss2");
+            enhancedCache.get("hit3");
+
+            // then.
+            assertThat(enhancedCache.getCacheLookups()).hasSize(5);
+            assertThat(enhancedCache.getCacheLookups())
+                    .extracting(CacheLookup::outcome)
+                    .containsExactly(
+                            CacheLookup.Outcome.HIT,
+                            CacheLookup.Outcome.MISS,
+                            CacheLookup.Outcome.HIT,
+                            CacheLookup.Outcome.MISS,
+                            CacheLookup.Outcome.HIT);
+            // and then.
+            checkMeterRegistryCacheLookup(3d, 2d);
+        }
+    }
+
+    private void checkMeterRegistryCacheStatusGauge(boolean cacheEnabled) {
+        Gauge gauge = meterRegistry.find(CACHE_ENABLED).tag("cache", CACHE_NAME).gauge();
+
+        assertThat(gauge).isNotNull();
+        // The value is returned as a double (1.0 for enabled, 0.0 for disabled)
+        assertThat(gauge.value()).isEqualTo(cacheEnabled ? 1.0 : 0.0);
+    }
+
+    private void checkMeterRegistryCacheLookup(double expectedHits, double expectedMisses) {
+        // 1. Verify Cache Hits
+        Counter cacheHitsCounter = meterRegistry
+                .find(CACHE_REQUESTS)
+                .tag("cache", CACHE_NAME)
+                .tag("result", CacheLookup.Outcome.HIT.getValue())
+                .counter();
+
+        if (expectedHits != 0.0) {
+            assertThat(cacheHitsCounter).isNotNull();
+            assertThat(cacheHitsCounter.count()).isEqualTo(expectedHits);
+        }
+
+        // 2. Verify Cache Misses
+        Counter cacheMissesCounter = meterRegistry
+                .find(CACHE_REQUESTS)
+                .tag("cache", CACHE_NAME)
+                .tag("result", CacheLookup.Outcome.MISS.getValue())
+                .counter();
+
+        if (expectedMisses != 0.0) {
+            assertThat(cacheMissesCounter).isNotNull();
+            assertThat(cacheMissesCounter.count()).isEqualTo(expectedMisses);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.cache;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Unit tests for {@link EnhancedCacheManager}.
+ *
+ * @since 23.06.2025
+ * @author Nikita Kirillov
+ * @author Sergey Cherkasov
+ * @author Mikhail Polivakha
+ */
+class EnhancedCacheManagerTest {
+
+    private EnhancedCacheManager subject;
+
+    @BeforeEach
+    void setUp() {
+        CacheManager cacheManager = new ConcurrentMapCacheManager();
+        AxelixMetricsPublisher axelixMetricsPublisher = new DefaultAxelixMetricsPublisher(new SimpleMeterRegistry());
+        subject = new DefaultEnhancedCacheManager("testCacheManagerBeanName", cacheManager, axelixMetricsPublisher);
+    }
+
+    @Test
+    void clear_shouldCallClearOnCache() {
+        // given.
+        String key = "key";
+        String cacheName = "cache";
+        Cache cache = subject.getCache(cacheName);
+        assertThat(cache).isNotNull();
+
+        cache.put(key, "value");
+        assertThat(cache.get(key)).isNotNull();
+
+        // when.
+        subject.clear(cacheName);
+
+        // then.
+        assertThat(cache.get(key)).isNull();
+    }
+
+    @Test
+    void clearAll_shouldClearAllCaches() {
+        // given.
+        String key1 = "key1", key2 = "key2";
+        Cache cache1 = subject.getCache("cache1");
+        Cache cache2 = subject.getCache("cache2");
+        assertThat(cache1).isNotNull();
+        assertThat(cache2).isNotNull();
+
+        cache1.put(key1, "value1");
+        cache2.put(key2, "value2");
+        assertThat(cache1.get(key1)).isNotNull();
+        assertThat(cache2.get(key2)).isNotNull();
+
+        // when.
+        subject.clearAll();
+
+        // then.
+        assertThat(cache1.get(key1)).isNull();
+        assertThat(cache2.get(key2)).isNull();
+    }
+
+    @Test
+    void clearWithKey_shouldEvictOnlySpecifiedKey() {
+        // given.
+        String cacheName = "cache";
+        String keyToRemove = "keyToRemove", keyToKeep = "keyToKeep";
+        Cache cache = subject.getCache(cacheName);
+        assertThat(cache).isNotNull();
+
+        cache.put(keyToRemove, "value1");
+        cache.put(keyToKeep, "value2");
+        assertThat(cache.get(keyToRemove)).isNotNull();
+        assertThat(cache.get(keyToKeep)).isNotNull();
+
+        // when.
+        subject.clear(cacheName, keyToRemove);
+
+        // then.
+        assertThat(cache.get(keyToRemove)).isNull();
+        assertThat(cache.get(keyToKeep))
+                .isNotNull()
+                .satisfies(cacheValue -> assertThat(cacheValue.get()).isEqualTo("value2"));
+    }
+
+    @Test
+    void clearAll_shouldDoNothing() {
+        assertThat(subject.getCacheNames()).isEmpty();
+        assertThatNoException().isThrownBy(() -> subject.clearAll());
+    }
+
+    @Test
+    void clear_shouldDoNothing() {
+        String cacheName = "nonExistentCache";
+        assertThatNoException().isThrownBy(() -> subject.clear(cacheName));
+    }
+
+    @Test
+    void clearWithKey_shouldDoNothing() {
+        String cacheName = "nonExistentCache";
+        assertThatNoException().isThrownBy(() -> subject.clear(cacheName, "key"));
+    }
+
+    @Test
+    void enableCacheManager_shouldEnableAllCachesWhenEnhancedCacheManager() {
+        Cache cache = subject.getCache("cache");
+        assert cache != null;
+
+        subject.disableAll();
+
+        cache.put("key", "value");
+        assertThat(cache.get("key")).isNull();
+
+        // when.
+        subject.enableAll();
+
+        // then.
+        cache.put("key2", "value2");
+        assertThat(cache.get("key2")).isNotNull();
+    }
+
+    @Test
+    void disableCacheManager_shouldDisableAllCachesWhenEnhancedCacheManager() {
+        // given.
+        Cache cache = subject.getCache("cache");
+        cache.put("key", "value");
+
+        assertThat(cache.get("key")).isNotNull();
+
+        // when.
+        subject.disableAll();
+
+        // then.
+        cache.put("key2", "value2");
+        assertThat(cache.get("key2")).isNull();
+    }
+
+    @Test
+    void enableCache_shouldEnableSpecificCacheWhenEnhancedCacheManager() {
+        // given.
+        Cache cache = subject.getCache("cache");
+        assert cache != null;
+        subject.disable("cache");
+
+        cache.put("key", "value");
+        assertThat(cache.get("key")).isNull();
+
+        // when.
+        subject.enable("cache");
+
+        // then.
+        cache.put("key2", "value2");
+        assertThat(cache.get("key2"))
+                .isNotNull()
+                .extracting(Cache.ValueWrapper::get)
+                .isEqualTo("value2");
+    }
+
+    @Test
+    void disableCache_shouldDisableSpecificCacheWhenEnhancedCacheManager() {
+        // given.
+        Cache cache = subject.getCache("cache");
+        cache.put("key", "value");
+        assertThat(cache.get("key")).isNotNull();
+
+        // when.
+        subject.disable("cache");
+
+        // then.
+        cache.put("key2", "value2");
+        assertThat(cache.get("key2")).isNull();
+    }
+
+    @Test
+    void enableCache_shouldWorkWhenCacheDoesNotExistInEnhancedCacheManager() {
+        assertThatNoException().isThrownBy(() -> subject.enable("nonExistentCache"));
+    }
+
+    @Test
+    void disableCache_shouldWorkWhenCacheDoesNotExistInEnhancedCacheManager() {
+        assertThatNoException().isThrownBy(() -> subject.disable("nonExistentCache"));
+    }
+
+    @Test
+    void enableCache_shouldNotAffectOtherCachesInEnhancedCacheManager() {
+        // given.
+        Cache cache1 = subject.getCache("cache1");
+        Cache cache2 = subject.getCache("cache2");
+
+        // when.
+        subject.disable("cache1");
+
+        // then.
+        cache1.put("key1", "value1");
+        cache2.put("key2", "value2");
+        assertThat(cache1.get("key1")).isNull();
+        assertThat(cache2.get("key2")).isNotNull();
+
+        // and also when.
+        subject.enable("cache1");
+
+        // then.
+        cache1.put("key3", "value3");
+        cache2.put("key4", "value4");
+
+        assertThat(cache1.get("key3")).isNotNull();
+        assertThat(cache2.get("key4")).isNotNull();
+    }
+
+    @Test
+    void isCacheEnabled_shouldReturnTrueForEnabledCacheInEnhancedCacheManager() {
+        // when.
+        String cacheName = "cache";
+        Cache cache = subject.getCache(cacheName);
+
+        // then.
+        assertThat(cache).isNotNull();
+        assertThat(subject.isEnabled(cacheName)).isTrue();
+    }
+
+    @Test
+    void isCacheEnabled_shouldReturnFalseForDisabledCacheInEnhancedCacheManager() {
+        // given.
+        String cacheName = "cache";
+        Cache cache = subject.getCache(cacheName);
+
+        // when.
+        subject.disable(cacheName);
+
+        // then.
+        assertThat(cache).isNotNull();
+        assertThat(subject.isEnabled(cacheName)).isFalse();
+    }
+
+    @Test
+    void isCacheEnabled_shouldReturnTrueAfterEnableDisableCacheInEnhancedCacheManager() {
+        // given.
+        String cacheName = "cache";
+
+        // when.
+        subject.disable(cacheName);
+        assertThat(subject.isEnabled(cacheName)).isFalse();
+
+        // then.
+        subject.enable(cacheName);
+        assertThat(subject.isEnabled(cacheName)).isTrue();
+    }
+
+    @Test
+    void isCacheEnabled_shouldReturnFalseWhenCacheManagerDisabledInEnhancedCacheManager() {
+        // given.
+        String cacheName1 = "cache1";
+        String cacheName2 = "cache2";
+        subject.getCache(cacheName1);
+        subject.getCache(cacheName2);
+
+        // when.
+        subject.disableAll();
+
+        // then.
+        assertThat(subject.isEnabled(cacheName1)).isFalse();
+        assertThat(subject.isEnabled(cacheName2)).isFalse();
+    }
+
+    @Test
+    void isCacheEnabled_shouldWorkWithMultipleCachesInEnhancedCacheManager() {
+        // given.
+        String[] cacheNames = {"cache1", "cache2", "cache3"};
+        for (String cacheName : cacheNames) {
+            subject.getCache(cacheName);
+        }
+
+        // when.
+        subject.disable("cache2");
+
+        // then.
+        assertThat(subject.isEnabled("cache1")).isTrue();
+        assertThat(subject.isEnabled("cache2")).isFalse();
+        assertThat(subject.isEnabled("cache3")).isTrue();
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpointTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.conditions;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+
+import com.axelixlabs.axelix.common.api.ConditionsFeed;
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AxelixConditionsEndpoint}.
+ *
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"axelix.prop.test.name=axelix-beans", "axelix.conditions.test.flag=enabled"})
+@Import(JwtAuthTestConfiguration.class)
+public class AxelixConditionsEndpointTest {
+
+    @Autowired
+    private TestRestTemplateBuilder testRestTemplate;
+
+    @TestConfiguration
+    static class AxelixConditionsEndpointTestConfiguration {
+        @Bean
+        public ConditionalTargetUnwrapper conditionalNameUnwrap() {
+            return new DefaultConditionalTargetUnwrapper();
+        }
+
+        @Bean
+        public ConditionalFeedBuilder conditionalFeedBuilder(
+                ConfigurableApplicationContext configurableApplicationContext,
+                ConditionalTargetUnwrapper conditionalTargetUnwrapper) {
+            return new DefaultConditionalFeedBuilder(configurableApplicationContext, conditionalTargetUnwrapper);
+        }
+
+        @Bean
+        public AxelixConditionsEndpoint axelixConditionsEndpoint(ConditionalFeedBuilder conditionalFeedBuilder) {
+            return new AxelixConditionsEndpoint(conditionalFeedBuilder);
+        }
+
+        @Bean
+        @ConditionalOnProperty(name = "axelix.conditions.test.flag", havingValue = "enabled")
+        public String positiveConditionBean() {
+            return "positive";
+        }
+
+        @Bean
+        @ConditionalOnProperty(name = "axelix.conditions.test.flag", havingValue = "disabled")
+        public String negativeConditionBean() {
+            return "negative";
+        }
+    }
+
+    @Test
+    void shouldReturnConditionsFeed() {
+        String className = AxelixConditionsEndpointTest.class.getSimpleName() + "."
+                + AxelixConditionsEndpointTestConfiguration.class.getSimpleName();
+        String positiveMethodName = "positiveConditionBean";
+        String negativeMethodName = "negativeConditionBean";
+
+        ResponseEntity<ConditionsFeed> response =
+                testRestTemplate.asViewer().getForEntity("/actuator/axelix-conditions", ConditionsFeed.class);
+
+        // PositiveMatches()
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getPositiveMatches()).isNotNull().isNotEmpty();
+        assertThat(response.getBody().getPositiveMatches())
+                .filteredOn(positiveCondition -> positiveMethodName.equals(positiveCondition.getMethodName()))
+                .singleElement()
+                .satisfies(positiveCondition -> {
+                    assertThat(positiveCondition.getClassName()).isEqualTo(className);
+                    assertThat(positiveCondition.getMethodName()).isEqualTo(positiveMethodName);
+                    assertThat(positiveCondition.getMatched()).isNotNull().isNotEmpty();
+                    assertThat(positiveCondition.getMatched()).allSatisfy(match -> {
+                        assertThat(match.getCondition()).isNotBlank();
+                        assertThat(match.getMessage()).isNotBlank();
+                    });
+                });
+
+        // NegativeMatches
+        assertThat(response.getBody().getNegativeMatches())
+                .filteredOn(negativeCondition -> negativeMethodName.equals(negativeCondition.getMethodName()))
+                .singleElement()
+                .satisfies(negativeCondition -> {
+                    assertThat(negativeCondition.getClassName()).isEqualTo(className);
+                    assertThat(negativeCondition.getMethodName()).isEqualTo(negativeMethodName);
+                    assertThat(negativeCondition.getNotMatched()).isNotNull().isNotEmpty();
+                    assertThat(negativeCondition.getMatched()).isNotNull();
+                    assertThat(negativeCondition.getNotMatched()).allSatisfy(match -> {
+                        assertThat(match.getCondition()).isNotBlank();
+                        assertThat(match.getMessage()).isNotBlank();
+                    });
+                });
+    }
+
+    @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-conditions")
+    void negativeAuthTests() {}
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/configprops/AxelixConfigurationPropertiesEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/configprops/AxelixConfigurationPropertiesEndpointTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.configprops;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+
+import com.axelixlabs.axelix.common.api.ConfigurationPropertiesFeed;
+import com.axelixlabs.axelix.common.api.KeyValue;
+import com.axelixlabs.axelix.common.auth.core.DefaultRole;
+import com.axelixlabs.axelix.common.auth.core.Role;
+import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.auth.RequiredAuthorityCheckService;
+import com.axelixlabs.axelix.sbs.spring.core.env.DefaultPropertyNameNormalizer;
+import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AxelixConfigurationPropertiesEndpoint}.
+ *
+ * @author Sergey Cherkasov
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(
+        properties = {
+            "axelix.prop.test.tags.forSanitization=toBeSanitized",
+            "axelix.prop.test.tags.FOR_SANITIZATION=toBeSanitized",
+            "axelix.prop.test.tags.version=1.0.0",
+            "axelix.prop.test.enabled-contexts=user-service, payment-service",
+            "axelix.prop.test.http-client.requests[0].name=user-api",
+            "axelix.prop.test.http-client.requests[0].base-url=https://api.users.example.com/v1",
+            "axelix.prop.test.http-client.requests[0].methods[0].type=GET",
+            "axelix.prop.test.http-client.requests[0].methods[0].retries[0].count=3",
+            "axelix.prop.test.http-client.requests[0].methods[0].retries[0].parameters.timeout=5000",
+            "axelix.prop.test.http-client.requests[0].methods[1].type=POST",
+            "axelix.prop.test.http-client.requests[1].name=payment-api",
+            "axelix.prop.test.http-client.requests[1].base-url=https://api.payments.example.com/v2",
+            "axelix.prop.test.http-client.requests[1].methods[0].type=PUT",
+            "axelix.prop.test.http-client.requests[1].methods[0].retries[0].count=2",
+            "axelix.prop.test.http-client.requests[1].methods[0].retries[0].parameters.log-level=DEBUG",
+        })
+@EnableConfigurationProperties({AxelixConfigurationPropertiesEndpointTest.AxelixConfigurationProperties.class})
+@Import(JwtAuthTestConfiguration.class)
+public class AxelixConfigurationPropertiesEndpointTest {
+
+    @Autowired
+    private TestRestTemplateBuilder restTemplate;
+
+    @ParameterizedTest
+    @MethodSource("propertiesFeed")
+    void shouldReturnPropertiesNameAndValue_forNonAdminRoles(String propertyName, String expectedValue, Role role) {
+        ResponseEntity<ConfigurationPropertiesFeed> response = restTemplate
+                .withRole(role)
+                .getForEntity("/actuator/axelix-configprops", ConfigurationPropertiesFeed.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        List<KeyValue> properties = response.getBody().getBeans().stream()
+                .filter(beans -> beans.getPrefix().equals("axelix.prop.test"))
+                .flatMap(bean -> bean.getProperties().stream())
+                .toList();
+
+        assertThat(properties)
+                .filteredOn(e -> e.getKey().equals(propertyName))
+                .extracting(KeyValue::getValue)
+                .containsExactly(expectedValue);
+    }
+
+    private static Stream<Arguments> propertiesFeed() {
+        return Stream.of(
+                Arguments.of("tags.forSanitization", "******", DefaultRole.VIEWER),
+                Arguments.of("tags.FOR_SANITIZATION", "******", DefaultRole.VIEWER),
+                Arguments.of("tags.forSanitization", "******", DefaultRole.EDITOR),
+                Arguments.of("tags.FOR_SANITIZATION", "******", DefaultRole.EDITOR),
+                Arguments.of("tags.forSanitization", "toBeSanitized", DefaultRole.ADMIN),
+                Arguments.of("tags.FOR_SANITIZATION", "toBeSanitized", DefaultRole.ADMIN),
+                Arguments.of("tags.version", "1.0.0", DefaultRole.VIEWER),
+                Arguments.of("enabledContexts[0]", "user-service", DefaultRole.VIEWER),
+                Arguments.of("enabledContexts[1]", "payment-service", DefaultRole.VIEWER),
+                Arguments.of("httpClient.requests[0].name", "user-api", DefaultRole.VIEWER),
+                Arguments.of("httpClient.requests[0].baseUrl", "https://api.users.example.com/v1", DefaultRole.VIEWER),
+                Arguments.of("httpClient.requests[0].methods[0].type", "GET", DefaultRole.VIEWER),
+                Arguments.of("httpClient.requests[0].methods[0].retries[0].count", "3", DefaultRole.VIEWER),
+                Arguments.of(
+                        "httpClient.requests[0].methods[0].retries[0].parameters.timeout", "5000", DefaultRole.VIEWER),
+                Arguments.of("httpClient.requests[0].methods[1].type", "POST", DefaultRole.VIEWER),
+                Arguments.of("httpClient.requests[1].name", "payment-api", DefaultRole.VIEWER),
+                Arguments.of(
+                        "httpClient.requests[1].baseUrl", "https://api.payments.example.com/v2", DefaultRole.VIEWER),
+                Arguments.of("httpClient.requests[1].methods[0].type", "PUT", DefaultRole.VIEWER),
+                Arguments.of("httpClient.requests[1].methods[0].retries[0].count", "2", DefaultRole.VIEWER),
+                Arguments.of(
+                        "httpClient.requests[1].methods[0].retries[0].parameters.log-level",
+                        "DEBUG",
+                        DefaultRole.VIEWER));
+    }
+
+    @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-configprops")
+    void negativeAuthTests() {}
+
+    @ConfigurationProperties(prefix = "axelix.prop.test")
+    public record AxelixConfigurationProperties(
+            Map<String, String> tags, List<String> enabledContexts, HttpClient httpClient) {
+
+        public record HttpClient(List<Request> requests) {}
+
+        public record Request(String name, String baseUrl, List<Method> methods) {}
+
+        public record Method(String type, List<Retry> retries) {}
+
+        public record Retry(Integer count, Map<String, Object> parameters) {}
+    }
+
+    @TestConfiguration
+    static class AxelixConfigurationPropertiesEndpointTestConfiguration {
+
+        @Bean
+        public ConfigurationPropertiesFlattener configurationPropertiesFlattener() {
+            return new DefaultConfigurationPropertiesFlattener();
+        }
+
+        @Bean
+        public ConfigurationPropertiesConverter configurationPropertiesConverter(
+                ConfigurationPropertiesFlattener configurationPropertiesFlattener) {
+            return new DefaultConfigurationPropertiesConverter(configurationPropertiesFlattener);
+        }
+
+        @Bean
+        public PropertyNameNormalizer propertyNameNormalizer() {
+            return new DefaultPropertyNameNormalizer();
+        }
+
+        @Bean
+        public SmartSanitizingFunction smartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
+            return new SmartSanitizingFunction(
+                    List.of("axelix.prop.test.tags.forSanitization", "axelix.prop.test.tags.FOR_SANITIZATION"),
+                    propertyNameNormalizer);
+        }
+
+        @Bean
+        public RequiredAuthorityCheckService requiredAuthorityCheckService(
+                SecurityContextExecutor securityContextExecutor) {
+            return new RequiredAuthorityCheckService(securityContextExecutor);
+        }
+
+        @Bean
+        public DefaultConfigurationPropertiesService configurationPropertiesCache(
+                SmartSanitizingFunction smartSanitizingFunction,
+                ApplicationContext applicationContext,
+                ConfigurationPropertiesConverter configurationPropertiesConverter,
+                RequiredAuthorityCheckService requiredAuthorityCheckService) {
+            return new DefaultConfigurationPropertiesService(
+                    smartSanitizingFunction,
+                    applicationContext,
+                    configurationPropertiesConverter,
+                    requiredAuthorityCheckService);
+        }
+
+        @Bean
+        public AxelixConfigurationPropertiesEndpoint axelixConfigurationPropertiesEndpoint(
+                DefaultConfigurationPropertiesService configurationPropertiesService) {
+            return new AxelixConfigurationPropertiesEndpoint(configurationPropertiesService);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/configprops/DefaultConfigurationPropertiesConverterTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/configprops/DefaultConfigurationPropertiesConverterTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.configprops;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.context.properties.ConfigurationPropertiesReportEndpoint;
+import org.springframework.boot.actuate.context.properties.ConfigurationPropertiesReportEndpoint.ConfigurationPropertiesDescriptor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+
+import com.axelixlabs.axelix.common.api.ConfigurationPropertiesFeed;
+import com.axelixlabs.axelix.common.api.KeyValue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link DefaultConfigurationPropertiesConverter}.
+ *
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest(properties = "management.endpoint.configprops.show-values=always")
+@TestPropertySource(
+        properties = {
+            "axelix.prop.test.tags.environment=test",
+            "axelix.prop.test.tags.version=1.0.0",
+            "axelix.prop.test.enabled-contexts=user-service,payment-service",
+            "axelix.prop.test.http-client.requests[0].name=user-api",
+            "axelix.prop.test.http-client.requests[0].base-url=https://api.users.example.com/v1",
+            "axelix.prop.test.http-client.requests[0].methods[0].type=GET",
+            "axelix.prop.test.http-client.requests[0].methods[0].retries[0].count=3",
+            "axelix.prop.test.http-client.requests[0].methods[0].retries[0].parameters.timeout=5000",
+            "axelix.prop.test.http-client.requests[0].methods[1].type=POST"
+        })
+@EnableConfigurationProperties(DefaultConfigurationPropertiesConverterTest.AxelixConfigurationProperties.class)
+public class DefaultConfigurationPropertiesConverterTest {
+
+    @Autowired
+    private ConfigurationPropertiesReportEndpoint endpoint;
+
+    @Autowired
+    private ConfigurationPropertiesConverter enricher;
+
+    @Test
+    void shouldReturnConfigurationPropertiesFeed() {
+        ConfigurationPropertiesDescriptor defaultDescriptor = endpoint.configurationProperties();
+
+        ConfigurationPropertiesFeed axelixConfPropDescriptor = enricher.convert(defaultDescriptor);
+
+        assertThat(axelixConfPropDescriptor).isNotNull();
+
+        assertThat(axelixConfPropDescriptor.getBeans()).isNotEmpty();
+
+        assertThat(axelixConfPropDescriptor.getBeans())
+                .filteredOn(beans -> beans.getPrefix().equals("axelix.prop.test"))
+                .singleElement()
+                .satisfies(bean -> {
+
+                    // Bean Name
+                    assertThat(bean.getBeanName()).isEqualTo(AxelixConfigurationProperties.class.getName());
+
+                    // prefix
+                    assertThat(bean.getPrefix()).isEqualTo("axelix.prop.test");
+
+                    // properties
+                    assertThat(bean.getProperties())
+                            .containsOnly(
+                                    new KeyValue("tags.environment", "test"),
+                                    new KeyValue("tags.version", "1.0.0"),
+                                    new KeyValue("enabledContexts[0]", "user-service"),
+                                    new KeyValue("enabledContexts[1]", "payment-service"),
+                                    new KeyValue("httpClient.requests[0].name", "user-api"),
+                                    new KeyValue("httpClient.requests[0].baseUrl", "https://api.users.example.com/v1"),
+                                    new KeyValue("httpClient.requests[0].methods[0].type", "GET"),
+                                    new KeyValue("httpClient.requests[0].methods[0].retries[0].count", "3"),
+                                    new KeyValue(
+                                            "httpClient.requests[0].methods[0].retries[0].parameters.timeout", "5000"),
+                                    new KeyValue("httpClient.requests[0].methods[1].type", "POST"));
+
+                    // inputs
+                    assertThat(bean.getInputs())
+                            .hasSize(20)
+                            .anyMatch(input -> input.getKey()
+                                    .equals("httpClient.requests[0].methods[0].retries[0].parameters.timeout.value"))
+                            .anyMatch(p -> p.getKey().equals("httpClient.requests[0].baseUrl.origin"));
+                });
+    }
+
+    @ConfigurationProperties(prefix = "axelix.prop.test")
+    public record AxelixConfigurationProperties(
+            Map<String, String> tags,
+            List<String> enabledContexts,
+            AxelixConfigurationPropertiesEndpointTest.AxelixConfigurationProperties.HttpClient httpClient) {
+
+        public record HttpClient(
+                List<AxelixConfigurationPropertiesEndpointTest.AxelixConfigurationProperties.Request> requests) {}
+
+        public record Request(
+                String name,
+                String baseUrl,
+                List<AxelixConfigurationPropertiesEndpointTest.AxelixConfigurationProperties.Method> methods) {}
+
+        public record Method(
+                String type,
+                List<AxelixConfigurationPropertiesEndpointTest.AxelixConfigurationProperties.Retry> retries) {}
+
+        public record Retry(Integer count, Map<String, Object> parameters) {}
+    }
+
+    @TestConfiguration
+    static class DefaultDefaultConfigurationPropertiesTestConfiguration {
+
+        @Bean
+        public ConfigurationPropertiesFlattener configurationPropertiesFlattener() {
+            return new DefaultConfigurationPropertiesFlattener();
+        }
+
+        @Bean
+        public ConfigurationPropertiesConverter configurationPropertiesConverter(
+                ConfigurationPropertiesFlattener configurationPropertiesFlattener) {
+            return new DefaultConfigurationPropertiesConverter(configurationPropertiesFlattener);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/configprops/DefaultConfigurationPropertiesServiceTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/configprops/DefaultConfigurationPropertiesServiceTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.configprops;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import com.axelixlabs.axelix.common.api.ConfigurationPropertiesFeed;
+import com.axelixlabs.axelix.common.api.KeyValue;
+import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
+import com.axelixlabs.axelix.common.auth.core.DefaultSecurityContext;
+import com.axelixlabs.axelix.common.auth.core.SecurityContext;
+import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
+import com.axelixlabs.axelix.common.auth.core.User;
+import com.axelixlabs.axelix.sbs.spring.core.auth.RequiredAuthorityCheckService;
+import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
+import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesServiceTest.WithExplicitSanitizationProperties.AxelixConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesServiceTest.WithExplicitSanitizationProperties.TestConfigWithExplicitSanitizationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesServiceTest.WithoutExplicitSanitizationProperties.TestConfigWithAllPropertiesSanitized;
+import com.axelixlabs.axelix.sbs.spring.core.env.DefaultPropertyNameNormalizer;
+import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
+
+import static com.axelixlabs.axelix.sbs.spring.core.utils.UserUtils.createUserWithAuthorities;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link DefaultConfigurationPropertiesService}.
+ *
+ * @author Sergey Cherkasov
+ * @author Mikhail Polivakha
+ * @author Nikita Kirillov
+ */
+public class DefaultConfigurationPropertiesServiceTest {
+
+    private final ThreadLocalSecurityContextExecutor securityContextExecutor = new ThreadLocalSecurityContextExecutor();
+
+    @SpringBootTest
+    @Nested
+    @Import(TestConfigWithAllPropertiesSanitized.class)
+    class WithoutExplicitSanitizationProperties {
+
+        @Autowired
+        private ConfigurationPropertiesService configurationPropertiesService;
+
+        @Test
+        void shouldReturnSanitizedConfigurationProperties_whenRequiredAuthorityIsMissing() {
+            // when.
+            User user = createUserWithAuthorities();
+            SecurityContext securityContext = new DefaultSecurityContext(user, "testToken");
+            ConfigurationPropertiesFeed configProps = securityContextExecutor.callWithinSecurityContext(
+                    () -> configurationPropertiesService.getConfigProps(), securityContext);
+
+            // then.
+            Set<@Nullable String> values = configProps.getBeans().stream()
+                    .flatMap(bean -> bean.getProperties().stream())
+                    .map(KeyValue::getValue)
+                    .collect(Collectors.toSet());
+
+            // TODO: Well, the "null" sanitization policy is not something that we currently have control over.
+            // It is also not clear if we want to sanitize "null" values in general. I think
+            // that it makes sense to sanitize them as well, but currently it is not possible due
+            // to internal implementation of the Spring Boot Actuator native config props endpoint.
+            assertThat(values).containsOnly(null, "******");
+        }
+
+        @Test
+        void shouldReturnUnsanitizedConfigurationProperties_whenUserHasRequiredAuthority() {
+            // when.
+            User user = createUserWithAuthorities(DefaultAuthority.CONFIG_PROPS_VALUES_READ);
+            SecurityContext securityContext = new DefaultSecurityContext(user, "testToken");
+            ConfigurationPropertiesFeed configProps = securityContextExecutor.callWithinSecurityContext(
+                    () -> configurationPropertiesService.getConfigProps(), securityContext);
+
+            // then.
+            Set<@Nullable String> values = configProps.getBeans().stream()
+                    .flatMap(bean -> bean.getProperties().stream())
+                    .map(KeyValue::getValue)
+                    .collect(Collectors.toSet());
+
+            assertThat(values).doesNotContain("******");
+        }
+
+        @TestConfiguration
+        @Import(ConfigurationPropertiesServiceTestConfiguration.class)
+        static class TestConfigWithAllPropertiesSanitized {
+
+            @Bean
+            public SmartSanitizingFunction smartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
+                return new SmartSanitizingFunction(
+                        EndpointsConfigurationProperties.SANITIZE_ALL, propertyNameNormalizer);
+            }
+        }
+    }
+
+    @SpringBootTest(
+            properties = {
+                "axelix.prop.test.tags.forSanitization=toBeSanitized",
+                "axelix.prop.test.tags.FOR_SANITIZATION=toBeSanitized"
+            })
+    @Nested
+    @EnableConfigurationProperties(AxelixConfigurationProperties.class)
+    @Import(TestConfigWithExplicitSanitizationProperties.class)
+    class WithExplicitSanitizationProperties {
+
+        @Autowired
+        private ConfigurationPropertiesService configurationPropertiesService;
+
+        @Test
+        void shouldReturnOnlyExplicitlySanitizedConfigurationProperties_whenRequiredAuthorityIsMissing() {
+            // when.
+            User user = createUserWithAuthorities();
+            SecurityContext securityContext = new DefaultSecurityContext(user, "testToken");
+            ConfigurationPropertiesFeed configProps = securityContextExecutor.callWithinSecurityContext(
+                    () -> configurationPropertiesService.getConfigProps(), securityContext);
+
+            // then.
+            Map<String, String> sanitizedProperties = configProps.getBeans().stream()
+                    .flatMap(bean -> bean.getProperties().stream())
+                    .filter(prop -> "******".equals(prop.getValue()))
+                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue));
+
+            assertThat(sanitizedProperties)
+                    .containsOnlyKeys("tags.forSanitization", "tags.FOR_SANITIZATION")
+                    .containsValues("******", "******");
+
+            List<KeyValue> nonSanitizedProps = configProps.getBeans().stream()
+                    .flatMap(bean -> bean.getProperties().stream())
+                    .filter(prop -> !"******".equals(prop.getValue()))
+                    .filter(prop -> prop.getValue() != null)
+                    .toList();
+
+            assertThat(nonSanitizedProps)
+                    .allMatch(prop -> !prop.getKey().contains("forSanitization")
+                            && !prop.getKey().contains("FOR_SANITIZATION"));
+        }
+
+        @Test
+        void shouldReturnUnsanitizedConfigurationProperties_whenUserHasRequiredAuthority() {
+            // when.
+            User user = createUserWithAuthorities(DefaultAuthority.CONFIG_PROPS_VALUES_READ);
+            SecurityContext securityContext = new DefaultSecurityContext(user, "testToken");
+            ConfigurationPropertiesFeed configProps = securityContextExecutor.callWithinSecurityContext(
+                    () -> configurationPropertiesService.getConfigProps(), securityContext);
+
+            // then.
+            Set<@Nullable String> values = configProps.getBeans().stream()
+                    .flatMap(bean -> bean.getProperties().stream())
+                    .map(KeyValue::getValue)
+                    .collect(Collectors.toSet());
+
+            assertThat(values).doesNotContain("******");
+        }
+
+        @TestConfiguration
+        @Import(ConfigurationPropertiesServiceTestConfiguration.class)
+        static class TestConfigWithExplicitSanitizationProperties {
+
+            @Bean
+            public SmartSanitizingFunction smartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
+                return new SmartSanitizingFunction(
+                        List.of("axelix.prop.test.tags.forSanitization", "axelix.prop.test.tags.FOR_SANITIZATION"),
+                        propertyNameNormalizer);
+            }
+        }
+
+        @ConfigurationProperties(prefix = "axelix.prop.test")
+        public record AxelixConfigurationProperties(Map<String, String> tags) {}
+    }
+
+    static class ConfigurationPropertiesServiceTestConfiguration {
+
+        @Bean
+        @ConfigurationProperties(prefix = "axelix.sbs.endpoints.config")
+        public EndpointsConfigurationProperties endpointsConfigurationProperties() {
+            return new EndpointsConfigurationProperties();
+        }
+
+        @Bean
+        public ConfigurationPropertiesFlattener configurationPropertiesFlattener() {
+            return new DefaultConfigurationPropertiesFlattener();
+        }
+
+        @Bean
+        public ConfigurationPropertiesConverter configurationPropertiesConverter(
+                ConfigurationPropertiesFlattener configurationPropertiesFlattener) {
+            return new DefaultConfigurationPropertiesConverter(configurationPropertiesFlattener);
+        }
+
+        @Bean
+        public PropertyNameNormalizer propertyNameNormalizer() {
+            return new DefaultPropertyNameNormalizer();
+        }
+
+        @Bean
+        public SecurityContextExecutor securityContextExecutor() {
+            return new ThreadLocalSecurityContextExecutor();
+        }
+
+        @Bean
+        public RequiredAuthorityCheckService requiredAuthorityCheckService(
+                SecurityContextExecutor securityContextExecutor) {
+            return new RequiredAuthorityCheckService(securityContextExecutor);
+        }
+
+        @Bean
+        public ConfigurationPropertiesService configurationPropertiesService(
+                SmartSanitizingFunction smartSanitizingFunction,
+                ApplicationContext applicationContext,
+                ConfigurationPropertiesConverter configurationPropertiesConverter,
+                RequiredAuthorityCheckService requiredAuthorityCheckService) {
+            return new DefaultConfigurationPropertiesService(
+                    smartSanitizingFunction,
+                    applicationContext,
+                    configurationPropertiesConverter,
+                    requiredAuthorityCheckService);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/configprops/SmartSanitizingFunctionTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/configprops/SmartSanitizingFunctionTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.configprops;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.boot.actuate.endpoint.SanitizableData;
+import org.springframework.core.env.MapPropertySource;
+
+import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.env.DefaultPropertyNameNormalizer;
+import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.of;
+
+/**
+ * Unit tests for {@link SmartSanitizingFunction}.
+ *
+ * @author Mikhail Polivakha
+ */
+class SmartSanitizingFunctionTest {
+
+    private static final List<String> TO_BE_SANITIZED = List.of("SCREAMING_SNAKE", "dot.based", "camelCaseBased");
+
+    private SmartSanitizingFunction subject;
+    private PropertyNameNormalizer propertyNameNormalizer;
+
+    @BeforeEach
+    void setUp() {
+        propertyNameNormalizer = new DefaultPropertyNameNormalizer();
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "commonCaseArgs")
+    void shouldSanitizeValue_CommonPath(SanitizableData input, Object expectedValue) {
+        // given.
+        subject = new SmartSanitizingFunction(TO_BE_SANITIZED, propertyNameNormalizer);
+        Object beforeSanitization = input.getValue();
+
+        // when.
+        SanitizableData result = subject.apply(input);
+
+        // then.
+        assertThat(result.getPropertySource()).isSameAs(input.getPropertySource());
+        assertThat(result.getKey()).isSameAs(input.getKey());
+        assertThat(result.getValue()).isEqualTo(expectedValue);
+
+        // we also should not chane the value in hte incoming SanitizableData
+        assertThat(input.getValue()).isSameAs(beforeSanitization);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "sanitizeAllArgs")
+    void shouldSanitizeValue_SanitizeAll(SanitizableData input) {
+        // given.
+        subject = new SmartSanitizingFunction(EndpointsConfigurationProperties.SANITIZE_ALL, propertyNameNormalizer);
+        Object beforeSanitization = input.getValue();
+
+        // when.
+        SanitizableData result = subject.apply(input);
+
+        // then.
+        assertThat(result.getPropertySource()).isSameAs(input.getPropertySource());
+        assertThat(result.getKey()).isSameAs(input.getKey());
+        assertThat(result.getValue()).isEqualTo("******");
+
+        // we also should not chane the value in hte incoming SanitizableData
+        assertThat(input.getValue()).isSameAs(beforeSanitization);
+    }
+
+    public static Stream<Arguments> commonCaseArgs() {
+        var propertySource = new MapPropertySource("testPropertySource", Map.of());
+
+        Stream<Arguments> exactMatch = TO_BE_SANITIZED.stream().map(it -> {
+            return of(new SanitizableData(propertySource, it, "doesNotMatter"), "******");
+        });
+
+        Stream<Arguments> normalizationAppliedMatch = Stream.of(
+                of(new SanitizableData(propertySource, "screaming.snake", "doesNotMatter"), "******"),
+                of(new SanitizableData(propertySource, "DOT_BASED", "doesNotMatter"), "******"),
+                of(new SanitizableData(propertySource, "camel.case.based", "doesNotMatter"), "******"));
+
+        Stream<Arguments> shouldBeLeftAsIs =
+                Stream.of(of(new SanitizableData(propertySource, "should.be.left.as.is", "itMatters"), "itMatters"));
+
+        return Stream.of(exactMatch, normalizationAppliedMatch, shouldBeLeftAsIs)
+                .flatMap(it -> it);
+    }
+
+    public static Stream<Arguments> sanitizeAllArgs() {
+        var propertySource = new MapPropertySource("testPropertySource", Map.of());
+
+        return Stream.of(
+                of(new SanitizableData(propertySource, "simple", "doesNotMatter")),
+                of(new SanitizableData(propertySource, "two.parts", "doesNotMatter")),
+                of(new SanitizableData(propertySource, "camelCase", "doesNotMatter")),
+                of(new SanitizableData(propertySource, "SNAKE_CASE", "doesNotMatter")));
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/details/AxelixDetailsEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/details/AxelixDetailsEndpointTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.details;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.SpringVersion;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.details.DefaultServiceDetailsAssemblerTest.DefaultServiceDetailsAssemblerTestConfig;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+
+/**
+ * Integration tests for {@link AxelixDetailsEndpoint}.
+ *
+ * @author Nikita Kirillov
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {"management.endpoints.web.exposure.include=axelix-details"})
+@Import({DefaultServiceDetailsAssemblerTestConfig.class, AxelixDetailsEndpoint.class, JwtAuthTestConfiguration.class})
+class AxelixDetailsEndpointTest {
+
+    @Autowired
+    private TestRestTemplateBuilder restTemplate;
+
+    @Test
+    void shouldReturnValidDetailsStructure() {
+        ResponseEntity<String> response =
+                restTemplate.asViewer().getForEntity("/actuator/axelix-details", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        String responseBody = response.getBody();
+        assertThat(responseBody).isNotNull();
+
+        assertThatJson(responseBody).node("git").isNotNull();
+        assertThatJson(responseBody)
+                .inPath("git")
+                .isObject()
+                .contains(
+                        entry("commitShaShort", "a8b0929"),
+                        entry("branch", "main"),
+                        entry("commitTimestamp", "1761249922000"))
+                .containsKeys("commitAuthor", "commitTimestamp");
+
+        assertThatJson(responseBody)
+                .inPath("git.commitAuthor")
+                .isObject()
+                .contains(entry("name", "Mikhail Polivakha"), entry("email", "mikhailpolivakha@email.com"));
+
+        assertThatJson(responseBody)
+                .inPath("git.commitAuthor")
+                .isObject()
+                .containsOnly(entry("name", "Mikhail Polivakha"), entry("email", "mikhailpolivakha@email.com"));
+
+        assertThatJson(responseBody)
+                .inPath("spring")
+                .isObject()
+                .contains(
+                        entry("springBootVersion", SpringBootVersion.getVersion()),
+                        entry("springFrameworkVersion", SpringVersion.getVersion()));
+
+        assertThatJson(responseBody)
+                .inPath("runtime")
+                .isObject()
+                .containsKeys("javaVersion", "jdkVendor", "garbageCollector");
+
+        assertThatJson(responseBody).node("build").isNotNull();
+        assertThatJson(responseBody)
+                .inPath("build")
+                .isObject()
+                .containsOnly(
+                        entry("artifact", "axelix-sbs"),
+                        entry("version", "1.0.0-SNAPSHOT"),
+                        entry("group", "com.axelixlabs.axelix"),
+                        entry("time", "2025-10-30T09:10:13.428Z"));
+
+        assertThatJson(responseBody).inPath("os").isObject().containsOnlyKeys("name", "version", "arch");
+    }
+
+    @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-details")
+    void negativeAuthTests() {}
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/details/DefaultServiceDetailsAssemblerTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/details/DefaultServiceDetailsAssemblerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.details;
+
+import java.util.Properties;
+
+import kotlin.KotlinVersion;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.SpringVersion;
+
+import com.axelixlabs.axelix.common.api.InstanceDetails;
+import com.axelixlabs.axelix.common.api.InstanceDetails.BuildDetails;
+import com.axelixlabs.axelix.common.api.InstanceDetails.GitDetails;
+import com.axelixlabs.axelix.common.api.InstanceDetails.OsDetails;
+import com.axelixlabs.axelix.common.api.InstanceDetails.RuntimeDetails;
+import com.axelixlabs.axelix.common.api.InstanceDetails.SpringDetails;
+import com.axelixlabs.axelix.sbs.spring.core.master.CommitIdPluginGitInformationProvider;
+import com.axelixlabs.axelix.sbs.spring.core.master.DefaultLibraryInformationProvider;
+import com.axelixlabs.axelix.sbs.spring.core.master.GitInformationProvider;
+import com.axelixlabs.axelix.sbs.spring.core.master.LibraryInformationProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link DefaultServiceDetailsAssembler}.
+ *
+ * @author Nikita Kirillov
+ */
+@SpringBootTest
+@Import(DefaultServiceDetailsAssemblerTest.DefaultServiceDetailsAssemblerTestConfig.class)
+class DefaultServiceDetailsAssemblerTest {
+
+    @Autowired
+    private ServiceDetailsAssembler serviceDetailsAssembler;
+
+    @Test
+    void shouldAssembleCompleteServiceDetails() {
+        InstanceDetails result = serviceDetailsAssembler.assemble();
+
+        assertThat(result).isNotNull();
+
+        GitDetails git = result.getGit();
+        assertThat(git.getCommitShaShort()).isEqualTo("a8b0929");
+        assertThat(git.getBranch()).isEqualTo("main");
+        assertThat(git.getCommitAuthor().getName()).isEqualTo("Mikhail Polivakha");
+        assertThat(git.getCommitAuthor().getEmail()).isEqualTo("mikhailpolivakha@email.com");
+        assertThat(git.getCommitTimestamp()).isEqualTo("1761249922000");
+
+        SpringDetails spring = result.getSpring();
+        assertThat(spring).isNotNull();
+        assertThat(spring.getSpringBootVersion()).isEqualTo(SpringBootVersion.getVersion());
+        assertThat(spring.getSpringFrameworkVersion()).isEqualTo(SpringVersion.getVersion());
+        assertThat(spring.getSpringCloudVersion()).isNull();
+
+        RuntimeDetails runtime = result.getRuntime();
+        assertThat(runtime).isNotNull();
+        assertThat(runtime.getJavaVersion()).isEqualTo(System.getProperty("java.version"));
+        assertThat(runtime.getJdkVendor()).isNotBlank().isEqualTo(System.getProperty("java.vendor"));
+        assertThat(runtime.getGarbageCollector()).isNotBlank();
+        assertThat(runtime.getKotlinVersion()).isEqualTo(KotlinVersion.CURRENT.toString());
+
+        BuildDetails build = result.getBuild();
+        assertThat(build.getArtifact()).isEqualTo("axelix-sbs");
+        assertThat(build.getVersion()).isEqualTo("1.0.0-SNAPSHOT");
+        assertThat(build.getGroup()).isEqualTo("com.axelixlabs.axelix");
+        assertThat(build.getTime()).isEqualTo("2025-10-30T09:10:13.428Z");
+
+        OsDetails os = result.getOs();
+        assertThat(os).isNotNull();
+        assertThat(os.getName()).isNotBlank();
+        assertThat(os.getVersion()).isNotBlank();
+        assertThat(os.getArch()).isNotBlank();
+    }
+
+    @TestConfiguration
+    static class DefaultServiceDetailsAssemblerTestConfig {
+
+        @Bean
+        @Primary
+        public BuildProperties buildProperties() {
+            Properties props = new Properties();
+            props.setProperty("group", "com.axelixlabs.axelix");
+            props.setProperty("artifact", "axelix-sbs");
+            props.setProperty("version", "1.0.0-SNAPSHOT");
+            props.setProperty("name", "test-application");
+            props.setProperty("time", "2025-10-30T09:10:13.428Z");
+
+            return new BuildProperties(props);
+        }
+
+        @Bean
+        public GitInformationProvider gitInformationProvider(GitProperties gitProperties) {
+            return new CommitIdPluginGitInformationProvider(gitProperties);
+        }
+
+        @Bean
+        public LibraryInformationProvider libraryInformationProvider() {
+            return new DefaultLibraryInformationProvider();
+        }
+
+        @Bean
+        public ServiceDetailsAssembler serviceDetailsAssembler(
+                GitInformationProvider gitInformationProvider,
+                ObjectProvider<BuildProperties> providerBuildProperties,
+                LibraryInformationProvider libraryInformationProvider) {
+            return new DefaultServiceDetailsAssembler(
+                    gitInformationProvider, providerBuildProperties, libraryInformationProvider);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/AxelixEnvironmentEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/AxelixEnvironmentEndpointTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.env;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+
+import com.axelixlabs.axelix.common.api.env.EnvironmentFeed;
+import com.axelixlabs.axelix.common.auth.core.DefaultRole;
+import com.axelixlabs.axelix.common.auth.core.Role;
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AxelixEnvironmentEndpoint}.
+ *
+ * @author Nikita Kirillov
+ * @author Sergey Cherkasov
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        args = {"--axelix.env.test.prop3=fromCommandLine"},
+        properties = {
+            "axelix.env.test.prop2=systemValue2",
+            "management.endpoint.env.show-values=always",
+        })
+@TestPropertySource(
+        properties = {
+            // properties -> shouldSelectPrimaryPropertyFromHighestPrecedenceSource
+            "axelix.env.test.prop1=fromTestSource",
+            "axelix.env.test.toBeSanitized=shouldBeSanitized",
+
+            // properties -> shouldReturnTheBeanNameThatMatchesTheConfigProps
+            "axelix.prop.test.tags.environment=test",
+            "axelix.prop.test.tags.version=1.0.0",
+            "axelix.prop.test.enabled-contexts=user-service,payment-service",
+            "axelix.prop.test.http-client.requests[0].name=user-api",
+            "axelix.prop.test.http-client.requests[0].base-url=https://api.users.example.com/v1",
+            "axelix.prop.test.http-client.requests[0].methods[0].type=GET",
+            "axelix.prop.test.http-client.requests[0].methods[0].retries[0].count=3",
+            "axelix.prop.test.http-client.requests[0].methods[0].retries[0].parameters.timeout=5000",
+            "axelix.prop.test.http-client.requests[0].methods[1].type=POST",
+            "axelix.prop.test.http-client.requests[1].name=payment-api",
+            "axelix.prop.test.http-client.requests[1].base-url=https://api.payments.example.com/v2",
+            "axelix.prop.test.http-client.requests[1].methods[0].type=PUT",
+            "axelix.prop.test.http-client.requests[1].methods[0].retries[0].count=2",
+            "axelix.prop.test.http-client.requests[1].methods[0].retries[0].parameters.log-level=DEBUG",
+        })
+@EnableConfigurationProperties(AxelixEnvironmentEndpointTest.AxelixPropTest.class)
+@Import({EnvironmentTestConfig.class, JwtAuthTestConfiguration.class})
+class AxelixEnvironmentEndpointTest {
+
+    @Autowired
+    private TestRestTemplateBuilder restTemplate;
+
+    @Autowired
+    private ConfigurableEnvironment environment;
+
+    @BeforeEach
+    void before() {
+        environment.getSystemProperties().put("axelix.env.test.prop1", "systemValue");
+        environment.getSystemProperties().put("axelix.env.test.prop2", "systemValue");
+        environment.getSystemProperties().put("axelix.env.test.prop3", "systemValue");
+        environment.getSystemProperties().put("AXELIX_FOR_SANITIZATION", "shouldBeSanitized");
+    }
+
+    @DynamicPropertySource
+    static void registerDynamic(DynamicPropertyRegistry registry) {
+        registry.add("axelix.env.test.prop2", () -> "dynamicValue");
+    }
+
+    @ParameterizedTest(name = "Property ''{0}'' should resolve from highest-precedence source")
+    @MethodSource("propertyExpectations")
+    void shouldSelectPrimaryPropertyFromHighestPrecedenceSource(String propertyName, String expectedValue) {
+        ResponseEntity<EnvironmentFeed> response =
+                restTemplate.asViewer().getForEntity("/actuator/axelix-env", EnvironmentFeed.class);
+
+        var propertyAppearances = findPropertyAppearances(propertyName, response);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(propertyAppearances)
+                .isNotEmpty()
+                .filteredOn(e -> e.getValue().isPrimary())
+                .hasSize(1)
+                .first()
+                .extracting(e -> e.getValue().getValue())
+                .isEqualTo(expectedValue);
+    }
+
+    @ParameterizedTest(name = "Property ''{0}'' should have value ''{1}'' for ''{2}''")
+    @MethodSource("sanitizationArgsSource")
+    void shouldReturnACorrectValueForTheGivenPropertyConsideringTheRole(String propertyName, String value, Role role) {
+        ResponseEntity<EnvironmentFeed> response =
+                restTemplate.withRole(role).getForEntity("/actuator/axelix-env", EnvironmentFeed.class);
+
+        var propertyAppearances = findPropertyAppearances(propertyName, response);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(propertyAppearances)
+                .filteredOn(it -> Objects.equals(it.getValue().getName(), propertyName))
+                .first()
+                .extracting(it -> it.getValue().getValue())
+                .isEqualTo(value);
+    }
+
+    @Test
+    void shouldReturnValidJsonStructure() {
+        ResponseEntity<String> response = restTemplate.asViewer().getForEntity("/actuator/axelix-env", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        String responseBody = response.getBody();
+
+        // We're not exactly sure about the shape of the returned json. It may and it would
+        // vary depending on the CI/CD runner, on the overall environment and spring version etc.
+        // So we just check the basic invariants.
+        assertThat(responseBody).isNotNull();
+
+        assertThatJson(responseBody).node("activeProfiles").isNotNull().isArray();
+
+        assertThatJson(responseBody).node("defaultProfiles").isNotNull().isArray();
+
+        assertThatJson(responseBody)
+                .inPath("propertySources[*].properties")
+                .isArray()
+                .allSatisfy(properties -> assertThatJson(properties).isArray().allSatisfy(property -> {
+                    assertThatJson(property)
+                            .isObject()
+                            .containsKey("name")
+                            .containsKey("isPrimary")
+                            .containsKey("value")
+                            .containsKey("configPropsBeanName")
+                            .containsKey("description")
+                            .containsKey("injectionPoints");
+
+                    assertThatJson(property).node("isPrimary").isBoolean();
+
+                    assertThatJson(property)
+                            .inPath("injectionPoints[*]")
+                            .isArray()
+                            .allSatisfy(injectionPoint -> {
+                                assertThatJson(injectionPoint)
+                                        .isObject()
+                                        .containsKeys("beanName", "injectionType", "targetName", "propertyExpression");
+                            });
+                }));
+    }
+
+    @ParameterizedTest
+    @MethodSource("propertyName")
+    void shouldReturnTheBeanNameThatMatchesTheConfigProps(String propertyName) {
+        ResponseEntity<EnvironmentFeed> response =
+                restTemplate.asEditor().getForEntity("/actuator/axelix-env", EnvironmentFeed.class);
+
+        var propertyAppearances = findPropertyAppearances(propertyName, response);
+
+        assertThat(propertyAppearances)
+                .extracting(e -> e.getValue().getConfigPropsBeanName())
+                .containsOnly(AxelixPropTest.class.getName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("propertySourceDescription")
+    void shouldReturnDescriptionKnownPropertySource(String sourceName, String sourceDescription) {
+        ResponseEntity<EnvironmentFeed> response =
+                restTemplate.asViewer().getForEntity("/actuator/axelix-env", EnvironmentFeed.class);
+
+        assertThat(response.getBody().getPropertySources())
+                .filteredOn(e -> e.getName().equals(sourceName))
+                .first()
+                .satisfies(e -> e.getDescription().equals(sourceDescription));
+    }
+
+    @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-env")
+    void negativeAuthTests() {}
+
+    private static Stream<Arguments> propertyExpectations() {
+        return Stream.of(
+                Arguments.of("axelix.env.test.prop1", "fromTestSource"),
+                Arguments.of("axelix.env.test.prop2", "dynamicValue"),
+                Arguments.of("axelix.env.test.prop3", "fromCommandLine"));
+    }
+
+    public static Stream<Arguments> sanitizationArgsSource() {
+        return Stream.of(
+                Arguments.of("axelix.env.test.toBeSanitized", "******", DefaultRole.EDITOR),
+                Arguments.of("AXELIX_FOR_SANITIZATION", "******", DefaultRole.EDITOR),
+                Arguments.of("axelix.env.test.toBeSanitized", "******", DefaultRole.VIEWER),
+                Arguments.of("AXELIX_FOR_SANITIZATION", "******", DefaultRole.VIEWER),
+                Arguments.of("axelix.env.test.toBeSanitized", "shouldBeSanitized", DefaultRole.ADMIN),
+                Arguments.of("AXELIX_FOR_SANITIZATION", "shouldBeSanitized", DefaultRole.ADMIN));
+    }
+
+    private static Stream<Arguments> propertyName() {
+        return Stream.of(
+                Arguments.of("axelix.prop.test.tags.environment"),
+                Arguments.of("axelix.prop.test.tags.version"),
+                Arguments.of("axelix.prop.test.enabled-contexts"),
+                Arguments.of("axelix.prop.test.http-client.requests[0].name"),
+                Arguments.of("axelix.prop.test.http-client.requests[0].base-url"),
+                Arguments.of("axelix.prop.test.http-client.requests[0].methods[0].type"),
+                Arguments.of("axelix.prop.test.http-client.requests[0].methods[0].retries[0].count"),
+                Arguments.of("axelix.prop.test.http-client.requests[0].methods[0].retries[0].parameters.timeout"),
+                Arguments.of("axelix.prop.test.http-client.requests[0].methods[1].type"),
+                Arguments.of("axelix.prop.test.http-client.requests[1].name"),
+                Arguments.of("axelix.prop.test.http-client.requests[1].base-url"),
+                Arguments.of("axelix.prop.test.http-client.requests[1].methods[0].type"),
+                Arguments.of("axelix.prop.test.http-client.requests[1].methods[0].retries[0].count"),
+                Arguments.of("axelix.prop.test.http-client.requests[1].methods[0].retries[0].parameters.log-level"));
+    }
+
+    private static Stream<Arguments> propertySourceDescription() {
+        return Stream.of(
+                Arguments.of(
+                        StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME,
+                        "Contains all Java system properties (those set via -Dkey=value at JVM startup, as well as properties set via 'System.setProperty()' at runtime) and has higher priority than properties in 'systemEnvironment'"),
+                Arguments.of(
+                        "server.ports",
+                        "Contains the 'server.port' property from 'application.*', which defines the web server port (8080 by default)."));
+    }
+
+    private static List<Map.Entry<String, EnvironmentFeed.Property>> findPropertyAppearances(
+            String propertyName, ResponseEntity<EnvironmentFeed> response) {
+
+        return response.getBody().getPropertySources().stream()
+                .flatMap(src -> src.getProperties().stream()
+                        .filter(p -> p.getName().equals(propertyName))
+                        .map(p -> Map.entry(src.getName(), p)))
+                .toList();
+    }
+
+    @ConfigurationProperties(prefix = "axelix.prop.test")
+    public record AxelixPropTest(Map<String, String> tags, List<String> enabledContexts, HttpClient httpClient) {
+
+        public record HttpClient(List<Request> requests) {}
+
+        public record Request(String name, String baseUrl, List<Method> methods) {}
+
+        public record Method(String type, List<Retry> retries) {}
+
+        public record Retry(Integer count, Map<String, Object> parameters) {}
+    }
+
+    @TestConfiguration
+    static class AxelixEnvironmentEndpointTestConfiguration {
+
+        @Bean
+        @ConfigurationProperties(prefix = "axelix.sbs.endpoints.config")
+        public EndpointsConfigurationProperties endpointsConfigurationProperties() {
+            return new EndpointsConfigurationProperties();
+        }
+
+        @Bean
+        public AxelixEnvironmentEndpoint axelixEnvironmentEndpoint(EnvironmentService environmentService) {
+            return new AxelixEnvironmentEndpoint(environmentService);
+        }
+
+        @Bean
+        public SmartSanitizingFunction smartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
+            return new SmartSanitizingFunction(
+                    List.of("axelix.env.test.toBeSanitized", "AXELIX_FOR_SANITIZATION"), propertyNameNormalizer);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvPropertyEnricherTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvPropertyEnricherTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.env;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.env.EnvironmentEndpoint;
+import org.springframework.boot.actuate.env.EnvironmentEndpoint.EnvironmentDescriptor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.StandardEnvironment;
+
+import com.axelixlabs.axelix.common.api.env.EnvironmentFeed;
+import com.axelixlabs.axelix.common.api.env.EnvironmentFeed.Property;
+import com.axelixlabs.axelix.common.api.env.EnvironmentFeed.PropertySource;
+import com.axelixlabs.axelix.common.auth.core.DefaultSecurityContext;
+import com.axelixlabs.axelix.common.auth.core.SecurityContext;
+import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
+import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
+import com.axelixlabs.axelix.sbs.spring.core.env.DefaultEnvPropertyEnricherTest.CurrentTestConfig;
+
+import static com.axelixlabs.axelix.sbs.spring.core.utils.UserUtils.createUserWithAuthorities;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link DefaultEnvPropertyEnricher}.
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest(args = "--fooBar=fromArgs")
+@Import({EnvironmentTestConfig.class, CurrentTestConfig.class})
+class DefaultEnvPropertyEnricherTest {
+
+    private final ThreadLocalSecurityContextExecutor securityContextExecutor = new ThreadLocalSecurityContextExecutor();
+
+    private final SecurityContext securityContext =
+            new DefaultSecurityContext(createUserWithAuthorities(), "testToken");
+
+    @Autowired
+    private EnvironmentEndpoint environmentEndpoint;
+
+    @Autowired
+    private EnvPropertyEnricher enricher;
+
+    @TestConfiguration
+    static class CurrentTestConfig {
+
+        @Bean
+        @ConfigurationProperties(prefix = "axelix.sbs.endpoints.config")
+        public EndpointsConfigurationProperties endpointsConfigurationProperties() {
+            return new EndpointsConfigurationProperties();
+        }
+
+        @Bean
+        SmartSanitizingFunction smartSanitizingFunction() {
+            return new SmartSanitizingFunction(List.of(), new DefaultPropertyNameNormalizer());
+        }
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty("foo.bar", "system.property");
+    }
+
+    @Test
+    void shouldEnrichAllPropertiesWithPrimaryField() {
+        EnvironmentDescriptor defaultDescriptor = environmentEndpoint.environment(null);
+
+        EnvironmentFeed environmentFeed = securityContextExecutor.callWithinSecurityContext(
+                () -> enricher.enrich(defaultDescriptor), securityContext);
+
+        assertThat(environmentFeed).isNotNull();
+        assertThat(environmentFeed.getActiveProfiles()).isNotNull();
+        assertThat(environmentFeed.getDefaultProfiles()).isNotNull();
+        assertThat(environmentFeed.getPropertySources()).isNotEmpty();
+
+        // property from the command line args should win
+        // https://docs.spring.io/spring-boot/reference/features/external-config.html
+        assertThat(findProperty(environmentFeed, StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME, "foo.bar")
+                        .isPrimary())
+                .isFalse();
+
+        assertThat(findProperty(environmentFeed, "commandLineArgs", "fooBar").isPrimary())
+                .isTrue();
+    }
+
+    @Test
+    void shouldNormalizeConfigResourcePropertySourceNameAndDescription() {
+        EnvironmentDescriptor defaultDescriptor = environmentEndpoint.environment(null);
+
+        EnvironmentFeed environmentFeed = securityContextExecutor.callWithinSecurityContext(
+                () -> enricher.enrich(defaultDescriptor), securityContext);
+
+        List<PropertySource> configResourceSources = environmentFeed.getPropertySources().stream()
+                .filter(it -> it.getName().endsWith(".yaml"))
+                .toList();
+
+        assertThat(configResourceSources).isNotEmpty();
+
+        configResourceSources.forEach(source -> {
+            assertThat(source.getName()).isEqualTo("application.yaml");
+
+            assertThat(source.getDescription())
+                    .isEqualTo("Properties that are loaded from application.yaml located in optional:classpath:/");
+        });
+    }
+
+    private static Property findProperty(
+            EnvironmentFeed environmentFeed, String propertySourceName, String propertyName) {
+        PropertySource propertySource = environmentFeed.getPropertySources().stream()
+                .filter(it -> it.getName().equals(propertySourceName))
+                .findFirst()
+                .orElseThrow();
+
+        return propertySource.getProperties().stream()
+                .filter(it -> it.getName().equals(propertyName))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvironmentServiceTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvironmentServiceTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.env;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import com.axelixlabs.axelix.common.api.env.EnvironmentFeed;
+import com.axelixlabs.axelix.common.api.env.EnvironmentFeed.Property;
+import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
+import com.axelixlabs.axelix.common.auth.core.DefaultSecurityContext;
+import com.axelixlabs.axelix.common.auth.core.SecurityContext;
+import com.axelixlabs.axelix.common.auth.core.User;
+import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
+import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
+import com.axelixlabs.axelix.sbs.spring.core.env.DefaultEnvironmentServiceTest.WithExplicitSanitizationProperties.AxelixConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.env.DefaultEnvironmentServiceTest.WithExplicitSanitizationProperties.TestConfigWithExplicitSanitizationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.env.DefaultEnvironmentServiceTest.WithoutExplicitSanitizationProperties.TestConfigWithAllPropertiesSanitized;
+
+import static com.axelixlabs.axelix.sbs.spring.core.utils.UserUtils.createUserWithAuthorities;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link DefaultEnvironmentService}
+ *
+ * @author Nikita Kirillov
+ */
+class DefaultEnvironmentServiceTest {
+
+    private final ThreadLocalSecurityContextExecutor securityContextExecutor = new ThreadLocalSecurityContextExecutor();
+
+    @SpringBootTest
+    @Nested
+    @Import(TestConfigWithAllPropertiesSanitized.class)
+    class WithoutExplicitSanitizationProperties {
+
+        @Autowired
+        private EnvironmentService environmentService;
+
+        @Test
+        void shouldReturnSanitizedConfigurationProperties_whenRequiredAuthorityIsMissing() {
+            // when.
+            User user = createUserWithAuthorities();
+            SecurityContext securityContext = new DefaultSecurityContext(user, "testToken");
+            EnvironmentFeed environmentFeed = securityContextExecutor.callWithinSecurityContext(
+                    () -> environmentService.getEnvironmentFeed(null), securityContext);
+
+            // then.
+            Set<@Nullable String> values = environmentFeed.getPropertySources().stream()
+                    .flatMap(propertySource -> propertySource.getProperties().stream())
+                    .map(Property::getValue)
+                    .collect(Collectors.toSet());
+
+            assertThat(values).containsOnly("******", null);
+        }
+
+        @Test
+        void shouldReturnUnsanitizedConfigurationProperties_whenUserHasRequiredAuthority() {
+            // when.
+            User user = createUserWithAuthorities(DefaultAuthority.ENV_VALUES_READ);
+            SecurityContext securityContext = new DefaultSecurityContext(user, "testToken");
+            EnvironmentFeed environmentFeed = securityContextExecutor.callWithinSecurityContext(
+                    () -> environmentService.getEnvironmentFeed(null), securityContext);
+
+            // then.
+            Set<@Nullable String> values = environmentFeed.getPropertySources().stream()
+                    .flatMap(propertySource -> propertySource.getProperties().stream())
+                    .map(Property::getValue)
+                    .collect(Collectors.toSet());
+
+            assertThat(values).doesNotContain("******");
+        }
+
+        @TestConfiguration
+        @Import(EnvironmentTestConfig.class)
+        static class TestConfigWithAllPropertiesSanitized {
+
+            @Bean
+            public SmartSanitizingFunction smartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
+                return new SmartSanitizingFunction(
+                        EndpointsConfigurationProperties.SANITIZE_ALL, propertyNameNormalizer);
+            }
+        }
+    }
+
+    @SpringBootTest(
+            properties = {
+                "axelix.prop.test.tags.forSanitization=toBeSanitized",
+                "axelix.prop.test.tags.FOR_SANITIZATION=toBeSanitized"
+            })
+    @Nested
+    @EnableConfigurationProperties(AxelixConfigurationProperties.class)
+    @Import(TestConfigWithExplicitSanitizationProperties.class)
+    class WithExplicitSanitizationProperties {
+
+        @Autowired
+        private EnvironmentService environmentService;
+
+        @Test
+        void shouldReturnOnlyExplicitlySanitizedConfigurationProperties_whenRequiredAuthorityIsMissing() {
+            // when.
+            User user = createUserWithAuthorities();
+            SecurityContext securityContext = new DefaultSecurityContext(user, "testToken");
+            EnvironmentFeed environmentFeed = securityContextExecutor.callWithinSecurityContext(
+                    () -> environmentService.getEnvironmentFeed(null), securityContext);
+
+            // then.
+            Map<String, String> sanitizedProperties = environmentFeed.getPropertySources().stream()
+                    .flatMap(propertySource -> propertySource.getProperties().stream())
+                    .filter(property -> "******".equals(property.getValue()))
+                    .collect(Collectors.toMap(Property::getName, Property::getValue));
+
+            assertThat(sanitizedProperties)
+                    .containsOnlyKeys("axelix.prop.test.tags.forSanitization", "axelix.prop.test.tags.FOR_SANITIZATION")
+                    .containsValues("******", "******");
+        }
+
+        @Test
+        void shouldReturnUnsanitizedConfigurationProperties_whenUserHasRequiredAuthority() {
+            // when.
+            User user = createUserWithAuthorities(DefaultAuthority.ENV_VALUES_READ);
+            SecurityContext securityContext = new DefaultSecurityContext(user, "testToken");
+            EnvironmentFeed environmentFeed = securityContextExecutor.callWithinSecurityContext(
+                    () -> environmentService.getEnvironmentFeed(null), securityContext);
+
+            // then.
+            Set<@Nullable String> values = environmentFeed.getPropertySources().stream()
+                    .flatMap(propertySource -> propertySource.getProperties().stream())
+                    .map(Property::getValue)
+                    .collect(Collectors.toSet());
+
+            assertThat(values).doesNotContain("******");
+        }
+
+        @TestConfiguration
+        @Import(EnvironmentTestConfig.class)
+        static class TestConfigWithExplicitSanitizationProperties {
+
+            @Bean
+            public SmartSanitizingFunction smartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
+                return new SmartSanitizingFunction(
+                        List.of("axelix.prop.test.tags.forSanitization", "axelix.prop.test.tags.FOR_SANITIZATION"),
+                        propertyNameNormalizer);
+            }
+        }
+
+        @ConfigurationProperties(prefix = "axelix.prop.test")
+        public record AxelixConfigurationProperties(Map<String, String> tags) {}
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultPropertyMetadataExtractorTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultPropertyMetadataExtractorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.env;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link DefaultPropertyMetadataExtractor}
+ *
+ * @author Nikita Kirillov
+ */
+@TestPropertySource(
+        properties = {
+            "prop.test.server.port=test",
+            "prop.test.logging.level.root=test",
+            "custom.test.without.reason.property=test",
+            "custom.test.without.replacement.property=test"
+        })
+@SpringBootTest
+@Import(DefaultPropertyMetadataExtractorTest.DefaultPropertyMetadataExtractorTestConfiguration.class)
+class DefaultPropertyMetadataExtractorTest {
+
+    @Autowired
+    private PropertyMetadataExtractor extractor;
+
+    @Autowired
+    private PropertyNameNormalizer normalizer;
+
+    @BeforeEach
+    void setUp() throws InterruptedException {
+        Thread.sleep(1000);
+    }
+
+    @Test
+    void shouldExtractAllPropertyMetadataCorrectly() {
+        PropertyMetadata serverPortMetadata = extractor.getMetadata(normalizer.normalize("prop.test.server.port"));
+        assertThat(serverPortMetadata).isNotNull();
+        assertThat(serverPortMetadata.getDescription()).isEqualTo("Server HTTP port.");
+        assertThat(serverPortMetadata.getDeprecation()).isNotNull();
+        assertThat(serverPortMetadata.getDeprecation().getMessage())
+                .isEqualTo("Just because. Deprecated in favor of new.prop.test.server.port property.");
+    }
+
+    @Test
+    void shouldExtractPropertyMetadataWithoutReason() {
+        PropertyMetadata metadataWithoutReason =
+                extractor.getMetadata(normalizer.normalize("custom.test.without.replacement.property"));
+        assertThat(metadataWithoutReason).isNotNull();
+        assertThat(metadataWithoutReason.getDescription()).isNull();
+        assertThat(metadataWithoutReason.getDeprecation()).isNotNull();
+        assertThat(metadataWithoutReason.getDeprecation().getMessage()).isEqualTo("Marked for deletion.");
+    }
+
+    @Test
+    void shouldExtractPropertyMetadataWithoutReplacement() {
+        PropertyMetadata metadataWithoutReplacament =
+                extractor.getMetadata(normalizer.normalize("custom.test.without.reason.property"));
+        assertThat(metadataWithoutReplacament).isNotNull();
+        assertThat(metadataWithoutReplacament.getDescription()).isNull();
+        assertThat(metadataWithoutReplacament.getDeprecation()).isNotNull();
+        assertThat(metadataWithoutReplacament.getDeprecation().getMessage())
+                .isEqualTo("Deprecated in favor of new.custom.test.without.reason.property property.");
+    }
+
+    @Test
+    void shouldExtractPropertyMetadataWithoutDeprecated() {
+        PropertyMetadata loggingMetadata = extractor.getMetadata(normalizer.normalize("prop.test.logging.level.root"));
+        assertThat(loggingMetadata).isNotNull();
+        assertThat(loggingMetadata.getDescription()).isEqualTo("Logging level for root logger.");
+        assertThat(loggingMetadata.getDeprecation()).isNull();
+    }
+
+    @Test
+    void shouldNotExtractPropertyMetadataWithoutDeprecated() {
+        PropertyMetadata nonExistentMetadata = extractor.getMetadata("non.existent.property");
+        assertThat(nonExistentMetadata).isNull();
+    }
+
+    @TestConfiguration
+    static class DefaultPropertyMetadataExtractorTestConfiguration {
+
+        @Bean
+        public PropertyNameNormalizer propertyNameNormalizer() {
+            return new DefaultPropertyNameNormalizer();
+        }
+
+        @Bean
+        public PropertyMetadataExtractor propertyMetadataExtractor(
+                ConfigurableEnvironment configurableEnvironment, PropertyNameNormalizer propertyNameNormalizer) {
+            return new DefaultPropertyMetadataExtractor(configurableEnvironment, propertyNameNormalizer);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/EnvironmentTestConfig.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/EnvironmentTestConfig.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.env;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+
+import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
+import com.axelixlabs.axelix.sbs.spring.core.auth.RequiredAuthorityCheckService;
+import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesConverter;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesFlattener;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesService;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesConverter;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesFlattener;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesService;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
+
+/**
+ * Environment test configuration.
+ *
+ * @author Mikhail Polivakha
+ * @author Nikita Kirillov
+ */
+@TestConfiguration
+public class EnvironmentTestConfig {
+
+    @Bean
+    public ConfigurationPropertiesFlattener configurationPropertiesFlattener() {
+        return new DefaultConfigurationPropertiesFlattener();
+    }
+
+    @Bean
+    public ConfigurationPropertiesConverter configurationPropertiesConverter(
+            ConfigurationPropertiesFlattener configurationPropertiesFlattener) {
+        return new DefaultConfigurationPropertiesConverter(configurationPropertiesFlattener);
+    }
+
+    @Bean
+    public SecurityContextExecutor securityContextExecutor() {
+        return new ThreadLocalSecurityContextExecutor();
+    }
+
+    @Bean
+    public RequiredAuthorityCheckService requiredAuthorityCheckService(
+            SecurityContextExecutor securityContextExecutor) {
+        return new RequiredAuthorityCheckService(securityContextExecutor);
+    }
+
+    @Bean
+    public EnvironmentService environmentService(
+            Environment environment,
+            SmartSanitizingFunction smartSanitizingFunction,
+            EnvPropertyEnricher envPropertyEnricher,
+            RequiredAuthorityCheckService requiredAuthorityCheckService) {
+        return new DefaultEnvironmentService(
+                environment, smartSanitizingFunction, envPropertyEnricher, requiredAuthorityCheckService);
+    }
+
+    @Bean
+    public ConfigurationPropertiesService configurationPropertiesService(
+            SmartSanitizingFunction smartSanitizingFunction,
+            ApplicationContext applicationContext,
+            ConfigurationPropertiesConverter configurationPropertiesConverter,
+            RequiredAuthorityCheckService requiredAuthorityCheckService) {
+        return new DefaultConfigurationPropertiesService(
+                smartSanitizingFunction,
+                applicationContext,
+                configurationPropertiesConverter,
+                requiredAuthorityCheckService);
+    }
+
+    @Bean
+    public PropertyNameNormalizer propertyNameNormalizer() {
+        return new DefaultPropertyNameNormalizer();
+    }
+
+    @Bean
+    public PropertyMetadataExtractor propertyMetadataExtractor(
+            ConfigurableEnvironment environment, PropertyNameNormalizer propertyNameNormalizer) {
+        return new DefaultPropertyMetadataExtractor(environment, propertyNameNormalizer);
+    }
+
+    @Bean
+    public ValueInjectionTrackerBeanPostProcessor valueInjectionTrackerBeanPostProcessor(
+            PropertyNameNormalizer propertyNameNormalizer) {
+        return new ValueInjectionTrackerBeanPostProcessor(propertyNameNormalizer);
+    }
+
+    @Bean
+    public EnvPropertyEnricher envPropertyEnricher(
+            Environment environment,
+            PropertyNameNormalizer propertyNameNormalizer,
+            ObjectProvider<ConfigurationPropertiesService> configurationPropertiesServiceProvider,
+            PropertyMetadataExtractor propertyMetadataExtractor,
+            ValueInjectionTrackerBeanPostProcessor valueInjectionTrackerBeanPostProcessor) {
+        return new DefaultEnvPropertyEnricher(
+                environment,
+                propertyNameNormalizer,
+                configurationPropertiesServiceProvider,
+                propertyMetadataExtractor,
+                valueInjectionTrackerBeanPostProcessor);
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/PropertySourceDescriptionTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/PropertySourceDescriptionTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.env;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.core.env.StandardEnvironment;
+
+import com.axelixlabs.axelix.sbs.spring.core.env.PropertySourceDescription.PropertySourceDisplayData;
+
+import static com.axelixlabs.axelix.sbs.spring.core.env.PropertySourceDescription.resolveDisplayData;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link PropertySourceDescription}
+ *
+ * @author Nikita Kirillov
+ */
+class PropertySourceDescriptionTest {
+
+    @ParameterizedTest
+    @MethodSource("configResourceSources")
+    void shouldParseConfigResourceSourceCorrectly(
+            String sourceName, String expectedDisplayName, String expectedDescription) {
+
+        PropertySourceDisplayData result = resolveDisplayData(sourceName);
+
+        assertThat(result.displayName()).isEqualTo(expectedDisplayName);
+        assertThat(result.description()).isEqualTo(expectedDescription);
+    }
+
+    private static Stream<Arguments> configResourceSources() {
+        return Stream.of(
+                Arguments.of(
+                        "Config resource 'class path resource [application.properties]' via location 'optional:classpath:/'",
+                        "application.properties",
+                        "Properties that are loaded from application.properties located in optional:classpath:/"),
+                Arguments.of(
+                        "Config resource 'class path resource [application-dev.properties]' via location 'optional:classpath:/'",
+                        "application-dev.properties",
+                        "Properties that are loaded from application-dev.properties located in optional:classpath:/"),
+                Arguments.of(
+                        "Config resource 'class path resource [config/application-local.yaml]' via location 'optional:classpath:/config/'",
+                        "application-local.yaml",
+                        "Properties that are loaded from application-local.yaml located in optional:classpath:/config/"),
+                Arguments.of(
+                        "Config resource 'file [/etc/app/application-prod.yaml]' via location 'optional:file:/etc/app/'",
+                        "application-prod.yaml",
+                        "Properties that are loaded from application-prod.yaml located in optional:file:/etc/app/"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("unknownSources")
+    void shouldReturnOriginalNameAndNullDescriptionForUnknownSources(String sourceName, String expectedDescription) {
+        PropertySourceDisplayData result = resolveDisplayData(sourceName);
+
+        assertThat(result.displayName()).isEqualTo(sourceName);
+        assertThat(result.description()).isEqualTo(expectedDescription);
+    }
+
+    private static Stream<Arguments> unknownSources() {
+        return Stream.of(
+                Arguments.of("someUnknownSource", null),
+                // Starts with "Config resource", but not match
+                Arguments.of(
+                        "Config resource 'unexpected format'",
+                        "Contains properties from the 'application*.properties/yaml' configuration file loaded from the pre-defined location (often from the classpath or the file system)"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("knownNonConfigResourceSources")
+    void shouldReturnOriginalNameAndDescriptionForKnownSources(String sourceName, String expectedDescription) {
+
+        PropertySourceDisplayData result = resolveDisplayData(sourceName);
+
+        assertThat(result.displayName()).isEqualTo(sourceName);
+        assertThat(result.description()).isEqualTo(expectedDescription);
+    }
+
+    private static Stream<Arguments> knownNonConfigResourceSources() {
+        return Stream.of(
+                Arguments.of(
+                        StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME,
+                        PropertySourceDescription.SYSTEM_PROPERTIES.getDescription()),
+                Arguments.of(
+                        StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+                        PropertySourceDescription.SYSTEM_ENVIRONMENT.getDescription()));
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/ValueInjectionTrackerBeanPostProcessorTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/ValueInjectionTrackerBeanPostProcessorTest.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.env;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.TestPropertySource;
+
+import com.axelixlabs.axelix.common.api.env.EnvironmentFeed.InjectionPoint;
+import com.axelixlabs.axelix.common.api.env.EnvironmentFeed.InjectionType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link ValueInjectionTrackerBeanPostProcessor}
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest(
+        classes = {
+            ValueInjectionTrackerBeanPostProcessorTest.ValueInjectionTrackerBeanPostProcessorTestConfig.class,
+            ValueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations.class,
+            ValueInjectionTrackerBeanPostProcessorTest.TestBeanWithSpEL.class
+        })
+@TestPropertySource(
+        properties = {
+            "test.server.port=9090",
+            "test.spring.application.name=TimeoutTestApp",
+            "test.spring.profiles.active=production",
+            "test.app.timeout=3000",
+            "test.inner.timeout=1500",
+            "test.inner.constructor.timeout=2500",
+            "test.method.timeout=4200"
+        })
+class ValueInjectionTrackerBeanPostProcessorTest {
+
+    @TestConfiguration
+    static class ValueInjectionTrackerBeanPostProcessorTestConfig {
+
+        @Bean
+        public static ValueInjectionTrackerBeanPostProcessor valueInjectionTrackerBeanPostProcessor() {
+            return new ValueInjectionTrackerBeanPostProcessor(new DefaultPropertyNameNormalizer());
+        }
+    }
+
+    @Autowired
+    private ValueInjectionTrackerBeanPostProcessor subject;
+
+    private final PropertyNameNormalizer normalizer = new DefaultPropertyNameNormalizer();
+
+    @Test
+    void testDirectValueInjectionOnField() {
+        // given.
+        String propertyServerPort = "test.server.port";
+
+        // when.
+        List<InjectionPoint> points = subject.getInjectionPointsForProperty(normalizer.normalize(propertyServerPort));
+
+        // then.
+        assertThat(points).hasSize(1).first().satisfies(point -> {
+            assertThat(point.getBeanName())
+                    .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+            assertThat(point.getInjectionType()).isEqualTo(InjectionType.FIELD);
+            assertThat(point.getTargetName()).isEqualTo("serverPort");
+            assertThat(point.getPropertyExpression()).isEqualTo("${" + propertyServerPort + ":8080}");
+        });
+    }
+
+    @Test
+    void testMetaAnnotationValueInjectionOnField() {
+        // given.
+        String propertyTimeout = "test.app.timeout";
+
+        // when.
+        List<InjectionPoint> points = subject.getInjectionPointsForProperty(normalizer.normalize(propertyTimeout));
+        InjectionPoint injectionPoint = points.stream()
+                .filter(point -> point.getInjectionType().equals(InjectionType.FIELD)
+                        && point.getTargetName().equals("timeout"))
+                .findAny()
+                .orElseThrow();
+
+        // then.
+        assertThat(injectionPoint.getBeanName())
+                .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+        assertThat(injectionPoint.getPropertyExpression()).isEqualTo("${" + propertyTimeout + ":5000}");
+    }
+
+    @Test
+    void testDirectConstructorParameterInjection() {
+        // when
+        String propertyApplicationName = "test.spring.application.name";
+
+        // then.
+        List<InjectionPoint> appNamePoints =
+                subject.getInjectionPointsForProperty(normalizer.normalize(propertyApplicationName));
+        assertThat(appNamePoints).hasSize(1).first().satisfies(point -> {
+            assertThat(point.getBeanName())
+                    .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+            assertThat(point.getInjectionType()).isEqualTo(InjectionType.CONSTRUCTOR_PARAMETER);
+            assertThat(point.getTargetName()).isEqualTo("appName");
+            assertThat(point.getPropertyExpression()).isEqualTo("${" + propertyApplicationName + ":TestApp}");
+        });
+    }
+
+    @Test
+    void testMetaAnnotationValueOnConstructorParameterInjection() {
+        // when.
+        List<InjectionPoint> timeoutPoints =
+                subject.getInjectionPointsForProperty(normalizer.normalize("test.app.timeout"));
+
+        // then.
+        assertThat(timeoutPoints)
+                .filteredOn(point -> point.getInjectionType() == InjectionType.CONSTRUCTOR_PARAMETER
+                        && point.getTargetName().equals("connectionTimeout"))
+                .hasSize(1)
+                .first()
+                .satisfies(point -> {
+                    assertThat(point.getBeanName())
+                            .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+                    assertThat(point.getPropertyExpression()).isEqualTo("${test.app.timeout:5000}");
+                });
+    }
+
+    @Test
+    void testDirectMethodParameterInjection() {
+        // when.
+        String propertyProfile = "test.spring.profiles.active";
+
+        // then.
+        List<InjectionPoint> profilePoints =
+                subject.getInjectionPointsForProperty(normalizer.normalize(propertyProfile));
+        assertThat(profilePoints).hasSize(1).first().satisfies(point -> {
+            assertThat(point.getBeanName())
+                    .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+            assertThat(point.getInjectionType()).isEqualTo(InjectionType.METHOD_PARAMETER);
+            assertThat(point.getTargetName()).contains("setProfile");
+            assertThat(point.getPropertyExpression()).isEqualTo("${" + propertyProfile + "}");
+        });
+    }
+
+    @Test
+    void testMetaAnnotationOnMethodParameterInjection() {
+        // when.
+        String propertyTimeout = "test.app.timeout";
+
+        // then.
+        List<InjectionPoint> timeoutPoints =
+                subject.getInjectionPointsForProperty(normalizer.normalize(propertyTimeout));
+        assertThat(timeoutPoints)
+                .filteredOn(point -> point.getInjectionType() == InjectionType.METHOD_PARAMETER
+                        && point.getTargetName().contains("setMaxTimeout"))
+                .hasSize(1)
+                .first()
+                .satisfies(point -> {
+                    assertThat(point.getBeanName())
+                            .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+                    assertThat(point.getPropertyExpression()).isEqualTo("${" + propertyTimeout + ":5000}");
+                });
+    }
+
+    @Test
+    void testDirectMethodInjection() {
+        // when.
+        String propertyMethodTimeout = "test.method.timeout";
+
+        // then.
+        List<InjectionPoint> timeoutPoints =
+                subject.getInjectionPointsForProperty(normalizer.normalize(propertyMethodTimeout));
+        assertThat(timeoutPoints)
+                .filteredOn(point -> point.getInjectionType() == InjectionType.METHOD
+                        && point.getTargetName().contains("calculateRandomTimeout"))
+                .hasSize(1)
+                .first()
+                .satisfies(point -> {
+                    assertThat(point.getBeanName())
+                            .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+                    assertThat(point.getPropertyExpression()).isEqualTo("${" + propertyMethodTimeout + "}");
+                });
+    }
+
+    @Test
+    void testMetaAnnotationMethodInjection() {
+        // when.
+        String propertyAppTimeout = "test.app.timeout";
+
+        // then.
+        List<InjectionPoint> customTimeoutPoints =
+                subject.getInjectionPointsForProperty(normalizer.normalize(propertyAppTimeout));
+        assertThat(customTimeoutPoints)
+                .filteredOn(point -> point.getInjectionType() == InjectionType.METHOD
+                        && point.getTargetName().contains("getDefaultTimeout"))
+                .hasSize(1)
+                .first()
+                .satisfies(point -> {
+                    assertThat(point.getBeanName())
+                            .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+                    assertThat(point.getPropertyExpression()).isEqualTo("${" + propertyAppTimeout + ":5000}");
+                });
+    }
+
+    @Test
+    void testEnvironmentGetPropertySpEL() {
+        // when.
+        List<InjectionPoint> points = subject.getInjectionPointsForProperty(normalizer.normalize("server.port"));
+
+        // then.
+        assertThat(points)
+                .filteredOn(p -> p.getTargetName().equals("envPort"))
+                .hasSize(1)
+                .first()
+                .satisfies(p -> {
+                    assertThat(p.getInjectionType()).isEqualTo(InjectionType.FIELD);
+                    assertThat(p.getPropertyExpression()).isEqualTo("#{environment.getProperty('server.port')}");
+                });
+    }
+
+    @Test
+    void testSystemPropertiesSpEL() {
+        // when.
+        List<InjectionPoint> points = subject.getInjectionPointsForProperty(normalizer.normalize("user.home"));
+
+        // then.
+        assertThat(points)
+                .filteredOn(p -> p.getTargetName().equals("systemHome"))
+                .hasSize(1)
+                .first()
+                .satisfies(p -> {
+                    assertThat(p.getInjectionType()).isEqualTo(InjectionType.FIELD);
+                    assertThat(p.getPropertyExpression()).isEqualTo("#{systemProperties['user.home']}");
+                });
+    }
+
+    @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Value("${test.app.timeout:5000}")
+    public @interface TimeoutValue {}
+
+    @Component
+    public static class TestBeanWithSpEL {
+
+        @Value("#{environment.getProperty('server.port')}")
+        private String envPort;
+
+        @Value("#{systemProperties['user.home']}")
+        private String systemHome;
+
+        @Value("#{environment.getProperty('app.timeout')}")
+        public Integer getTimeout() {
+            return 5000;
+        }
+    }
+
+    @Component
+    public static class TestBeanWithCustomAnnotations {
+
+        @Value("${test.server.port:8080}")
+        private String serverPort;
+
+        @TimeoutValue
+        private Integer timeout;
+
+        public TestBeanWithCustomAnnotations(
+                @Value("${test.spring.application.name:TestApp}") String appName,
+                @TimeoutValue String connectionTimeout) {}
+
+        private String profile;
+        private Integer maxTimeout;
+
+        @Autowired
+        public void setProfile(@Value("${test.spring.profiles.active}") String profile) {
+            this.profile = profile;
+        }
+
+        @Autowired
+        public void setMaxTimeout(@TimeoutValue Integer timeout) {
+            this.maxTimeout = timeout * 2;
+        }
+
+        @Value("${test.method.timeout}")
+        public void calculateRandomTimeout() {}
+
+        @TimeoutValue
+        public void getDefaultTimeout() {}
+
+        public String getServerPort() {
+            return serverPort;
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/gclog/AxelixGcEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/gclog/AxelixGcEndpointTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.gclog;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import com.axelixlabs.axelix.common.api.gclog.GcLogEnableRequest;
+import com.axelixlabs.axelix.common.api.gclog.GcLogStatusResponse;
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.gclog.AxelixGcEndpointTest.AxelixGcEndpointTestTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import({AxelixGcEndpointTestTestConfiguration.class, JwtAuthTestConfiguration.class})
+class AxelixGcEndpointTest {
+
+    @Autowired
+    private TestRestTemplateBuilder restTemplate;
+
+    @Autowired
+    private GcLogService gcLogService;
+
+    @AfterEach
+    void tearDown() {
+        gcLogService.disable();
+    }
+
+    @AfterAll
+    static void afterAll() throws InterruptedException, IOException {
+        Thread.sleep(500);
+        Files.deleteIfExists(Path.of("gc.log"));
+        Files.deleteIfExists(Path.of("gc.log.0"));
+    }
+
+    @Test
+    void status_shouldReturnCurrentStatus() {
+        // User with the VIEWER role has the authority to view the gc log status.
+        ResponseEntity<GcLogStatusResponse> response =
+                restTemplate.asViewer().getForEntity("/actuator/axelix-gc/log/status", GcLogStatusResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+
+        GcLogStatusResponse gcLogStatusResponse = response.getBody();
+        assertThat(gcLogStatusResponse.isEnabled()).isFalse();
+        assertThat(gcLogStatusResponse.getLevel()).isNull();
+        assertThat(gcLogStatusResponse.getAvailableLevels()).isNotEmpty().doesNotContain("off");
+    }
+
+    @Test
+    void enable_shouldEnableGcLogging() {
+        List<String> availableLevels = getStatus().getAvailableLevels();
+
+        GcLogEnableRequest request = new GcLogEnableRequest(availableLevels.get(0));
+
+        ResponseEntity<Void> response =
+                restTemplate.asEditor().postForEntity("/actuator/axelix-gc/log/enable", request, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        GcLogStatusResponse status = getStatus();
+        assertThat(status.isEnabled()).isTrue();
+        assertThat(status.getLevel()).isEqualTo(request.getLevel());
+    }
+
+    @Test
+    void disable_shouldDisableGcLogging() {
+        List<String> availableLevels = getStatus().getAvailableLevels();
+        GcLogEnableRequest enableRequest = new GcLogEnableRequest(availableLevels.get(0));
+
+        ResponseEntity<Void> enableResponse =
+                restTemplate.asEditor().postForEntity("/actuator/axelix-gc/log/enable", enableRequest, Void.class);
+
+        assertThat(enableResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        ResponseEntity<Void> disableResponse =
+                restTemplate.asAdmin().postForEntity("/actuator/axelix-gc/log/disable", null, Void.class);
+
+        assertThat(disableResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        GcLogStatusResponse status = getStatus();
+        assertThat(status.isEnabled()).isFalse();
+        assertThat(status.getLevel()).isNull();
+    }
+
+    @Test
+    void gcLogfile_shouldReturnFileWhenLoggingEnabled() throws InterruptedException {
+        List<String> availableLevels = getStatus().getAvailableLevels();
+        GcLogEnableRequest enableRequest = new GcLogEnableRequest(availableLevels.get(0));
+
+        ResponseEntity<Void> enableResponse =
+                restTemplate.asAdmin().postForEntity("/actuator/axelix-gc/log/enable", enableRequest, Void.class);
+
+        assertThat(enableResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        System.gc();
+        Thread.sleep(500);
+
+        ResponseEntity<byte[]> response =
+                restTemplate.asEditor().getForEntity("/actuator/axelix-gc/log/file", byte[].class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.TEXT_PLAIN);
+        assertThat(response.getBody()).isNotEmpty();
+    }
+
+    @Test
+    void triggerGc_shouldTriggerGarbageCollection() {
+        ResponseEntity<Void> response =
+                restTemplate.asEditor().postForEntity("/actuator/axelix-gc/trigger", HttpEntity.EMPTY, Void.class);
+
+        // Cannot assert GC happened, but endpoint should respond
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void enable_shouldReturnErrorForInvalidLevel() {
+        GcLogEnableRequest request = new GcLogEnableRequest("invalid-level");
+
+        ResponseEntity<String> response =
+                restTemplate.asEditor().postForEntity("/actuator/axelix-gc/log/enable", request, String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-gc/log/status")
+    void negativeAuthTests() {}
+
+    private GcLogStatusResponse getStatus() {
+        ResponseEntity<GcLogStatusResponse> response =
+                restTemplate.asEditor().getForEntity("/actuator/axelix-gc/log/status", GcLogStatusResponse.class);
+
+        return response.getBody();
+    }
+
+    @TestConfiguration
+    static class AxelixGcEndpointTestTestConfiguration {
+
+        @Bean
+        public JcmdExecutor jcmdExecutor() {
+            return new JcmdExecutor();
+        }
+
+        @Bean
+        public GcLogService gcLogService(JcmdExecutor jcmdExecutor) {
+            return new DefaultGcLogService(jcmdExecutor);
+        }
+
+        @Bean
+        public AxelixGcEndpoint axelixGcEndpoint(GcLogService gcLogService) {
+            return new AxelixGcEndpoint(gcLogService);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/gclog/DefaultGcLogServiceTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/gclog/DefaultGcLogServiceTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.gclog;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.axelixlabs.axelix.common.api.gclog.GcLogStatusResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit test for {@link DefaultGcLogService}
+ *
+ * @author Nikita Kirillov
+ */
+class DefaultGcLogServiceTest {
+
+    private static final DefaultGcLogService subject = new DefaultGcLogService(new JcmdExecutor());
+
+    @AfterEach
+    void tearDown() {
+        subject.disable();
+    }
+
+    @AfterAll
+    static void afterAll() throws InterruptedException, IOException {
+        Thread.sleep(500);
+        Files.deleteIfExists(Path.of("gc.log"));
+        Files.deleteIfExists(Path.of("gc.log.0"));
+    }
+
+    @Test
+    void shouldReturnOnlyEnableableGcLogLevels() {
+        var levels = subject.getStatus().getAvailableLevels();
+
+        assertThat(levels).isNotEmpty().doesNotContain("off");
+    }
+
+    @ParameterizedTest
+    @MethodSource("availableLevelsProvider")
+    void shouldEnableGcLoggingForEveryAvailableLevel(String level) {
+        subject.enable(level);
+        GcLogStatusResponse status = subject.getStatus();
+
+        assertThat(status.isEnabled()).isTrue();
+        assertThat(status.getLevel()).isEqualTo(level);
+
+        subject.disable();
+    }
+
+    private static Stream<String> availableLevelsProvider() {
+        return subject.getStatus().getAvailableLevels().stream();
+    }
+
+    @Test
+    void shouldDisableGcLogging() {
+        List<String> availableLevels = subject.getStatus().getAvailableLevels();
+
+        subject.enable(availableLevels.get(0));
+        subject.disable();
+
+        GcLogStatusResponse status = subject.getStatus();
+
+        assertThat(status.isEnabled()).isFalse();
+        assertThat(status.getLevel()).isNull();
+    }
+
+    @Test
+    void shouldCreateGcLogFileAndWriteToIt() throws InterruptedException, IOException {
+        List<String> availableLevels = subject.getStatus().getAvailableLevels();
+        subject.enable(availableLevels.get(0));
+
+        System.gc();
+
+        Thread.sleep(500);
+
+        File logFile = subject.getGcLogFile();
+        assertThat(logFile).exists().isFile();
+
+        String content = Files.readString(logFile.toPath());
+        assertThat(content).isNotBlank();
+    }
+
+    @Test
+    void shouldThrowExceptionWhenEnableWithNullLevel() {
+        assertThatThrownBy(() -> subject.enable(null)).isInstanceOf(GcLogException.class);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenEnableWithInvalidLevel() {
+        assertThatThrownBy(() -> subject.enable("invalid-level")).isInstanceOf(GcLogException.class);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenEnableWithOffLevel() {
+        assertThatThrownBy(() -> subject.enable("off")).isInstanceOf(GcLogException.class);
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/loggers/AxelixLoggersEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/loggers/AxelixLoggersEndpointTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.loggers;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.logging.LogLevel;
+import org.springframework.boot.logging.LoggerGroups;
+import org.springframework.boot.logging.LoggingSystem;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.loggers.AxelixLoggersEndpointTest.AxelixLoggersEndpointTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AxelixLoggersEndpoint}.
+ *
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(
+        properties = {
+            "logging.group.axelix.logger.group=axelix.logger.test",
+            "logging.level.axelix.logger.test=WARN",
+            "logging.level.a.b=WARN",
+            "logging.level.a.b.c.d.e=DEBUG"
+        })
+@Import({AxelixLoggersEndpointTestConfiguration.class, JwtAuthTestConfiguration.class})
+public class AxelixLoggersEndpointTest {
+
+    @Autowired
+    private TestRestTemplateBuilder testRestTemplate;
+
+    @Autowired
+    private LoggingSystem loggingSystem;
+
+    @Autowired
+    private LoggerGroups loggerGroups;
+
+    private static final String LOGGER = "axelix.logger.test";
+    private static final String GROUP = "axelix.logger.group";
+    private static final String AB_RESET_LOGGER = "a.b";
+    private static final String ABC_RESET_LOGGER = "a.b.c";
+    private static final String ABCD_RESET_LOGGER = "a.b.c.d";
+    private static final String ABCDE_RESET_LOGGER = "a.b.c.d.e";
+
+    private static final Logger abc_reset_logger = LoggerFactory.getLogger(ABC_RESET_LOGGER);
+    private static final Logger abcd_reset_logger = LoggerFactory.getLogger(ABCD_RESET_LOGGER);
+
+    @AfterEach
+    void resetLogLevels() {
+        loggingSystem.setLogLevel(LOGGER, LogLevel.WARN);
+        loggingSystem.setLogLevel(AB_RESET_LOGGER, LogLevel.WARN);
+        loggingSystem.setLogLevel(ABC_RESET_LOGGER, null);
+        loggingSystem.setLogLevel(ABCD_RESET_LOGGER, null);
+    }
+
+    @Test
+    void shouldReturnAllLoggers() {
+        // when.
+        ResponseEntity<String> response =
+                testRestTemplate.asViewer().getForEntity("/actuator/axelix-loggers", String.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideValidLoggerAndGroupPaths")
+    void shouldReturnOk_WhenLoggerOrGroupFound(String path) {
+        // when.
+        ResponseEntity<String> response = testRestTemplate.asViewer().getForEntity(path, String.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    private static Stream<Arguments> provideValidLoggerAndGroupPaths() {
+        return Stream.of(
+                Arguments.of("/actuator/axelix-loggers/logger/%s".formatted(LOGGER)),
+                Arguments.of("/actuator/axelix-loggers/group/%s".formatted(GROUP)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidLoggerAndGroupPaths")
+    void shouldReturnBadRequest_WhenLoggerOrGroupNotFound(String path) {
+        // when.
+        ResponseEntity<String> response = testRestTemplate.asEditor().getForEntity(path, String.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    private static Stream<Arguments> provideInvalidLoggerAndGroupPaths() {
+        return Stream.of(
+                Arguments.of("/actuator/axelix-loggers/logger/non.existent.logger"),
+                Arguments.of("/actuator/axelix-loggers/group/non.existent.group"));
+    }
+
+    @Test
+    void shouldSetLoggerLevel() {
+        // language=json
+        String request = """
+        {
+          "configuredLevel":"debug"
+        }
+        """;
+
+        // when.
+        ResponseEntity<Void> response = testRestTemplate
+                .asAdmin()
+                .postForEntity(
+                        "/actuator/axelix-loggers/logger/%s/change-level".formatted(LOGGER),
+                        defaultJsonEntity(request),
+                        Void.class);
+
+        // then.
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(getLogLevel(LOGGER)).isEqualTo(LogLevel.DEBUG);
+    }
+
+    @Test
+    void shouldSetGroupLevel() {
+        // language=json
+        String request = """
+        {
+          "configuredLevel":"debug"
+        }
+        """;
+
+        // when.
+        ResponseEntity<Void> response = testRestTemplate
+                .asViewer()
+                .postForEntity(
+                        "/actuator/axelix-loggers/group/%s/change-level".formatted(GROUP),
+                        defaultJsonEntity(request),
+                        Void.class);
+
+        // then.
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(getGroupLevel(GROUP)).isEqualTo(LogLevel.DEBUG);
+    }
+
+    @ParameterizedTest
+    @MethodSource("argSetLogLevel")
+    void shouldReturnBadRequest_SetLogLevel(String path) {
+        // language=json
+        String request = """
+        {
+          "configuredLevel":"debug"
+        }
+        """;
+
+        // when.
+        ResponseEntity<Void> response =
+                testRestTemplate.asViewer().postForEntity(path, defaultJsonEntity(request), Void.class);
+
+        // then.
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    private static Stream<Arguments> argSetLogLevel() {
+        return Stream.of(
+                Arguments.of("/actuator/axelix-loggers/group/non.existent.logger/change-level"),
+                Arguments.of("/actuator/axelix-loggers/logger/non.existent.logger/change-level"));
+    }
+
+    @Test
+    void shouldResetLogLevel_WhenLogLevelAffectsOtherLoggers() {
+        // language=json
+        String request = """
+        {
+          "configuredLevel":"error"
+        }
+        """;
+
+        testRestTemplate
+                .asViewer()
+                .postForEntity(
+                        "/actuator/axelix-loggers/logger/%s/change-level".formatted(ABC_RESET_LOGGER),
+                        defaultJsonEntity(request),
+                        Void.class);
+        assertThat(getLogLevel(ABC_RESET_LOGGER)).isEqualTo(LogLevel.ERROR);
+        assertThat(getLogLevel(ABCD_RESET_LOGGER)).isEqualTo(LogLevel.ERROR);
+
+        // when.
+        testRestTemplate
+                .asViewer()
+                .postForEntity(
+                        "/actuator/axelix-loggers/logger/%s/reset".formatted(ABC_RESET_LOGGER), null, Void.class);
+
+        // then.
+        assertThat(getLogLevel(ABC_RESET_LOGGER)).isEqualTo(LogLevel.WARN);
+        assertThat(getLogLevel(ABCD_RESET_LOGGER)).isEqualTo(LogLevel.WARN);
+    }
+
+    @Test
+    void shouldResetLogLevel_WhenLogLevelDoesNotAffectOtherLoggers() {
+        // language=json
+        String request = """
+        {
+          "configuredLevel":"error"
+        }
+        """;
+
+        testRestTemplate
+                .asViewer()
+                .postForEntity(
+                        "/actuator/axelix-loggers/logger/%s/change-level".formatted(AB_RESET_LOGGER),
+                        defaultJsonEntity(request),
+                        Void.class);
+        assertThat(getLogLevel(AB_RESET_LOGGER)).isEqualTo(LogLevel.ERROR);
+        assertThat(getLogLevel(ABCDE_RESET_LOGGER)).isEqualTo(LogLevel.DEBUG);
+
+        // when.
+        testRestTemplate
+                .asViewer()
+                .postForEntity("/actuator/axelix-loggers/logger/%s/reset".formatted(AB_RESET_LOGGER), null, Void.class);
+
+        // then.
+        assertThat(getLogLevel(AB_RESET_LOGGER)).isEqualTo(LogLevel.WARN);
+        assertThat(getLogLevel(ABCDE_RESET_LOGGER)).isEqualTo(LogLevel.DEBUG);
+    }
+
+    @Test
+    void shouldReturnBadRequest_WhenResettingUnknownLogger() {
+        ResponseEntity<Void> response = testRestTemplate
+                .asViewer()
+                .postForEntity("/actuator/axelix-loggers/logger/non.existent.logger/reset", null, Void.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-loggers")
+    void negativeAuthTests() {}
+
+    private LogLevel getLogLevel(String loggerName) {
+        return loggingSystem.getLoggerConfiguration(loggerName).getEffectiveLevel();
+    }
+
+    private LogLevel getGroupLevel(String groupName) {
+        return loggerGroups.get(groupName).getConfiguredLevel();
+    }
+
+    private <T> HttpEntity<T> defaultJsonEntity(T request) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return new HttpEntity<>(request, headers);
+    }
+
+    @TestConfiguration
+    static class AxelixLoggersEndpointTestConfiguration {
+
+        @Bean
+        public AxelixLoggersEndpoint axelixLoggersEndpoint(
+                LoggingSystem loggingSystem, ObjectProvider<LoggerGroups> loggerGroups) {
+            return new AxelixLoggersEndpoint(loggingSystem, loggerGroups.getIfAvailable(LoggerGroups::new));
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/AxelixMetadataEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/AxelixMetadataEndpointTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.master;
+
+import java.lang.management.ManagementFactory;
+
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseEntity;
+
+import com.axelixlabs.axelix.common.api.registration.BasicDiscoveryMetadata;
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.common.domain.version.AxelixVersionDiscoverer;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AxelixMetadataEndpoint}.
+ *
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import({
+    AxelixMetadataEndpoint.class,
+    AxelixMetadataEndpointTest.CurrentConfig.class,
+    DefaultServiceMetadataAssembler.class,
+    CommitIdPluginGitInformationProvider.class,
+    CommitIdPluginShortBuildInfoProvider.class,
+    JwtAuthTestConfiguration.class
+})
+class AxelixMetadataEndpointTest {
+
+    @Autowired
+    private TestRestTemplateBuilder testRestTemplate;
+
+    @TestConfiguration
+    static class CurrentConfig {
+
+        @Bean
+        VMFeaturesProvider vmFeaturesProvider() {
+            return new OptionsParsingVMFeaturesProvider(
+                    ManagementFactory.getRuntimeMXBean().getInputArguments());
+        }
+
+        @Bean
+        HealthDetectionFunction healthDetectionFunction() {
+            return () -> BasicDiscoveryMetadata.HealthStatus.UP;
+        }
+
+        @Bean
+        AxelixVersionDiscoverer axelixVersionDiscoverer() {
+            return () -> "1.1.3";
+        }
+
+        @Bean
+        public LibraryInformationProvider libraryInformationProvider() {
+            return new DefaultLibraryInformationProvider();
+        }
+    }
+
+    @Test
+    void shouldReceiveServiceMetadata() {
+        // when.
+        ResponseEntity<String> result =
+                testRestTemplate.asViewer().getForEntity("/actuator/axelix-metadata", String.class);
+
+        // then.
+        assertThat(result.getStatusCode().is2xxSuccessful()).isTrue();
+        JsonAssertions.assertThatJson(result.getBody())
+                // we do not want to know exactly the java version on which the test is going to run
+                .whenIgnoringPaths("softwareVersions", "vmFeatures")
+                .isEqualTo(
+                        // language=json
+                        """
+            {
+              "version": "1.1.3",
+              "serviceVersion" : "3.5.0-SNAPSHOT",
+              "commitShortSha" : "a8b0929",
+              "jdkVendor" : "#{json-unit.ignore}",
+              "softwareVersions" : {
+                "springBoot" : "3.5.0",
+                "java" : "25",
+                "springFramework" : "6.1.2",
+                "kotlin" : null
+              },
+              "healthStatus" : "UP",
+              "memoryDetails" : {
+                "heap" : "#{json-unit.ignore}"
+              },
+              "vmFeatures": []
+            }
+            """);
+    }
+
+    @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-metadata")
+    void negativeAuthTests() {}
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginGitInformationProviderTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginGitInformationProviderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.master;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import com.axelixlabs.axelix.common.api.registration.GitInfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link CommitIdPluginGitInformationProvider}.
+ *
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest
+@Import({CommitIdPluginGitInformationProvider.class, ProjectInfoAutoConfiguration.class})
+class CommitIdPluginGitInformationProviderTest {
+
+    @Autowired
+    private CommitIdPluginGitInformationProvider subject;
+
+    @Test
+    void shouldAssembleGitInfoFromPropertiesFile() {
+
+        // when.
+        GitInfo gitCommitInfo = subject.getGitCommitInfo().orElse(null);
+
+        // then.
+        assertThat(gitCommitInfo).isNotNull();
+        assertThat(gitCommitInfo.branch()).isEqualTo("main");
+        assertThat(gitCommitInfo.commitShaShort()).isEqualTo("a8b0929");
+        assertThat(gitCommitInfo.commitTimestamp()).isEqualTo("1761249922000");
+
+        assertThat(gitCommitInfo.commitAuthor())
+                .extracting(GitInfo.CommitAuthor::email)
+                .isEqualTo("mikhailpolivakha@email.com");
+
+        assertThat(gitCommitInfo.commitAuthor())
+                .extracting(GitInfo.CommitAuthor::name)
+                .isEqualTo("Mikhail Polivakha");
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginShortBuildInfoProviderTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginShortBuildInfoProviderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.master;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import com.axelixlabs.axelix.common.api.registration.ShortBuildInfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link CommitIdPluginShortBuildInfoProvider}.
+ *
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest
+@Import({CommitIdPluginShortBuildInfoProvider.class, ProjectInfoAutoConfiguration.class})
+class CommitIdPluginShortBuildInfoProviderTest {
+
+    @Autowired
+    private CommitIdPluginShortBuildInfoProvider subject;
+
+    @Test
+    void shouldAssembleShortBuildInfoFromPropertiesFile() {
+        ShortBuildInfo shortBuildInfo = subject.getShortBuildInfo().orElse(null);
+
+        assertThat(shortBuildInfo).isNotNull();
+        assertThat(shortBuildInfo.serviceVersion()).isEqualTo("3.5.0-SNAPSHOT");
+        assertThat(shortBuildInfo.buildTimestamp()).isEqualTo("1732804672000");
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultServiceMetadataAssemblerTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultServiceMetadataAssemblerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.master;
+
+import java.lang.management.ManagementFactory;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.boot.health.actuate.endpoint.HealthEndpoint;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.axelixlabs.axelix.common.api.registration.BasicDiscoveryMetadata;
+import com.axelixlabs.axelix.common.domain.version.AxelixVersionDiscoverer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link DefaultServiceMetadataAssembler}.
+ *
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest
+@Import({
+    CommitIdPluginGitInformationProvider.class,
+    CommitIdPluginShortBuildInfoProvider.class,
+    DefaultServiceMetadataAssembler.class,
+    DefaultServiceMetadataAssemblerTest.CurrentConfig.class
+})
+class DefaultServiceMetadataAssemblerTest {
+
+    @Autowired
+    private DefaultServiceMetadataAssembler subject;
+
+    @MockitoBean
+    private HealthEndpoint healthEndpoint;
+
+    @TestConfiguration
+    static class CurrentConfig {
+
+        @Bean
+        VMFeaturesProvider vmFeaturesProvider() {
+            return new OptionsParsingVMFeaturesProvider(
+                    ManagementFactory.getRuntimeMXBean().getInputArguments());
+        }
+
+        @Bean
+        HealthDetectionFunction healthDetectionFunction() {
+            return () -> BasicDiscoveryMetadata.HealthStatus.UP;
+        }
+
+        @Bean
+        AxelixVersionDiscoverer axelixVersionDiscoverer() {
+            return () -> "1.1.3";
+        }
+
+        @Bean
+        public LibraryInformationProvider libraryInformationProvider() {
+            return new DefaultLibraryInformationProvider();
+        }
+    }
+
+    @Test
+    void shouldAssembleTheMetadataAboutGivenService() {
+        // when.
+        BasicDiscoveryMetadata serviceMetadata = subject.assemble();
+
+        // then.
+        assertThat(serviceMetadata.getCommitShortSha()).isEqualTo("a8b0929");
+        assertThat(serviceMetadata.getServiceVersion()).isEqualTo("3.5.0-SNAPSHOT");
+        assertThat(serviceMetadata.getSoftwareVersions().getJava()).isEqualTo(System.getProperty("java.version"));
+        assertThat(serviceMetadata.getVersion()).isEqualTo("1.1.3");
+        assertThat(serviceMetadata.getSoftwareVersions().getSpringBoot()).isEqualTo(SpringBootVersion.getVersion());
+        assertThat(serviceMetadata.getHealthStatus()).isEqualTo(BasicDiscoveryMetadata.HealthStatus.UP);
+        assertThat(serviceMetadata.getMemoryDetails()).isNotNull();
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsEndpointTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.metrics;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.assertj.core.data.Percentage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.micrometer.metrics.actuate.endpoint.MetricsEndpoint;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseEntity;
+
+import com.axelixlabs.axelix.common.api.metrics.MetricProfile;
+import com.axelixlabs.axelix.common.api.metrics.MetricsGroupsFeed;
+import com.axelixlabs.axelix.common.api.metrics.MetricsGroupsFeed.MetricsGroup.MetricDescription;
+import com.axelixlabs.axelix.common.api.transform.BaseUnitParser;
+import com.axelixlabs.axelix.common.api.transform.BytesMemoryBaseUnitValueTransformer;
+import com.axelixlabs.axelix.common.api.transform.KilobytesMemoryBaseUnitValueTransformer;
+import com.axelixlabs.axelix.common.api.transform.units.MegabytesMemoryBaseUnit;
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AxelixMetricsEndpoint}.
+ *
+ * @author Nikita Kirillov
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import({
+    AxelixMetricsEndpoint.class,
+    MetricsEndpoint.class,
+    DefaultServiceMetricsGroupsAssembler.class,
+    BaseUnitParser.class,
+    KilobytesMemoryBaseUnitValueTransformer.class,
+    BytesMemoryBaseUnitValueTransformer.class,
+    JwtAuthTestConfiguration.class
+})
+class AxelixMetricsEndpointTest {
+
+    @Autowired
+    private TestRestTemplateBuilder testRestTemplate;
+
+    @Test
+    void shouldProduceOnlyValidCombinationsOfTags() {
+        // when.
+        String metricName = "jvm.memory.max";
+        ResponseEntity<MetricProfile> response =
+                testRestTemplate.asViewer().getForEntity("/actuator/axelix-metrics/" + metricName, MetricProfile.class);
+
+        // then.
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        MetricProfile metricProfile = response.getBody();
+
+        assertThat(metricProfile.getName()).isEqualTo(metricName);
+        assertThat(metricProfile.getValidTagCombinations())
+                .containsOnly(
+                        Map.of(
+                                "area", "nonheap",
+                                "id", "Compressed Class Space"),
+                        Map.of(
+                                "area", "nonheap",
+                                "id", "CodeHeap 'non-profiled nmethods'"),
+                        Map.of(
+                                "area", "heap",
+                                "id", "G1 Old Gen"),
+                        Map.of(
+                                "area", "heap",
+                                "id", "G1 Eden Space"),
+                        Map.of(
+                                "area", "nonheap",
+                                "id", "CodeHeap 'profiled nmethods'"),
+                        Map.of(
+                                "area", "nonheap",
+                                "id", "CodeHeap 'non-nmethods'"),
+                        Map.of(
+                                "area", "nonheap",
+                                "id", "Metaspace"),
+                        Map.of(
+                                "area", "heap",
+                                "id", "G1 Survivor Space"));
+    }
+
+    @Test
+    void shouldApplyValueTransformationsForGivenValue() {
+        // when.
+        String metricName = "for.value.transformations";
+        ResponseEntity<MetricProfile> response =
+                testRestTemplate.asEditor().getForEntity("/actuator/axelix-metrics/" + metricName, MetricProfile.class);
+
+        // then.
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        MetricProfile metricProfile = response.getBody();
+
+        assertThat(metricProfile.getName()).isEqualTo(metricName);
+        assertThat(metricProfile.getBaseUnit()).isEqualTo(MegabytesMemoryBaseUnit.INSTANCE.getDisplayName());
+        assertThat(metricProfile.getMeasurements().get(0).getValue()).isCloseTo(5.22, Percentage.withPercentage(1));
+    }
+
+    @Test
+    void shouldProduceEmptyValidTagCombinationsArrayInCaseNoTagsArePresent() {
+        // when.
+        String metricName = "jvm.gc.overhead";
+        ResponseEntity<MetricProfile> response =
+                testRestTemplate.asAdmin().getForEntity("/actuator/axelix-metrics/" + metricName, MetricProfile.class);
+
+        // then.
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        MetricProfile metricProfile = response.getBody();
+
+        assertThat(metricProfile.getName()).isEqualTo(metricName);
+        assertThat(metricProfile.getValidTagCombinations()).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("metricsGroups")
+    void shouldReturnGroupedMetricsWithDescriptions(String groupName, String metricName, String metricDescription) {
+        // when.
+        ResponseEntity<MetricsGroupsFeed> response =
+                testRestTemplate.asViewer().getForEntity("/actuator/axelix-metrics", MetricsGroupsFeed.class);
+
+        // then.
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        MetricsGroupsFeed metricsGroups = response.getBody();
+
+        assertThat(metricsGroups.getMetricsGroups())
+                // metrics group
+                .filteredOn(group -> group.getGroupName().equals(groupName))
+                .first()
+                .satisfies(group -> {
+                    List<MetricDescription> metrics = group.getMetrics();
+
+                    // metric name
+                    assertThat(metrics)
+                            .extracting(MetricDescription::getMetricName)
+                            .contains(metricName);
+
+                    // metric description
+                    assertThat(metrics)
+                            .extracting(MetricDescription::getDescription)
+                            .contains(metricDescription);
+                });
+    }
+
+    private static Stream<Arguments> metricsGroups() {
+        return Stream.of(
+                Arguments.of(
+                        "axelixMetrics",
+                        "axelixMetrics.test.metric1",
+                        "Test metric belonging to the `axelixMetrics` group with a description"),
+                Arguments.of(
+                        "axelixMetrics",
+                        "axelixMetrics.test.metric2",
+                        "Test metric belonging to the `axelixMetrics` group with a description"),
+                Arguments.of("axelixMetrics", "axelixMetrics.test.metric3", null),
+                Arguments.of(
+                        "testMetrics",
+                        "testMetrics.axelix.metric1",
+                        "Test metric belonging to the `testMetrics` group with a description"),
+                Arguments.of(
+                        "testMetrics",
+                        "testMetrics.axelix.metric2",
+                        "Test metric belonging to the `testMetrics` group with a description"),
+                Arguments.of(
+                        "Others",
+                        "standalone",
+                        "Test metric belonging to the 'Others' group without a prefix and with a description"));
+    }
+
+    @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-metrics")
+    void negativeAuthTests() {}
+
+    @TestConfiguration
+    static class AxelixMetricsEndpointTestConfiguration {
+
+        @Bean
+        public MeterBinder groupingMetrics() {
+            return registry -> {
+                Counter.builder("axelixMetrics.test.metric1")
+                        .description("Test metric belonging to the `axelixMetrics` group with a description")
+                        .register(registry);
+
+                Counter.builder("axelixMetrics.test.metric2")
+                        .description("Test metric belonging to the `axelixMetrics` group with a description")
+                        .register(registry);
+
+                Counter.builder("axelixMetrics.test.metric3").register(registry);
+
+                Counter.builder("testMetrics.axelix.metric1")
+                        .description("Test metric belonging to the `testMetrics` group with a description")
+                        .register(registry);
+
+                Counter.builder("testMetrics.axelix.metric2").register(registry);
+
+                Counter.builder("standalone")
+                        .description(
+                                "Test metric belonging to the 'Others' group without a prefix and with a description")
+                        .register(registry);
+
+                Gauge.builder(
+                                "for.value.transformations", () -> 5480079 // ~ 5.22 MB
+                                )
+                        .baseUnit("bytes")
+                        .register(registry);
+            };
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultServiceMetricsGroupsFeedAssemblerTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultServiceMetricsGroupsFeedAssemblerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.common.api.metrics.MetricsGroupsFeed;
+import com.axelixlabs.axelix.common.api.metrics.MetricsGroupsFeed.MetricsGroup;
+import com.axelixlabs.axelix.common.api.metrics.MetricsGroupsFeed.MetricsGroup.MetricDescription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link DefaultServiceMetricsGroupsAssembler}.
+ *
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest
+public class DefaultServiceMetricsGroupsFeedAssemblerTest {
+
+    @Autowired
+    ServiceMetricsGroupsAssembler assembler;
+
+    @Test
+    void shouldReturnGroupedMetricsWithDescriptions() {
+        MetricsGroupsFeed metricsGroups = assembler.assemble();
+
+        MetricsGroup axelix = getMetricsGroup(metricsGroups, "axelixMetrics");
+        assertThat(axelix.getGroupName()).isEqualTo("axelixMetrics");
+        assertThat(axelix.getMetrics())
+                .containsOnly(
+                        new MetricDescription(
+                                "axelixMetrics.test.metric1",
+                                "Test metric belonging to the `axelixMetrics` group with a description"),
+                        new MetricDescription(
+                                "axelixMetrics.test.metric2",
+                                "Test metric belonging to the `axelixMetrics` group with a description"),
+                        new MetricDescription("axelixMetrics.test.metric3", null));
+
+        MetricsGroup test = getMetricsGroup(metricsGroups, "testMetrics");
+        assertThat(test.getGroupName()).isEqualTo("testMetrics");
+        assertThat(test.getMetrics())
+                .containsOnly(
+                        new MetricDescription(
+                                "testMetrics.axelix.metric1",
+                                "Test metric belonging to the `testMetrics` group with a description"),
+                        new MetricDescription("testMetrics.axelix.metric2", null));
+
+        MetricsGroup other = getMetricsGroup(metricsGroups, "Others");
+        assertThat(other.getGroupName()).isEqualTo("Others");
+        assertThat(other.getMetrics())
+                .contains(new MetricDescription(
+                        "standalone",
+                        "Test metric belonging to the 'Others' group without a prefix and with a description"));
+    }
+
+    private MetricsGroup getMetricsGroup(MetricsGroupsFeed response, String groupName) {
+        return response.getMetricsGroups().stream()
+                .filter(group -> group.getGroupName().equals(groupName))
+                .findFirst()
+                .get();
+    }
+
+    @TestConfiguration
+    static class DefaultServiceMetricsGroupsAssemblerTestConfiguration {
+
+        @Bean
+        public ServiceMetricsGroupsAssembler defaultMetricsGroupsAssembler(MeterRegistry registry) {
+            return new DefaultServiceMetricsGroupsAssembler(registry);
+        }
+
+        @Bean
+        public MeterBinder groupingMetrics() {
+            return registry -> {
+                Counter.builder("axelixMetrics.test.metric1")
+                        .description("Test metric belonging to the `axelixMetrics` group with a description")
+                        .register(registry);
+
+                Counter.builder("axelixMetrics.test.metric2")
+                        .description("Test metric belonging to the `axelixMetrics` group with a description")
+                        .register(registry);
+
+                Counter.builder("axelixMetrics.test.metric3").register(registry);
+
+                Counter.builder("testMetrics.axelix.metric1")
+                        .description("Test metric belonging to the `testMetrics` group with a description")
+                        .register(registry);
+
+                Counter.builder("testMetrics.axelix.metric2").register(registry);
+
+                Counter.builder("standalone")
+                        .description(
+                                "Test metric belonging to the 'Others' group without a prefix and with a description")
+                        .register(registry);
+            };
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpointTest.java
@@ -1,0 +1,580 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.scheduled;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.TriggerContext;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.test.context.TestPropertySource;
+
+import com.axelixlabs.axelix.common.api.scheduledtask.ScheduledTaskCronExpressionModifyRequest;
+import com.axelixlabs.axelix.common.api.scheduledtask.ScheduledTaskExecuteRequest;
+import com.axelixlabs.axelix.common.api.scheduledtask.ScheduledTaskIntervalModifyRequest;
+import com.axelixlabs.axelix.common.api.scheduledtask.ScheduledTaskToggleRequest;
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpointTest.AxelixScheduledTasksEndpointTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+// TODO: Revisit this test design.
+/**
+ * Integration tests for {@link AxelixScheduledTasksEndpoint}
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"management.endpoints.web.exposure.include=axelix-scheduled-tasks"})
+@Import({AxelixScheduledTasksEndpointTestConfiguration.class, JwtAuthTestConfiguration.class})
+class AxelixScheduledTasksEndpointTest {
+
+    // Cron
+    private static final String CRON_TASK_ID =
+            AxelixScheduledTasksEndpointTestConfiguration.class.getName() + ".testCronTask";
+    private static final String CRON_TASK_ID_FOR_MODIFY =
+            AxelixScheduledTasksEndpointTestConfiguration.class.getName() + ".testCronTaskForModify";
+
+    // FixedDelay
+    private static final String FIXED_DELAY_TASK_ID =
+            AxelixScheduledTasksEndpointTestConfiguration.class.getName() + ".testFixedDelayTask";
+    private static final String FIXED_DELAY_TASK_ID_FOR_MODIFY =
+            AxelixScheduledTasksEndpointTestConfiguration.class.getName() + ".testFixedDelayTaskForModify";
+    private static final String FIXED_DELAY_TASK_ID_FOR_EXECUTE =
+            AxelixScheduledTasksEndpointTestConfiguration.class.getName() + ".testFixedDelayTaskForExecute";
+
+    // FixedRate
+    private static final String FIXED_RATE_TASK_ID =
+            AxelixScheduledTasksEndpointTestConfiguration.class.getName() + ".testFixedRateTask";
+    private static final String FIXED_RATE_TASK_ID_FOR_MODIFY =
+            AxelixScheduledTasksEndpointTestConfiguration.class.getName() + ".testFixedRateTaskForModify";
+    private static final String FIXED_RATE_TASK_ID_FOR_EXECUTE =
+            AxelixScheduledTasksEndpointTestConfiguration.class.getName() + ".testFixedRateTaskForExecute";
+
+    // Custom
+    private static final String CUSTOM_TASK_ID =
+            AxelixScheduledTasksEndpointTestConfiguration.CustomTestTask.class.getName();
+
+    private static final String CUSTOM_TRIGGER = "CustomTestTrigger";
+
+    private static volatile boolean cronFlag = false;
+
+    private static volatile boolean fixedDelayFlag = false;
+
+    private static volatile boolean fixedRateFlag = false;
+
+    private static volatile boolean customTaskFlag = false;
+
+    @Autowired
+    private TestRestTemplateBuilder restTemplate;
+
+    @Test
+    void shouldEnableDisabledTask_testCronTask() throws InterruptedException {
+        String taskId = CRON_TASK_ID;
+
+        forceDisableTask(taskId);
+        Thread.sleep(200);
+        cronFlag = false;
+        Thread.sleep(1200);
+        assertThat(cronFlag).isFalse();
+
+        assertThatJson(getScheduledTasks()).node("cron").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(taskId);
+            assertThatJson(task).node("enabled").isEqualTo(false);
+        });
+    }
+
+    @Test
+    void shouldForceRescheduleEnabledTask_testCronTask() throws InterruptedException {
+        String taskId = CRON_TASK_ID;
+
+        forceDisableTask(taskId);
+        Thread.sleep(200);
+        cronFlag = false;
+        Thread.sleep(1200);
+        assertThat(cronFlag).isFalse();
+
+        assertThatJson(getScheduledTasks()).node("cron").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(taskId);
+            assertThatJson(task).node("enabled").isEqualTo(false);
+        });
+
+        enableScheduledTask(taskId);
+        Thread.sleep(1200);
+        assertThat(cronFlag).isTrue();
+
+        assertThatJson(getScheduledTasks()).node("cron").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(taskId);
+            assertThatJson(task).node("enabled").isEqualTo(true);
+        });
+    }
+
+    @Test
+    void shouldEnableDisabledTask_testFixedDelayTask() throws InterruptedException {
+        String taskId = FIXED_DELAY_TASK_ID;
+
+        forceDisableTask(taskId);
+        Thread.sleep(200);
+        fixedDelayFlag = false;
+        Thread.sleep(200);
+        assertThat(fixedDelayFlag).isFalse();
+
+        assertThatJson(getScheduledTasks()).node("fixedDelay").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(taskId);
+            assertThatJson(task).node("enabled").isEqualTo(false);
+        });
+    }
+
+    @Test
+    void shouldForceRescheduleEnabledTask_testFixedDelayTask() throws InterruptedException {
+        String taskId = FIXED_DELAY_TASK_ID;
+
+        forceDisableTask(taskId);
+        Thread.sleep(200);
+        fixedDelayFlag = false;
+        Thread.sleep(200);
+        assertThat(fixedDelayFlag).isFalse();
+
+        assertThatJson(getScheduledTasks()).node("fixedDelay").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(taskId);
+            assertThatJson(task).node("enabled").isEqualTo(false);
+        });
+
+        enableScheduledTask(taskId);
+        Thread.sleep(200);
+        assertThat(fixedDelayFlag).isTrue();
+
+        assertThatJson(getScheduledTasks()).node("fixedDelay").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(taskId);
+            assertThatJson(task).node("enabled").isEqualTo(true);
+        });
+    }
+
+    @Test
+    void shouldEnableDisabledTask_testFixedRateTask() throws InterruptedException {
+        String taskId = FIXED_RATE_TASK_ID;
+
+        forceDisableTask(taskId);
+        Thread.sleep(200);
+        fixedRateFlag = false;
+        Thread.sleep(200);
+        assertThat(fixedRateFlag).isFalse();
+
+        assertThatJson(getScheduledTasks()).node("fixedRate").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(taskId);
+            assertThatJson(task).node("enabled").isEqualTo(false);
+        });
+    }
+
+    @Test
+    void shouldForceRescheduleEnabledTask_testFixedRateTask() throws InterruptedException {
+        String taskId = FIXED_RATE_TASK_ID;
+
+        forceDisableTask(taskId);
+        Thread.sleep(200);
+        fixedRateFlag = false;
+        Thread.sleep(200);
+        assertThat(fixedRateFlag).isFalse();
+
+        assertThatJson(getScheduledTasks()).node("fixedRate").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(taskId);
+            assertThatJson(task).node("enabled").isEqualTo(false);
+        });
+
+        enableScheduledTask(taskId);
+        Thread.sleep(200);
+        assertThat(fixedRateFlag).isTrue();
+
+        assertThatJson(getScheduledTasks()).node("fixedRate").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(taskId);
+            assertThatJson(task).node("enabled").isEqualTo(true);
+        });
+    }
+
+    @Test
+    void shouldEnableDisabledTask_customTestTask() throws InterruptedException {
+        String taskId = CUSTOM_TASK_ID;
+
+        forceDisableTask(taskId);
+        Thread.sleep(200);
+        customTaskFlag = false;
+        Thread.sleep(200);
+        assertThat(customTaskFlag).isFalse();
+
+        assertThatJson(getScheduledTasks()).node("custom").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(taskId);
+            assertThatJson(task).node("trigger").isEqualTo(CUSTOM_TRIGGER);
+            assertThatJson(task).node("enabled").isEqualTo(false);
+        });
+    }
+
+    @Test
+    void shouldForceRescheduleEnabledTask_customTestTask() throws InterruptedException {
+        String taskId = CUSTOM_TASK_ID;
+
+        forceDisableTask(taskId);
+        Thread.sleep(200);
+        customTaskFlag = false;
+        Thread.sleep(200);
+        assertThat(customTaskFlag).isFalse();
+
+        assertThatJson(getScheduledTasks()).node("custom").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(taskId);
+            assertThatJson(task).node("enabled").isEqualTo(false);
+        });
+
+        enableScheduledTask(taskId);
+        Thread.sleep(200);
+        assertThat(customTaskFlag).isTrue();
+
+        assertThatJson(getScheduledTasks()).node("custom").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(taskId);
+            assertThatJson(task).node("enabled").isEqualTo(true);
+        });
+    }
+
+    @Test
+    void shouldModifyCronExpression_testCronTask() {
+        String newCronExpression = "*/5 * * * * *";
+
+        ScheduledTaskCronExpressionModifyRequest request =
+                new ScheduledTaskCronExpressionModifyRequest(CRON_TASK_ID_FOR_MODIFY, newCronExpression);
+
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity(
+                        "/actuator/axelix-scheduled-tasks/modify/cron-expression",
+                        defaultJsonEntity(request),
+                        Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.NO_CONTENT, ResponseEntity::getStatusCode);
+        assertThatJson(getScheduledTasks()).node("cron").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(CRON_TASK_ID_FOR_MODIFY);
+            assertThatJson(task).node("expression").isEqualTo(newCronExpression);
+        });
+    }
+
+    @Test
+    void shouldReturnBadRequest_modifyCronExpressionForCronTask() {
+        // language=json
+        String request = """
+            {
+              "trigger" : "%s",
+              "cronExpression": "invalid value"
+            }
+            """.formatted(CRON_TASK_ID_FOR_MODIFY);
+
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity(
+                        "/actuator/axelix-scheduled-tasks/modify/cron-expression",
+                        defaultJsonEntity(request),
+                        Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldModifyInterval_testFixedDelay() {
+        Long newInterval = 555555L;
+
+        ScheduledTaskIntervalModifyRequest request =
+                new ScheduledTaskIntervalModifyRequest(FIXED_DELAY_TASK_ID_FOR_MODIFY, newInterval);
+
+        ResponseEntity<Void> response = restTemplate
+                .asAdmin()
+                .postForEntity(
+                        "/actuator/axelix-scheduled-tasks/modify/interval", defaultJsonEntity(request), Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.NO_CONTENT, ResponseEntity::getStatusCode);
+        assertThatJson(getScheduledTasks()).node("fixedDelay").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(FIXED_DELAY_TASK_ID_FOR_MODIFY);
+            assertThatJson(task).node("interval").isEqualTo(newInterval);
+        });
+    }
+
+    @Test
+    void shouldReturnBadRequest_modifyIntervalForFixedDelay() {
+        // language=json
+        String request = """
+                {
+                  "trigger" : "%s",
+                  "cronExpression": "invalid value"
+                }
+                """.formatted(FIXED_DELAY_TASK_ID_FOR_MODIFY);
+
+        ResponseEntity<Void> response = restTemplate
+                .asAdmin()
+                .postForEntity(
+                        "/actuator/axelix-scheduled-tasks/modify/interval", defaultJsonEntity(request), Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldModifyInterval_testFixedRate() {
+        Long newInterval = 777777L;
+
+        ScheduledTaskIntervalModifyRequest request =
+                new ScheduledTaskIntervalModifyRequest(FIXED_RATE_TASK_ID_FOR_MODIFY, newInterval);
+
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity(
+                        "/actuator/axelix-scheduled-tasks/modify/interval", defaultJsonEntity(request), Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.NO_CONTENT, ResponseEntity::getStatusCode);
+        assertThatJson(getScheduledTasks()).node("fixedRate").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(FIXED_RATE_TASK_ID_FOR_MODIFY);
+            assertThatJson(task).node("interval").isEqualTo(newInterval);
+        });
+    }
+
+    @Test
+    void shouldReturnBadRequest_modifyIntervalForFixedRate() {
+        // language=json
+        String request = """
+                {
+                  "trigger" : "%s",
+                  "cronExpression": "invalid value"
+                }
+                """.formatted(FIXED_RATE_TASK_ID_FOR_MODIFY);
+
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity(
+                        "/actuator/axelix-scheduled-tasks/modify/interval", defaultJsonEntity(request), Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldExecuteWithDisableTask_testFixedDelay() {
+        forceDisableTask(FIXED_DELAY_TASK_ID_FOR_EXECUTE);
+        ScheduledTaskExecuteRequest request = new ScheduledTaskExecuteRequest(FIXED_DELAY_TASK_ID_FOR_EXECUTE);
+
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity("/actuator/axelix-scheduled-tasks/execute", defaultJsonEntity(request), Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.NO_CONTENT, ResponseEntity::getStatusCode);
+        assertThatJson(getScheduledTasks()).node("fixedDelay").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(FIXED_DELAY_TASK_ID_FOR_EXECUTE);
+            assertThatJson(task).node("interval").isEqualTo(2000000000);
+            assertThatJson(task).node("enabled").isEqualTo(false);
+        });
+        assertThat(fixedDelayFlag).isTrue();
+    }
+
+    @Test
+    void shouldExecuteTask_testFixedRate() {
+        ScheduledTaskExecuteRequest request = new ScheduledTaskExecuteRequest(FIXED_RATE_TASK_ID_FOR_EXECUTE);
+
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity("/actuator/axelix-scheduled-tasks/execute", defaultJsonEntity(request), Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.NO_CONTENT, ResponseEntity::getStatusCode);
+        assertThatJson(getScheduledTasks()).node("fixedRate").isArray().anySatisfy(task -> {
+            assertThatJson(task).node("runnable.target").isEqualTo(FIXED_RATE_TASK_ID_FOR_EXECUTE);
+            assertThatJson(task).node("interval").isEqualTo(2000000000);
+            assertThatJson(task).node("enabled").isEqualTo(true);
+        });
+        assertThat(fixedRateFlag).isTrue();
+    }
+
+    @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-scheduled-tasks")
+    void negativeAuthTests() {}
+
+    private void enableScheduledTask(String target) {
+        ScheduledTaskToggleRequest request = new ScheduledTaskToggleRequest(target);
+
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity("/actuator/axelix-scheduled-tasks/enable", defaultJsonEntity(request), Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.NO_CONTENT, ResponseEntity::getStatusCode);
+    }
+
+    private void forceDisableTask(String targetScheduledTask) {
+        ScheduledTaskToggleRequest request = new ScheduledTaskToggleRequest(targetScheduledTask);
+
+        ResponseEntity<Void> response = restTemplate
+                .asAdmin()
+                .postForEntity(
+                        "/actuator/axelix-scheduled-tasks/disable?force=true", defaultJsonEntity(request), Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.NO_CONTENT, ResponseEntity::getStatusCode);
+    }
+
+    private String getScheduledTasks() {
+        ResponseEntity<String> response =
+                restTemplate.asEditor().getForEntity("/actuator/axelix-scheduled-tasks", String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+
+        return response.getBody();
+    }
+
+    private <T> HttpEntity<T> defaultJsonEntity(T request) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return new HttpEntity<>(request, headers);
+    }
+
+    @TestConfiguration
+    @EnableScheduling
+    static class AxelixScheduledTasksEndpointTestConfiguration implements SchedulingConfigurer {
+
+        @Bean
+        public TaskScheduler taskScheduler() {
+            return new ConcurrentTaskScheduler();
+        }
+
+        @Bean
+        public ScheduledTasksRegistry scheduledTaskRegistry(ScheduledAnnotationBeanPostProcessor processor) {
+            return new ScheduledTasksRegistry(List.of(processor));
+        }
+
+        @Bean
+        TaskRescheduler testTriggerBasedTaskRescheduler(TaskScheduler taskScheduler) {
+            return new TriggerBasedTaskRescheduler(taskScheduler);
+        }
+
+        @Bean
+        TaskRescheduler testIntervalBasedTaskRescheduler(TaskScheduler taskScheduler) {
+            return new IntervalBasedTaskRescheduler(taskScheduler);
+        }
+
+        @Bean
+        public ScheduledTaskService scheduledTaskService(
+                ScheduledTasksRegistry registry,
+                List<TaskRescheduler> taskReschedulers,
+                ThreadPoolTaskExecutor taskExecutor) {
+            return new ScheduledTaskService(registry, taskReschedulers, taskExecutor);
+        }
+
+        @Bean
+        public ScheduledTasksAssembler serviceScheduledTasksAssembler(ScheduledTasksRegistry scheduledTasksRegistry) {
+            return new DefaultScheduledTasksAssembler(scheduledTasksRegistry);
+        }
+
+        @Bean
+        public AxelixScheduledTasksEndpoint scheduledTasksEndpointExtension(
+                ScheduledTaskService service, ScheduledTasksAssembler scheduledTasksAssembler) {
+            return new AxelixScheduledTasksEndpoint(service, scheduledTasksAssembler);
+        }
+
+        // Cron tasks
+        @Scheduled(cron = "*/1 * * * * *")
+        public void testCronTask() {
+            cronFlag = true;
+        }
+
+        @Scheduled(cron = "*/2 * * * * *")
+        public void testCronTaskForModify() {}
+
+        // FixedDelay tasks
+        @Scheduled(fixedDelay = 100)
+        public void testFixedDelayTask() {
+            fixedDelayFlag = true;
+        }
+
+        @Scheduled(fixedDelay = 20000000)
+        public void testFixedDelayTaskForModify() {}
+
+        @Scheduled(fixedDelay = 2000000000)
+        public void testFixedDelayTaskForExecute() {
+            fixedDelayFlag = true;
+        }
+
+        // FixedRate tasks
+        @Scheduled(fixedRate = 100, initialDelay = 50)
+        public void testFixedRateTask() {
+            fixedRateFlag = true;
+        }
+
+        @Scheduled(fixedRate = 20000000)
+        public void testFixedRateTaskForModify() {}
+
+        @Scheduled(fixedRate = 2000000000)
+        public void testFixedRateTaskForExecute() {
+            fixedRateFlag = true;
+        }
+
+        // Custom task
+        @Override
+        public void configureTasks(ScheduledTaskRegistrar registrar) {
+            registrar.addTriggerTask(new CustomTestTask(), new CustomTestTrigger());
+        }
+
+        static class CustomTestTask implements Runnable {
+            @Override
+            public void run() {
+                customTaskFlag = true;
+            }
+
+            @Override
+            public String toString() {
+                return CUSTOM_TASK_ID;
+            }
+        }
+
+        static class CustomTestTrigger implements Trigger {
+            @Override
+            @Nullable
+            public Instant nextExecution(@NonNull TriggerContext triggerContext) {
+                return Instant.now().plusMillis(100);
+            }
+
+            @Override
+            public String toString() {
+                return CUSTOM_TRIGGER;
+            }
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskServiceTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskServiceTest.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.scheduled;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.TriggerContext;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.config.IntervalTask;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.scheduling.support.CronTrigger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ScheduledTaskService}
+ *
+ * @author Nikita Kirillov
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest
+@Import(ScheduledTaskServiceTest.ScheduledTaskServiceTestConfiguration.class)
+class ScheduledTaskServiceTest {
+
+    // Cron
+    private static final String CRON_TASK_ID = ScheduledTaskServiceTestConfiguration.class.getName() + ".testCronTask";
+    private static final String CRON_TASK_ID_FOR_MODIFY =
+            ScheduledTaskServiceTestConfiguration.class.getName() + ".testCronTaskForModify";
+
+    // FixedDelay
+    private static final String FIXED_DELAY_TASK_ID =
+            ScheduledTaskServiceTestConfiguration.class.getName() + ".testFixedDelayTask";
+    private static final String FIXED_DELAY_TASK_ID_FOR_MODIFY =
+            ScheduledTaskServiceTestConfiguration.class.getName() + ".testFixedDelayTaskForModify";
+
+    // FixedRate
+    private static final String FIXED_RATE_TASK_ID =
+            ScheduledTaskServiceTestConfiguration.class.getName() + ".testFixedRateTask";
+    private static final String FIXED_RATE_TASK_ID_FOR_MODIFY =
+            ScheduledTaskServiceTestConfiguration.class.getName() + ".testFixedRateTaskForModify";
+    private static final String FIXED_RATE_TASK_ID_FOR_EXECUTE =
+            ScheduledTaskServiceTestConfiguration.class.getName() + ".testFixedDelayTaskForExecute";
+
+    // Custom
+    private static final String CUSTOM_TASK_ID =
+            ScheduledTaskServiceTestConfiguration.class.getName() + ".testCustomTask";
+
+    @Autowired
+    private ScheduledTaskService taskService;
+
+    @Autowired
+    private ScheduledTasksRegistry taskRegistry;
+
+    private static volatile boolean cronFlag = false;
+
+    private static volatile boolean fixedDelayFlag = false;
+
+    private static volatile boolean fixedRateFlag = false;
+
+    private static volatile boolean fixedRateFlagForExecute = false;
+
+    private static volatile boolean customTaskFlag = false;
+
+    @Test
+    void shouldDisabledTask_testCronTask() throws InterruptedException {
+        String taskId = CRON_TASK_ID;
+
+        taskService.disableTask(taskId, true);
+        Thread.sleep(200);
+        cronFlag = false;
+        Thread.sleep(1200);
+
+        ManagedScheduledTask task = taskRegistry.find(taskId).orElseThrow();
+        assertThat(task.getFuture().isCancelled()).isTrue();
+    }
+
+    @Test
+    void shouldForceRescheduleEnabledTask_testCronTask() throws InterruptedException {
+        String taskId = CRON_TASK_ID;
+
+        taskService.disableTask(taskId, true);
+        Thread.sleep(200);
+        cronFlag = false;
+        Thread.sleep(1200);
+
+        ManagedScheduledTask task = taskRegistry.find(taskId).orElseThrow();
+        assertThat(task.getFuture().isCancelled()).isTrue();
+
+        taskService.enableTask(taskId);
+        Thread.sleep(200);
+
+        task = taskRegistry.find(taskId).orElseThrow();
+        assertThat(task.getFuture().isCancelled()).isFalse();
+    }
+
+    @Test
+    void shouldDisabledTask_testFixedDelayTask() throws InterruptedException {
+        String taskId = FIXED_DELAY_TASK_ID;
+
+        taskService.disableTask(taskId, false);
+        Thread.sleep(200);
+        fixedDelayFlag = false;
+        Thread.sleep(200);
+
+        ManagedScheduledTask task = taskRegistry.find(taskId).orElseThrow();
+        assertThat(task.getFuture().isCancelled()).isTrue();
+    }
+
+    @Test
+    void shouldForceRescheduleEnabledTask_testFixedDelayTask() throws InterruptedException {
+        String taskId = FIXED_DELAY_TASK_ID;
+
+        taskService.disableTask(taskId, true);
+        Thread.sleep(200);
+        fixedDelayFlag = false;
+
+        ManagedScheduledTask task = taskRegistry.find(taskId).orElseThrow();
+        assertThat(task.getFuture().isCancelled()).isTrue();
+
+        taskService.enableTask(taskId);
+        Thread.sleep(100);
+
+        task = taskRegistry.find(taskId).orElseThrow();
+        assertThat(task.getFuture().isCancelled()).isFalse();
+    }
+
+    @Test
+    void shouldDisabledTask_testFixedRateTask() throws InterruptedException {
+        String taskId = FIXED_RATE_TASK_ID;
+
+        taskService.disableTask(taskId, false);
+        Thread.sleep(200);
+        fixedRateFlag = false;
+        Thread.sleep(200);
+
+        ManagedScheduledTask task = taskRegistry.find(taskId).orElseThrow();
+        assertThat(task.getFuture().isCancelled()).isTrue();
+    }
+
+    @Test
+    void shouldForceRescheduleEnabledTask_testFixedRateTask() throws InterruptedException {
+        String taskId = FIXED_RATE_TASK_ID;
+
+        taskService.disableTask(taskId, true);
+        Thread.sleep(200);
+        fixedRateFlag = false;
+
+        ManagedScheduledTask task = taskRegistry.find(taskId).orElseThrow();
+        assertThat(task.getFuture().isCancelled()).isTrue();
+
+        taskService.enableTask(taskId);
+        Thread.sleep(200);
+
+        task = taskRegistry.find(taskId).orElseThrow();
+        assertThat(task.getFuture().isCancelled()).isFalse();
+    }
+
+    @Test
+    void shouldDisabledTask_testCustomTask() throws InterruptedException {
+        String taskId = CUSTOM_TASK_ID;
+
+        taskService.disableTask(taskId, false);
+        Thread.sleep(200);
+        customTaskFlag = false;
+        Thread.sleep(200);
+
+        ManagedScheduledTask task = taskRegistry.find(taskId).orElseThrow();
+        assertThat(task.getFuture().isCancelled()).isTrue();
+    }
+
+    @Test
+    void shouldForceRescheduleEnabledTask_testCustomTask() throws InterruptedException {
+        String taskId = CUSTOM_TASK_ID;
+
+        taskService.disableTask(taskId, true);
+        Thread.sleep(200);
+        customTaskFlag = false;
+
+        ManagedScheduledTask task = taskRegistry.find(taskId).orElseThrow();
+        assertThat(task.getFuture().isCancelled()).isTrue();
+
+        taskService.enableTask(taskId);
+        Thread.sleep(200);
+
+        task = taskRegistry.find(taskId).orElseThrow();
+        assertThat(task.getFuture().isCancelled()).isFalse();
+    }
+
+    @Test
+    void shouldModifyCronExpression_testCronTask() {
+        String newCronExpression = "*/5 * * * * *";
+
+        taskService.modifyCronExpression(CRON_TASK_ID_FOR_MODIFY, newCronExpression);
+
+        ManagedScheduledTask task = taskRegistry.find(CRON_TASK_ID_FOR_MODIFY).orElseThrow();
+        assertThat(((CronTrigger) task.getTrigger()).getExpression()).isEqualTo(newCronExpression);
+    }
+
+    @Test
+    void shouldModifyInterval_testFixedDelay() {
+        Duration newInterval = Duration.ofMillis(555555L);
+
+        taskService.modifyInterval(FIXED_DELAY_TASK_ID_FOR_MODIFY, newInterval);
+
+        ManagedScheduledTask task =
+                taskRegistry.find(FIXED_DELAY_TASK_ID_FOR_MODIFY).orElseThrow();
+        assertThat(((IntervalTask) task.getTask()).getIntervalDuration()).isEqualTo(newInterval);
+    }
+
+    @Test
+    void shouldModifyInterval_testFixedRate() {
+        Duration newInterval = Duration.ofMillis(777777L);
+
+        taskService.modifyInterval(FIXED_RATE_TASK_ID_FOR_MODIFY, newInterval);
+
+        ManagedScheduledTask task =
+                taskRegistry.find(FIXED_RATE_TASK_ID_FOR_MODIFY).orElseThrow();
+        assertThat(((IntervalTask) task.getTask()).getIntervalDuration()).isEqualTo(newInterval);
+    }
+
+    @Test
+    void shouldExecuteScheduledTask_testFixedRate() {
+        // when.
+        taskService.executeScheduledTask(FIXED_RATE_TASK_ID_FOR_EXECUTE);
+
+        // then task exists and was executed
+        taskRegistry.find(FIXED_RATE_TASK_ID_FOR_EXECUTE).orElseThrow();
+        assertThat(fixedRateFlagForExecute).isTrue();
+    }
+
+    @TestConfiguration
+    @EnableScheduling
+    static class ScheduledTaskServiceTestConfiguration implements SchedulingConfigurer {
+
+        @Bean
+        public TaskScheduler taskScheduler() {
+            return new ConcurrentTaskScheduler();
+        }
+
+        @Bean
+        public ScheduledTasksRegistry scheduledTaskRegistry(ScheduledAnnotationBeanPostProcessor processor) {
+            return new ScheduledTasksRegistry(List.of(processor));
+        }
+
+        @Bean
+        TaskRescheduler testTriggerBasedTaskRescheduler(TaskScheduler taskScheduler) {
+            return new TriggerBasedTaskRescheduler(taskScheduler);
+        }
+
+        @Bean
+        TaskRescheduler testIntervalBasedTaskRescheduler(TaskScheduler taskScheduler) {
+            return new IntervalBasedTaskRescheduler(taskScheduler);
+        }
+
+        @Bean
+        public ScheduledTaskService scheduledTaskService(
+                ScheduledTasksRegistry registry,
+                List<TaskRescheduler> taskReschedulers,
+                ThreadPoolTaskExecutor taskExecutor) {
+            return new ScheduledTaskService(registry, taskReschedulers, taskExecutor);
+        }
+
+        // Cron
+        @Scheduled(cron = "*/1 * * * * *")
+        public void testCronTask() {
+            cronFlag = true;
+        }
+
+        @Scheduled(cron = "*/2 * * * * *")
+        public void testCronTaskForModify() {}
+
+        // FixedDelay
+        @Scheduled(fixedDelay = 100)
+        public void testFixedDelayTask() {
+            fixedDelayFlag = true;
+        }
+
+        @Scheduled(fixedDelay = 200)
+        public void testFixedDelayTaskForModify() {}
+
+        // FixedRate
+        @Scheduled(fixedRate = 100, initialDelay = 50)
+        public void testFixedRateTask() {
+            fixedRateFlag = true;
+        }
+
+        @Scheduled(fixedRate = 200)
+        public void testFixedRateTaskForModify() {}
+
+        @Scheduled(fixedRate = 2000000000)
+        public void testFixedDelayTaskForExecute() {
+            fixedRateFlagForExecute = true;
+        }
+
+        // Custom
+        @Override
+        public void configureTasks(ScheduledTaskRegistrar registrar) {
+            registrar.addTriggerTask(new CustomTestTask(), new CustomTestTrigger());
+        }
+
+        static class CustomTestTask implements Runnable {
+            @Override
+            public void run() {
+                customTaskFlag = true;
+            }
+
+            @Override
+            public String toString() {
+                return CUSTOM_TASK_ID;
+            }
+        }
+
+        static class CustomTestTrigger implements Trigger {
+            @Override
+            @Nullable
+            public Instant nextExecution(@NonNull TriggerContext triggerContext) {
+                return Instant.now().plusMillis(100);
+            }
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistryTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistryTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.scheduled;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.lang.Nullable;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.TriggerContext;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.config.CronTask;
+import org.springframework.scheduling.config.FixedDelayTask;
+import org.springframework.scheduling.config.FixedRateTask;
+import org.springframework.scheduling.config.ScheduledTask;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.scheduling.config.TriggerTask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ScheduledTasksRegistry}
+ *
+ * @author Nikita Kirillov
+ */
+@SpringBootTest
+@Import(ScheduledTasksRegistryTest.ScheduledTaskRegistryTestConfiguration.class)
+class ScheduledTasksRegistryTest {
+
+    private static final String CRON_TASK_ID = ScheduledTaskRegistryTestConfiguration.class.getName() + ".testCronTask";
+    private static final String FIXED_DELAY_TASK_ID =
+            ScheduledTaskRegistryTestConfiguration.class.getName() + ".testFixedDelayTask";
+    private static final String FIXED_RATE_TASK_ID =
+            ScheduledTaskRegistryTestConfiguration.class.getName() + ".testFixedRateTask";
+    private static final String CUSTOM_TASK_ID =
+            ScheduledTaskRegistryTestConfiguration.class.getName() + ".testCustomTask";
+
+    @Autowired
+    private ScheduledTasksRegistry taskRegistry;
+
+    @Test
+    void shouldRegisterAllScheduledTasks() {
+        Collection<ManagedScheduledTask> registeredTasks = taskRegistry.getAll();
+
+        assertThat(registeredTasks).isNotNull().isNotEmpty().hasSize(4);
+
+        List<String> taskIds =
+                registeredTasks.stream().map(ManagedScheduledTask::getId).toList();
+
+        assertThat(taskIds)
+                .hasSize(4)
+                .allSatisfy(id -> assertThat(id).isNotBlank())
+                .containsExactlyInAnyOrder(CRON_TASK_ID, FIXED_DELAY_TASK_ID, FIXED_RATE_TASK_ID, CUSTOM_TASK_ID);
+
+        assertThat(registeredTasks)
+                .allSatisfy(task -> assertThat(task.getFuture().isCancelled()).isFalse());
+
+        taskIds.forEach(id -> assertThat(taskRegistry.find(id))
+                .isPresent()
+                .get()
+                .extracting(ManagedScheduledTask::getId)
+                .isEqualTo(id));
+
+        assertThat(taskRegistry.find("non-existent-task")).isEmpty();
+    }
+
+    @Test
+    void shouldHaveCorrectTaskTypes() {
+        Collection<ManagedScheduledTask> tasks = taskRegistry.getAll();
+
+        assertThat(tasks)
+                .hasSize(4)
+                .extracting(ManagedScheduledTask::getScheduledTask)
+                .extracting(ScheduledTask::getTask)
+                .satisfiesExactlyInAnyOrder(
+                        task -> assertThat(task).isInstanceOf(CronTask.class),
+                        task -> assertThat(task).isInstanceOf(FixedDelayTask.class),
+                        task -> assertThat(task).isInstanceOf(FixedRateTask.class),
+                        task -> assertThat(task).isInstanceOf(TriggerTask.class).isNotInstanceOf(CronTask.class));
+    }
+
+    @TestConfiguration
+    @EnableScheduling
+    static class ScheduledTaskRegistryTestConfiguration implements SchedulingConfigurer {
+
+        @Bean
+        public ScheduledTasksRegistry scheduledTaskRegistry(ScheduledAnnotationBeanPostProcessor processor) {
+            return new ScheduledTasksRegistry(List.of(processor));
+        }
+
+        @Scheduled(cron = "*/2 * * * * *")
+        public void testCronTask() {}
+
+        @Scheduled(fixedDelay = 2000)
+        public void testFixedDelayTask() {}
+
+        @Scheduled(fixedRate = 2000, initialDelay = 100)
+        public void testFixedRateTask() {}
+
+        @Override
+        public void configureTasks(ScheduledTaskRegistrar registrar) {
+            Runnable customTask = new Runnable() {
+                @Override
+                public void run() {
+                    executeCustomTask();
+                }
+
+                @Override
+                public String toString() {
+                    return CUSTOM_TASK_ID;
+                }
+            };
+            registrar.addTriggerTask(customTask, new CustomTrigger());
+        }
+
+        private void executeCustomTask() {}
+
+        static class CustomTrigger implements Trigger {
+            @Override
+            @Nullable
+            public Instant nextExecution(@NonNull TriggerContext triggerContext) {
+                return Instant.now().plusMillis(1000);
+            }
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpointTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.threaddump;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseEntity;
+
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link ThreadDumpManagementEndpoint}
+ *
+ * @author Sergey Cherkasov
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(JwtAuthTestConfiguration.class)
+public class ThreadDumpManagementEndpointTest {
+
+    @Autowired
+    private TestRestTemplateBuilder restTemplate;
+
+    @Test
+    void shouldEnableThreadContentionMonitoring() {
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+
+        // when.
+        restTemplate.asViewer().postForEntity("/actuator/axelix-thread-dump/enable", null, Void.class);
+
+        // then.
+        assertThat(threadMXBean.isThreadContentionMonitoringEnabled()).isTrue();
+    }
+
+    @Test
+    void shouldReceiveThreadDumpJson() {
+        // when.
+        ResponseEntity<String> response =
+                restTemplate.asViewer().getForEntity("/actuator/axelix-thread-dump", String.class);
+
+        // then.
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+    }
+
+    @Test
+    void shouldDisableThreadContentionMonitoring() {
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        threadMXBean.setThreadContentionMonitoringEnabled(true);
+
+        // when.
+        restTemplate.asViewer().postForEntity("/actuator/axelix-thread-dump/disable", null, Void.class);
+
+        // then.
+        assertThat(threadMXBean.isThreadContentionMonitoringEnabled()).isFalse();
+    }
+
+    @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-thread-dump")
+    void negativeAuthTests() {}
+
+    @TestConfiguration
+    static class ThreadDumpManagementEndpointTestConfiguration {
+
+        @Bean
+        public ThreadDumpContentionMonitoringManagement management() {
+            return new DefaultThreadDumpContentionMonitoringManagement();
+        }
+
+        @Bean
+        public ThreadDumpManagementEndpoint threadDumpManagementEndpoint(
+                ThreadDumpContentionMonitoringManagement management) {
+            return new ThreadDumpManagementEndpoint(management);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ProxyingDataSourceBeanPostProcessorTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ProxyingDataSourceBeanPostProcessorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link ProxyingDataSourceBeanPostProcessor}.
+ *
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest
+@Import(ProxyingDataSourceBeanPostProcessorTest.ProxyingDataSourceBeanPostProcessorTestConfiguration.class)
+class ProxyingDataSourceBeanPostProcessorTest {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private ProxyingDataSourceBeanPostProcessor subject;
+
+    @Test
+    void shouldWrapDataSourceWithProxyingDataSource() {
+        assertThat(dataSource).isInstanceOf(ProxyingDataSource.class);
+    }
+
+    @Test
+    void shouldNotWrapNonDataSourceBean() {
+        Object nonDataSourceBean = new Object();
+
+        Object result = subject.postProcessAfterInitialization(nonDataSourceBean, "someBean");
+        assertThat(result).isSameAs(nonDataSourceBean);
+    }
+
+    @Test
+    void shouldNotDoubleWrapAlreadyProxiedDataSource() {
+        ProxyingDataSource alreadyProxied = (ProxyingDataSource) dataSource;
+
+        Object result = subject.postProcessAfterInitialization(alreadyProxied, "dataSource");
+
+        assertThat(result).isSameAs(alreadyProxied);
+    }
+
+    @TestConfiguration
+    static class ProxyingDataSourceBeanPostProcessorTestConfiguration {
+
+        @Bean
+        public QueriesRecorder queriesRecorder() {
+            return new DefaultQueriesRecorder();
+        }
+
+        @Bean
+        public ProxyingDataSourceBeanPostProcessor proxyingDataSourceBeanPostProcessor(
+                QueriesRecorder queriesRecorder) {
+            return new ProxyingDataSourceBeanPostProcessor(queriesRecorder);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessorTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessorTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.Advisor;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link TransactionMonitoringBeanPostProcessor}.
+ *
+ * @author Nikita Kirillov
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest
+@Import(TransactionMonitoringBeanPostProcessorTest.TransactionMonitoringBeanPostProcessorTestConfiguration.class)
+class TransactionMonitoringBeanPostProcessorTest {
+
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    @Autowired
+    private PropagationTestHelper propagationTestHelper;
+
+    @Autowired
+    private PropagationTestService propagationTestService;
+
+    @Autowired
+    private TransactionMonitoringBeanPostProcessor transactionMonitoringBeanPostProcessor;
+
+    private Map<MethodClassKey, Propagation> propagationCache;
+
+    private List<Object> transactionalBeans;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setup() {
+        propagationCache = (Map<MethodClassKey, Propagation>)
+                ReflectionTestUtils.getField(transactionMonitoringBeanPostProcessor, "propagationCache");
+
+        transactionalBeans = List.of(propagationTestService, propagationTestHelper, ownerRepository);
+    }
+
+    @Test
+    void testServicesAreProxied() {
+        assertThat(AopUtils.isCglibProxy(propagationTestHelper)).isTrue();
+        assertThat(AopUtils.isCglibProxy(propagationTestService)).isTrue();
+
+        assertThat(AopUtils.isJdkDynamicProxy(propagationTestHelper)).isFalse();
+        assertThat(AopUtils.isJdkDynamicProxy(propagationTestService)).isFalse();
+    }
+
+    @Test
+    void testAllTransactionalBeansHaveMonitoringAdvisor() {
+        for (Object bean : transactionalBeans) {
+            List<Advisor> advisors = Arrays.asList(((Advised) bean).getAdvisors());
+
+            boolean hasMonitoringInterceptor = advisors.stream()
+                    .anyMatch(advisor -> advisor.getAdvice() instanceof TransactionMonitoringInterceptor);
+
+            assertThat(hasMonitoringInterceptor).isTrue();
+        }
+    }
+
+    @Test
+    void testCachesAreFilled() throws NoSuchMethodException {
+        assertThat(propagationCache).isNotEmpty();
+
+        Method testRequired = PropagationTestService.class.getDeclaredMethod("testRequired", String.class);
+        MethodClassKey key = new MethodClassKey(testRequired, PropagationTestService.class);
+
+        assertThat(propagationCache).containsKey(key);
+
+        Method testFromNonTransactional = PropagationTestHelper.class.getMethod("testMandatory", String.class);
+        key = new MethodClassKey(testFromNonTransactional, PropagationTestHelper.class);
+
+        assertThat(propagationCache).containsKey(key);
+    }
+
+    @TestConfiguration
+    @EnableJpaRepositories(basePackageClasses = OwnerRepository.class, considerNestedRepositories = true)
+    @EntityScan(basePackageClasses = Owner.class)
+    static class TransactionMonitoringBeanPostProcessorTestConfiguration {
+
+        @Bean
+        public TransactionStatsCollector transactionStatsCollector() {
+            return new DefaultTransactionStatsCollector(30);
+        }
+
+        @Bean
+        public TransactionMonitoringBeanPostProcessor transactionMonitoringBeanPostProcessor(
+                TransactionStatsCollector transactionStatsCollector,
+                QueriesRecorder queriesCollector,
+                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
+            return new TransactionMonitoringBeanPostProcessor(
+                    transactionStatsCollector, queriesCollector, axelixMetricsPublisherObjectProvider);
+        }
+
+        @Bean
+        public QueriesRecorder queriesStatsCollector() {
+            return new DefaultQueriesRecorder();
+        }
+
+        @Bean
+        public ProxyingDataSourceBeanPostProcessor transactionMonitoringDataSourceBeanPostProcessor(
+                QueriesRecorder queriesCollector) {
+            return new ProxyingDataSourceBeanPostProcessor(queriesCollector);
+        }
+
+        @Bean
+        public PropagationTestHelper propagationTestHelper(
+                OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
+            return new PropagationTestHelper(ownerRepository, self);
+        }
+
+        @Bean
+        public PropagationTestService propagationTestService(
+                OwnerRepository ownerRepository, PropagationTestHelper helper) {
+            return new PropagationTestService(ownerRepository, helper);
+        }
+
+        @Bean
+        public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
+            return new DefaultAxelixMetricsPublisher(meterRegistry);
+        }
+    }
+
+    @Entity
+    static class Owner {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+
+        private String lastName;
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+    }
+
+    interface OwnerRepository extends JpaRepository<Owner, Long> {
+
+        @Transactional
+        default Owner findByLastName(String lastName) {
+            return new Owner();
+        }
+
+        @Transactional(propagation = Propagation.SUPPORTS)
+        default List<Owner> findAll() {
+            return List.of(new Owner());
+        }
+    }
+
+    static class PropagationTestHelper {
+
+        private final OwnerRepository ownerRepository;
+        private final PropagationTestHelper self;
+
+        public PropagationTestHelper(OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
+            this.ownerRepository = ownerRepository;
+            this.self = self;
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void testRequiresNew(String lastName) {
+            ownerRepository.findByLastName(lastName);
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void testNestedRequiresNew() {
+            ownerRepository.findByLastName("Franklin");
+        }
+
+        @Transactional(propagation = Propagation.MANDATORY)
+        public void testMandatory(String lastName) {
+            ownerRepository.findByLastName(lastName);
+        }
+    }
+
+    static class PropagationTestService {
+
+        private final OwnerRepository ownerRepository;
+        private final PropagationTestHelper helperService;
+
+        public PropagationTestService(OwnerRepository ownerRepository, PropagationTestHelper helperService) {
+            this.ownerRepository = ownerRepository;
+            this.helperService = helperService;
+        }
+
+        @Transactional(propagation = Propagation.REQUIRED)
+        void testRequired(String lastName) {
+            ownerRepository.findByLastName(lastName);
+            helperService.testNestedRequiresNew();
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
@@ -1,0 +1,769 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import com.jayway.jsonpath.JsonPath;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest.TransactionMonitoringEndpointTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
+
+import static com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricNames.TRANSACTION_DURATION;
+import static com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricNames.TRANSACTION_QUERIES;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Integration test for {@link TransactionMonitoringEndpoint}
+ *
+ * @author Nikita Kirillov
+ * @author Sergey Cherkasov
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"management.endpoints.web.exposure.include=axelix-transactions-monitoring"})
+@Import({TransactionMonitoringEndpointTestConfiguration.class, JwtAuthTestConfiguration.class})
+class TransactionMonitoringEndpointTest {
+
+    private final String expectedClassName = PropagationTestHelper.class.getSimpleName();
+
+    @Autowired
+    private TestRestTemplateBuilder restTemplate;
+
+    @Autowired
+    private PropagationTestHelper propagationTestHelper;
+
+    @Autowired
+    private TransactionStatsCollector transactionStatsCollector;
+
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    @BeforeEach
+    void cleanUp() {
+        transactionStatsCollector.clearAllStats();
+        meterRegistry.clear();
+    }
+
+    @Test
+    void shouldReturnsStatsAfterTransactionExecution() {
+        propagationTestHelper.saveRequiresNew("Smith");
+
+        String responseBody = getMonitoringResponse();
+
+        assertThatJson(responseBody)
+                .isEqualTo(
+                        // language=json
+                        """
+                {
+                  "entrypoints" : [ {
+                    "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+                    "methodName" : "saveRequiresNew",
+                    "executions" : [ {
+                      "startTimestampMs" : "#{json-unit.ignore}",
+                      "endTimestampMs" : "#{json-unit.ignore}",
+                      "queries" : [ {
+                        "sql" : "insert into owner (last_name,id) values (?,default)",
+                        "startTimestampMs" : "#{json-unit.ignore}",
+                        "endTimestampMs" : "#{json-unit.ignore}"
+                      } ]
+                    } ],
+                    "executionStats" : {
+                      "averageDurationMs" : "#{json-unit.ignore}",
+                      "maxDurationMs" : "#{json-unit.ignore}",
+                      "medianDurationMs" : "#{json-unit.ignore}"
+                    }
+                  } ]
+                }""");
+
+        Long executionStartTimestampMs = JsonPath.read(responseBody, "$.entrypoints[0].executions[0].startTimestampMs");
+        Long executionEndTimestampMs = JsonPath.read(responseBody, "$.entrypoints[0].executions[0].endTimestampMs");
+        Long queryStartTimestampMs =
+                JsonPath.read(responseBody, "$.entrypoints[0].executions[0].queries[0].startTimestampMs");
+        Long queryEndTimestampMs =
+                JsonPath.read(responseBody, "$.entrypoints[0].executions[0].queries[0].endTimestampMs");
+
+        assertThat(executionStartTimestampMs).isLessThanOrEqualTo(executionEndTimestampMs);
+        assertThat(queryStartTimestampMs).isLessThanOrEqualTo(queryEndTimestampMs);
+        assertThat(queryStartTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
+        assertThat(queryEndTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
+
+        assertThatJson(responseBody).node("entrypoints[0].executionStats").isObject();
+        assertThatJson(responseBody)
+                .node("entrypoints[0].executionStats.averageDurationMs")
+                .isNumber();
+        assertThatJson(responseBody)
+                .node("entrypoints[0].executionStats.maxDurationMs")
+                .isNumber();
+        assertThatJson(responseBody)
+                .node("entrypoints[0].executionStats.medianDurationMs")
+                .isNumber();
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "saveRequiresNew", "success", 1);
+    }
+
+    @Test
+    void shouldClearsAllTransactionMonitoringStats() {
+        for (int i = 0; i < 3; i++) {
+            propagationTestHelper.saveRequiresNew("Johnson");
+        }
+
+        var allStats = transactionStatsCollector.getAllStats();
+
+        assertThat(allStats.size()).isGreaterThan(0);
+
+        ResponseEntity<Void> deleteResponse = restTemplate
+                .asViewer()
+                .exchange("/actuator/axelix-transactions-monitoring", HttpMethod.DELETE, null, Void.class);
+
+        assertThat(deleteResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        allStats = transactionStatsCollector.getAllStats();
+        assertThat(allStats).isEmpty();
+    }
+
+    @Test
+    void shouldTrackMultipleQueriesInsideTransaction() {
+        propagationTestHelper.testSaveMultipleOwners();
+
+        String responseBody = getMonitoringResponse();
+
+        assertThatJson(responseBody)
+                .isEqualTo(
+                        // language=json
+                        """
+            {
+              "entrypoints" : [ {
+                "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+                "methodName" : "testSaveMultipleOwners",
+                "executions" : [ {
+                  "startTimestampMs" : "#{json-unit.ignore}",
+                  "endTimestampMs" : "#{json-unit.ignore}",
+                  "queries" : [ {
+                    "sql" : "insert into owner (last_name,id) values (?,default)",
+                    "startTimestampMs" : "#{json-unit.ignore}",
+                    "endTimestampMs" : "#{json-unit.ignore}"
+                  }, {
+                    "sql" : "insert into owner (last_name,id) values (?,default)",
+                    "startTimestampMs" : "#{json-unit.ignore}",
+                    "endTimestampMs" : "#{json-unit.ignore}"
+                  }, {
+                    "sql" : "insert into owner (last_name,id) values (?,default)",
+                    "startTimestampMs" : "#{json-unit.ignore}",
+                    "endTimestampMs" : "#{json-unit.ignore}"
+                  } ]
+                } ],
+                "executionStats" : {
+                  "averageDurationMs" : "#{json-unit.ignore}",
+                  "maxDurationMs" : "#{json-unit.ignore}",
+                  "medianDurationMs" : "#{json-unit.ignore}"
+                }
+              } ]
+            }
+            """);
+
+        Long executionStartTimestampMs = JsonPath.read(responseBody, "$.entrypoints[0].executions[0].startTimestampMs");
+        Long executionEndTimestampMs = JsonPath.read(responseBody, "$.entrypoints[0].executions[0].endTimestampMs");
+        List<Map<String, Number>> queries = JsonPath.read(responseBody, "$.entrypoints[0].executions[0].queries");
+
+        assertThat(executionStartTimestampMs).isLessThanOrEqualTo(executionEndTimestampMs);
+        assertThat(queries).isNotEmpty();
+
+        for (Map<String, Number> query : queries) {
+            Long queryStartTimestampMs = query.get("startTimestampMs").longValue();
+            Long queryEndTimestampMs = query.get("endTimestampMs").longValue();
+
+            assertThat(queryStartTimestampMs).isLessThanOrEqualTo(queryEndTimestampMs);
+            assertThat(queryStartTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
+            assertThat(queryEndTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
+        }
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "testSaveMultipleOwners", "success", 3);
+    }
+
+    @Test
+    void shouldTrackNPlusOneInsideTransaction() {
+        // given.
+        Owner owner = new Owner();
+        owner.addPet(new Pet("pet1", owner)).addPet(new Pet("pet2", owner)).addPet(new Pet("pet3", owner));
+
+        Owner save = ownerRepository.save(owner);
+
+        // (will cause N + 1)
+        propagationTestHelper.findOwnerById(save.getId());
+
+        // when.
+        String responseBody = getMonitoringResponse();
+
+        // then.
+        assertThatJson(responseBody)
+                .isEqualTo(
+                        // language=json
+                        """
+                {
+                  "entrypoints" : [ {
+                    "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+                    "methodName" : "findOwnerById",
+                    "executions" : [ {
+                      "startTimestampMs" : "#{json-unit.ignore}",
+                      "endTimestampMs" : "#{json-unit.ignore}",
+                      "queries" : [ {
+                        "sql" : "select o1_0.id,o1_0.last_name from owner o1_0 where o1_0.id=?",
+                        "startTimestampMs" : "#{json-unit.ignore}",
+                        "endTimestampMs" : "#{json-unit.ignore}"
+                      }, {
+                        "sql" : "select p1_0.owner_id,p1_0.id,p1_0.name from pet p1_0 where p1_0.owner_id=?",
+                        "startTimestampMs" : "#{json-unit.ignore}",
+                        "endTimestampMs" : "#{json-unit.ignore}"
+                      } ]
+                    } ],
+                    "executionStats" : {
+                      "averageDurationMs" : "#{json-unit.ignore}",
+                      "maxDurationMs" : "#{json-unit.ignore}",
+                      "medianDurationMs" : "#{json-unit.ignore}"
+                    }
+                  } ]
+                }
+                """);
+
+        Long executionStartTimestampMs = JsonPath.read(responseBody, "$.entrypoints[0].executions[0].startTimestampMs");
+        Long executionEndTimestampMs = JsonPath.read(responseBody, "$.entrypoints[0].executions[0].endTimestampMs");
+        List<Map<String, Number>> queries = JsonPath.read(responseBody, "$.entrypoints[0].executions[0].queries");
+
+        assertThat(executionStartTimestampMs).isLessThanOrEqualTo(executionEndTimestampMs);
+        assertThat(queries).isNotEmpty();
+
+        for (Map<String, Number> query : queries) {
+            Long queryStartTimestampMs = query.get("startTimestampMs").longValue();
+            Long queryEndTimestampMs = query.get("endTimestampMs").longValue();
+
+            assertThat(queryStartTimestampMs).isLessThanOrEqualTo(queryEndTimestampMs);
+            assertThat(queryStartTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
+            assertThat(queryEndTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
+        }
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "findOwnerById", "success", 2);
+    }
+
+    @Test
+    void shouldTrackHibernateOnMerge() {
+        // given.
+        Owner owner = new Owner();
+        Owner saved = ownerRepository.save(owner);
+        saved.setLastName("newLastName");
+
+        // when. (will cause entityManager.merge)
+        propagationTestHelper.updateOwner(saved);
+
+        String responseBody = getMonitoringResponse();
+
+        // then.
+        assertThatJson(responseBody)
+                .isEqualTo(
+                        // language=json
+                        """
+            {
+              "entrypoints" : [ {
+                "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+                "methodName" : "updateOwner",
+                "executions" : [ {
+                  "startTimestampMs" : "#{json-unit.ignore}",
+                  "endTimestampMs" : "#{json-unit.ignore}",
+                  "queries" : [ {
+                    "sql" : "select o1_0.id,o1_0.last_name from owner o1_0 where o1_0.id=?",
+                    "startTimestampMs" : "#{json-unit.ignore}",
+                    "endTimestampMs" : "#{json-unit.ignore}"
+                  }, {
+                    "sql" : "update owner set last_name=? where id=?",
+                    "startTimestampMs" : "#{json-unit.ignore}",
+                    "endTimestampMs" : "#{json-unit.ignore}"
+                  } ]
+                } ],
+                "executionStats" : {
+                  "averageDurationMs" : "#{json-unit.ignore}",
+                  "maxDurationMs" : "#{json-unit.ignore}",
+                  "medianDurationMs" : "#{json-unit.ignore}"
+                }
+              } ]
+            }
+            """);
+
+        Long executionStartTimestampMs = JsonPath.read(responseBody, "$.entrypoints[0].executions[0].startTimestampMs");
+        Long executionEndTimestampMs = JsonPath.read(responseBody, "$.entrypoints[0].executions[0].endTimestampMs");
+        List<Map<String, Number>> queries = JsonPath.read(responseBody, "$.entrypoints[0].executions[0].queries");
+
+        assertThat(executionStartTimestampMs).isLessThanOrEqualTo(executionEndTimestampMs);
+        assertThat(queries).isNotEmpty();
+
+        for (Map<String, Number> query : queries) {
+            Long queryStartTimestampMs = query.get("startTimestampMs").longValue();
+            Long queryEndTimestampMs = query.get("endTimestampMs").longValue();
+
+            assertThat(queryStartTimestampMs).isLessThanOrEqualTo(queryEndTimestampMs);
+            assertThat(queryStartTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
+            assertThat(queryEndTimestampMs).isBetween(executionStartTimestampMs, executionEndTimestampMs);
+        }
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "updateOwner", "success", 2);
+    }
+
+    @Test
+    void rollbackScenarioIsMonitored() {
+        // given.
+        assertThatThrownBy(() -> propagationTestHelper.testRollbackScenario("Rodriquez"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Test rollback");
+
+        // when.
+        String responseBody = getMonitoringResponse();
+
+        // then.
+        assertThatJson(responseBody)
+                .isEqualTo(
+                        // language=json
+                        """
+                {
+                  "entrypoints" : [ {
+                    "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+                    "methodName" : "testRollbackScenario",
+                    "executions" : [ {
+                      "startTimestampMs" : "#{json-unit.ignore}",
+                      "endTimestampMs" : "#{json-unit.ignore}",
+                      "queries" : [ {
+                        "sql" : "select o1_0.id,o1_0.last_name from owner o1_0 where o1_0.last_name=?",
+                        "startTimestampMs" : "#{json-unit.ignore}",
+                        "endTimestampMs" : "#{json-unit.ignore}"
+                      } ]
+                    } ],
+                    "executionStats" : {
+                      "averageDurationMs" : "#{json-unit.ignore}",
+                      "maxDurationMs" : "#{json-unit.ignore}",
+                      "medianDurationMs" : "#{json-unit.ignore}"
+                    }
+                  } ]
+                }
+            """);
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "testRollbackScenario", "error", 1);
+    }
+
+    @Test
+    void nestedRequiresNewPropagationIsMonitoredSeparately() {
+        // given.
+        propagationTestHelper.outerRequiredMethod("ParentOwner");
+
+        // when.
+        String responseBody = getMonitoringResponse();
+
+        // then.
+        assertThatJson(responseBody)
+                .when(IGNORING_ARRAY_ORDER)
+                .isEqualTo(
+                        // language=json
+                        """
+        {
+          "entrypoints" : [
+            {
+              "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+              "methodName" : "saveRequiresNew",
+              "executions" : [ {
+                "startTimestampMs" : "#{json-unit.ignore}",
+                "endTimestampMs" : "#{json-unit.ignore}",
+                "queries" : [
+                  {
+                    "sql" : "insert into owner (last_name,id) values (?,default)",
+                    "startTimestampMs" : "#{json-unit.ignore}",
+                    "endTimestampMs" : "#{json-unit.ignore}"
+                  }
+                ]
+              } ],
+              "executionStats" : {
+                "averageDurationMs" : "#{json-unit.ignore}",
+                "maxDurationMs" : "#{json-unit.ignore}",
+                "medianDurationMs" : "#{json-unit.ignore}"
+              }
+            },
+            {
+              "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+              "methodName" : "outerRequiredMethod",
+              "executions" : [ {
+                "startTimestampMs" : "#{json-unit.ignore}",
+                "endTimestampMs" : "#{json-unit.ignore}",
+                "queries" : [
+                  {
+                    "sql" : "insert into owner (last_name,id) values (?,default)",
+                    "startTimestampMs" : "#{json-unit.ignore}",
+                    "endTimestampMs" : "#{json-unit.ignore}"
+                  },
+                  {
+                    "sql" : "insert into owner (last_name,id) values (?,default)",
+                    "startTimestampMs" : "#{json-unit.ignore}",
+                    "endTimestampMs" : "#{json-unit.ignore}"
+                  }
+                ]
+              } ],
+              "executionStats" : {
+                "averageDurationMs" : "#{json-unit.ignore}",
+                "maxDurationMs" : "#{json-unit.ignore}",
+                "medianDurationMs" : "#{json-unit.ignore}"
+              }
+            }
+          ]
+        }
+    """);
+    }
+
+    @Test
+    void nestedPropagationIsMonitored() {
+        // given.
+        propagationTestHelper.testNested();
+
+        // when.
+        String responseBody = getMonitoringResponse();
+
+        // then.
+        assertThatJson(responseBody)
+                .isEqualTo(
+                        // language=json
+                        """
+        {
+          "entrypoints" : [ {
+            "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+            "methodName" : "testNested",
+            "executions" : [ {
+              "startTimestampMs" : "#{json-unit.ignore}",
+              "endTimestampMs" : "#{json-unit.ignore}",
+              "queries" : [ {
+                "sql" : "select o1_0.id,o1_0.last_name from owner o1_0 where o1_0.last_name=?",
+                "startTimestampMs" : "#{json-unit.ignore}",
+                "endTimestampMs" : "#{json-unit.ignore}"
+              } ]
+            } ],
+            "executionStats" : {
+              "averageDurationMs" : "#{json-unit.ignore}",
+              "maxDurationMs" : "#{json-unit.ignore}",
+              "medianDurationMs" : "#{json-unit.ignore}"
+            }
+          } ]
+        }
+    """);
+
+        // and then. Verify that metrics were successfully published to MeterRegistry
+        checkMeterRegistry(expectedClassName, "testNested", "success", 1);
+    }
+
+    @Test
+    @Transactional
+    void supportsPropagationWithExistingTransactionShouldNotOpenATransaction() {
+        // given.
+        propagationTestHelper.testSupports("Rodriquez");
+
+        // when.
+        String responseBody = getMonitoringResponse();
+
+        // then.
+        assertThatJson(responseBody).node("entrypoints").isArray().isEmpty();
+    }
+
+    @Test
+    void supportsWithoutTransactionIsNotMonitored() {
+        // given.
+        propagationTestHelper.testSupportsWithoutTransaction();
+
+        // when.
+        String responseBody = getMonitoringResponse();
+
+        // then.
+        assertThatJson(responseBody).node("entrypoints").isArray().isEmpty();
+    }
+
+    private void checkMeterRegistry(
+            String expectedClassName, String expectedMethodName, String status, int expectedQueryCount) {
+        // given when. Verify Transaction Duration Timer
+        Timer transactionTimer = meterRegistry
+                .find(TRANSACTION_DURATION)
+                .tag("class", expectedClassName)
+                .tag("method", expectedMethodName)
+                .tag("status", status)
+                .timer();
+
+        // then.
+        assertThat(transactionTimer).isNotNull();
+        assertThat(transactionTimer.count()).isEqualTo(1);
+        assertThat(transactionTimer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+
+        // given when. Verify SQL Queries Counter
+        Counter queriesCounter = meterRegistry
+                .find(TRANSACTION_QUERIES)
+                .tag("class", expectedClassName)
+                .tag("method", expectedMethodName)
+                .counter();
+
+        // then.
+        assertThat(queriesCounter).isNotNull();
+        assertThat(queriesCounter.count()).isEqualTo(expectedQueryCount);
+    }
+
+    @ProtectedEndpointTests(
+            method = com.axelixlabs.axelix.common.domain.http.HttpMethod.GET,
+            path = "/actuator/axelix-transactions-monitoring")
+    void negativeAuthTests() {}
+
+    private String getMonitoringResponse() {
+        ResponseEntity<String> response =
+                restTemplate.asViewer().getForEntity("/actuator/axelix-transactions-monitoring", String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        return response.getBody();
+    }
+
+    @TestConfiguration
+    @EnableJpaRepositories(basePackageClasses = OwnerRepository.class, considerNestedRepositories = true)
+    @EntityScan(basePackageClasses = {Owner.class, Pet.class})
+    static class TransactionMonitoringEndpointTestConfiguration {
+
+        @Bean
+        public TransactionMonitoringEndpoint transactionMonitoringEndpoint(
+                TransactionMonitoringService transactionMonitoringService) {
+            return new TransactionMonitoringEndpoint(transactionMonitoringService);
+        }
+
+        @Bean
+        public TransactionMonitoringService transactionMonitoringService(
+                TransactionStatsCollector transactionStatsCollector) {
+            return new DefaultTransactionMonitoringService(transactionStatsCollector);
+        }
+
+        @Bean
+        public TransactionStatsCollector transactionStatsCollector() {
+            return new DefaultTransactionStatsCollector(30);
+        }
+
+        @Bean
+        public TransactionMonitoringBeanPostProcessor transactionMonitoringBeanPostProcessor(
+                TransactionStatsCollector transactionStatsCollector,
+                QueriesRecorder queriesCollector,
+                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
+            return new TransactionMonitoringBeanPostProcessor(
+                    transactionStatsCollector, queriesCollector, axelixMetricsPublisherObjectProvider);
+        }
+
+        @Bean
+        public QueriesRecorder queriesStatsCollector() {
+            return new DefaultQueriesRecorder();
+        }
+
+        @Bean
+        public ProxyingDataSourceBeanPostProcessor transactionMonitoringDataSourceBeanPostProcessor(
+                QueriesRecorder queriesCollector) {
+            return new ProxyingDataSourceBeanPostProcessor(queriesCollector);
+        }
+
+        @Bean
+        public PropagationTestHelper propagationTestHelper(
+                OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
+            return new PropagationTestHelper(ownerRepository, self);
+        }
+
+        @Bean
+        public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
+            return new DefaultAxelixMetricsPublisher(meterRegistry);
+        }
+    }
+
+    @Entity
+    @Table(name = "owner")
+    static class Owner {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+
+        private String lastName;
+
+        @OneToMany(mappedBy = "owner", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+        private List<Pet> pets = new ArrayList<>();
+
+        public List<Pet> getPets() {
+            return pets;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public Owner setLastName(String lastName) {
+            this.lastName = lastName;
+            return this;
+        }
+
+        public Owner addPet(Pet pet) {
+            this.pets.add(pet);
+            return this;
+        }
+    }
+
+    @Entity
+    @Table(name = "pet")
+    static class Pet {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+
+        private String name;
+
+        @ManyToOne
+        @JoinColumn(name = "owner_id")
+        private Owner owner;
+
+        public Pet() {}
+
+        public Pet(String name, Owner owner) {
+            this.name = name;
+            this.owner = owner;
+        }
+    }
+
+    interface OwnerRepository extends JpaRepository<Owner, Long> {
+
+        @Transactional
+        Owner findByLastName(String lastName);
+
+        @Transactional(propagation = Propagation.SUPPORTS)
+        default List<Owner> findAll() {
+            return List.of(new Owner());
+        }
+    }
+
+    static class PropagationTestHelper {
+
+        private final OwnerRepository ownerRepository;
+        private final PropagationTestHelper self;
+
+        public PropagationTestHelper(OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
+            this.ownerRepository = ownerRepository;
+            this.self = self;
+        }
+
+        // IMPORTANT: Calling via 'self' proxy is required to properly test the REQUIRED -> REQUIRES_NEW stack behavior.
+        @Transactional(propagation = Propagation.REQUIRED)
+        public void outerRequiredMethod(String outerName) {
+            ownerRepository.save(new Owner().setLastName(outerName));
+
+            self.saveRequiresNew("SomeName");
+
+            ownerRepository.save(new Owner().setLastName(outerName));
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void saveRequiresNew(String lastName) {
+            ownerRepository.save(new Owner().setLastName(lastName));
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void testSaveMultipleOwners() {
+            ownerRepository.saveAll(List.of(new Owner(), new Owner(), new Owner()));
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void updateOwner(Owner owner) {
+            // will cause entityManager.merge --> new SELECT, since Owner has an id
+            ownerRepository.save(owner);
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void findOwnerById(Long id) {
+            Owner owner = ownerRepository.findById(id).orElseThrow();
+            owner.getPets().size(); // will cause n + 1
+        }
+
+        @Transactional(propagation = Propagation.NESTED)
+        public void testNested() {
+            ownerRepository.findByLastName("Schroeder");
+        }
+
+        @Transactional(propagation = Propagation.SUPPORTS)
+        public void testSupports(String lastName) {
+            ownerRepository.findByLastName(lastName);
+        }
+
+        @Transactional(propagation = Propagation.SUPPORTS)
+        public void testSupportsWithoutTransaction() {}
+
+        @Transactional
+        public void testRollbackScenario(String lastName) {
+            ownerRepository.findByLastName(lastName);
+            throw new RuntimeException("Test rollback");
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/InvalidAuthScenario.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/InvalidAuthScenario.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.utils;
+
+import java.util.function.Function;
+
+import org.springframework.boot.resttestclient.TestRestTemplate;
+
+/**
+ * This enum contains a set of invalid authentication scenarios used to parameterize API integration tests.
+ *
+ * @author Sergey Cherkasov
+ * @author Mikhail Polivakha
+ */
+public enum InvalidAuthScenario {
+
+    // Request without a cookies with an authentication token.
+    NO_COOKIE(TestRestTemplateBuilder::withoutToken),
+
+    // Request with an expired authentication token.
+    EXPIRED_TOKEN(TestRestTemplateBuilder::withExpiredToken),
+
+    // Request with a malformed authentication token.
+    MALFORMED_TOKEN(TestRestTemplateBuilder::withMalformedToken);
+
+    /**
+     * Modifier function that applies an invalid authentication scenario
+     * to {@link TestRestTemplateBuilder} and return {@link TestRestTemplate}.
+     */
+    private final Function<TestRestTemplateBuilder, TestRestTemplate> modifier;
+
+    InvalidAuthScenario(Function<TestRestTemplateBuilder, TestRestTemplate> modifier) {
+        this.modifier = modifier;
+    }
+
+    public Function<TestRestTemplateBuilder, TestRestTemplate> getModifier() {
+        return modifier;
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/TestRestTemplateBuilder.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/TestRestTemplateBuilder.java
@@ -102,6 +102,22 @@ public class TestRestTemplateBuilder {
 
         return buildWithToken(malformedToken);
     }
+
+    public TestRestTemplate withExpiredTokenInAuthHeader() {
+        String expiredToken = generateExpiredToken();
+
+        return buildWithToken(expiredToken);
+    }
+
+    public TestRestTemplate withMalformedTokenInAuthHeader() {
+        String malformedToken = "malformed token";
+
+        return buildWithToken(malformedToken);
+    }
+
+    public TestRestTemplate withoutToken() {
+        return new TestRestTemplate(new RestTemplateBuilder().rootUri(HOST + testTomcatServerPort));
+    }
     // END: Bad token auth scenarios
 
     private TestRestTemplate buildWithToken(String expiredToken) {

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/BadAuthorityEndpointInvocationContext.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/BadAuthorityEndpointInvocationContext.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.utils.auth;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.axelixlabs.axelix.common.auth.core.Authority;
+import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
+import com.axelixlabs.axelix.common.auth.core.DefaultRole;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The {@link TestTemplateInvocationContext} that is specific for checking that any other authority except
+ * the provided in {@link ProtectedEndpointTests} will result in {@link HttpStatus#FORBIDDEN}.
+ *
+ * @author Mikhail Polivakha
+ */
+public class BadAuthorityEndpointInvocationContext implements TestTemplateInvocationContext {
+
+    private final DefaultAuthority accessAuthority;
+
+    /**
+     * @param accessAuthority  the authority that is required to access the given endpoint. The assumption is that for
+     *                         any given endpoint there will be just one authority required. Therefore, everything else,
+     *                         any other authority except this one MUST produce 403 from the backend.
+     */
+    public BadAuthorityEndpointInvocationContext(DefaultAuthority accessAuthority) {
+        this.accessAuthority = accessAuthority;
+    }
+
+    @Override
+    public @NonNull List<Extension> getAdditionalExtensions() {
+
+        EnumSet<DefaultAuthority> allTheOtherAuthorities = EnumSet.complementOf(EnumSet.of(accessAuthority));
+
+        return allTheOtherAuthorities.stream()
+                .map(defaultAuthority -> (Extension) new TestInvocationCallback(defaultAuthority))
+                .toList();
+    }
+
+    public static class TestInvocationCallback implements BeforeTestExecutionCallback {
+
+        private final Authority authority;
+
+        TestInvocationCallback(Authority authority) {
+            this.authority = authority;
+        }
+
+        @Override
+        public void beforeTestExecution(ExtensionContext context) {
+            ProtectedEndpointTests meta = context.getRequiredTestMethod().getAnnotation(ProtectedEndpointTests.class);
+
+            ApplicationContext applicationContext = SpringExtension.getApplicationContext(context);
+
+            TestRestTemplateBuilder testRestTemplateBuilder = applicationContext.getBean(TestRestTemplateBuilder.class);
+
+            TestRestTemplate integrationTestsRole =
+                    testRestTemplateBuilder.withRole(new DefaultRole("INTEGRATION_TESTS_ROLE", Set.of(authority)));
+
+            ResponseEntity<Void> result = integrationTestsRole.exchange(
+                    meta.path(),
+                    org.springframework.http.HttpMethod.valueOf(meta.method().name()),
+                    ProtectedEndpointRequestSupport.httpEntity(meta),
+                    Void.class);
+
+            assertThat(result.getStatusCode().value()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/BadTokenProtectedEndpointInvocationContext.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/BadTokenProtectedEndpointInvocationContext.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.utils.auth;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.axelixlabs.axelix.sbs.spring.core.utils.InvalidAuthScenario;
+import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link TestTemplateInvocationContext} for scenarios with bad token.
+ *
+ * @author Mikhail Polivakha
+ */
+public class BadTokenProtectedEndpointInvocationContext implements TestTemplateInvocationContext {
+
+    @Override
+    public List<Extension> getAdditionalExtensions() {
+        return Arrays.stream(InvalidAuthScenario.values())
+                .map(invalidAuthScenario -> (Extension) (BeforeTestExecutionCallback) context -> {
+                    ProtectedEndpointTests meta =
+                            context.getRequiredTestMethod().getAnnotation(ProtectedEndpointTests.class);
+
+                    ApplicationContext applicationContext = SpringExtension.getApplicationContext(context);
+
+                    TestRestTemplateBuilder testRestTemplateBuilder =
+                            applicationContext.getBean(TestRestTemplateBuilder.class);
+
+                    ResponseEntity<Void> result = invalidAuthScenario
+                            .getModifier()
+                            .apply(testRestTemplateBuilder)
+                            .exchange(
+                                    meta.path(),
+                                    HttpMethod.valueOf(meta.method().name()),
+                                    ProtectedEndpointRequestSupport.httpEntity(meta),
+                                    Void.class);
+
+                    assertThat(result.getStatusCode().value()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+                })
+                .toList();
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/ProtectedEndpointExtension.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/ProtectedEndpointExtension.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.utils.auth;
+
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+/**
+ * A specific extension for Junit 6 to provide {@link TestTemplateInvocationContext} instances for the given
+ * {@link ProtectedEndpointTests} methods.
+ *
+ * @author Mikhail Polivakha
+ */
+public class ProtectedEndpointExtension implements TestTemplateInvocationContextProvider {
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return context.getTestMethod()
+                .map(method -> method.isAnnotationPresent(ProtectedEndpointTests.class))
+                .orElse(false);
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+        Method requiredTestMethod = context.getRequiredTestMethod();
+
+        ProtectedEndpointTests annotation = requiredTestMethod.getAnnotation(ProtectedEndpointTests.class);
+
+        Stream<BadAuthorityEndpointInvocationContext> first;
+
+        if (annotation.requiredAuthority().length > 0) {
+            first = Stream.of(
+                    new BadAuthorityEndpointInvocationContext(annotation.requiredAuthority()[0]));
+        } else {
+            first = Stream.of();
+        }
+
+        return Stream.concat(
+                // authorization negative cases
+                first,
+
+                // authentication negative cases
+                Stream.of(new BadTokenProtectedEndpointInvocationContext()));
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/ProtectedEndpointRequestSupport.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/ProtectedEndpointRequestSupport.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.utils.auth;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+/**
+ * Builds {@link HttpEntity} instances for {@link ProtectedEndpointTests} metadata.
+ *
+ * @author Mikhail Polivakha
+ */
+final class ProtectedEndpointRequestSupport {
+
+    private ProtectedEndpointRequestSupport() {}
+
+    static HttpEntity<?> httpEntity(ProtectedEndpointTests meta) {
+        if (meta.jsonBody().isEmpty()) {
+            return HttpEntity.EMPTY;
+        }
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return new HttpEntity<>(meta.jsonBody(), headers);
+    }
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/ProtectedEndpointTests.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/ProtectedEndpointTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.utils.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
+import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+
+/**
+ * The annotation should be placed over the test class's method to signify that this API resource is supposed
+ * to be a protected one, i.e. we require the access token to access it with the correct privilege.
+ * <p>
+ * By placing this annotation on the test template method of the Junit test class, the {@link ProtectedEndpointExtension}
+ * listener will be invoked to create necessary {@link BadAuthorityEndpointInvocationContext invocation contexts}
+ * that are themselves going to check the negative authentication/authorization cases.
+ *
+ * @see TestTemplate
+ * @see ProtectedEndpointExtension
+ * @see BadAuthorityEndpointInvocationContext
+ *
+ * @author Mikhail Polivakha
+ */
+@Documented
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@TestTemplate
+@ExtendWith(ProtectedEndpointExtension.class)
+public @interface ProtectedEndpointTests {
+
+    /**
+     * Path to the endpoint (e.g. /api/external/...).
+     */
+    String path();
+
+    /**
+     * Http method of the endpoint.
+     */
+    HttpMethod method();
+
+    /**
+     * The authority that is required to access this endpoint. The size of array is expected to always be either
+     * zero or one, where zero means there is no authority to check for this endpoint.
+     */
+    DefaultAuthority[] requiredAuthority() default {};
+
+    /**
+     * Optional JSON request body for POST, PUT, or PATCH. When empty, the request is sent without a body (same as
+     * {@code null} {@link org.springframework.http.HttpEntity}).
+     */
+    String jsonBody() default "";
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/resources/META-INF/spring-configuration-metadata.json
+++ b/sbs/axelix-spring-boot-4-starter/src/test/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,37 @@
+{
+  "properties": [
+    {
+      "name": "prop.test.server.port",
+      "description": "Server HTTP port.",
+      "deprecation": {
+        "reason": "Just because.",
+        "replacement": "new.prop.test.server.port"
+      }
+    },
+    {
+      "name": "prop.test.server.port",
+      "description": "Server HTTP port.",
+      "deprecation": {
+        "reason": "Just because.",
+        "replacement": "new.prop.test.server.port"
+      }
+    },
+    {
+      "name": "custom.test.without.reason.property",
+      "deprecation": {
+        "replacement": "new.custom.test.without.reason.property"
+      }
+    },
+    {
+      "name": "custom.test.without.replacement.property",
+      "deprecation": {
+        "reason": "Marked for deletion."
+      }
+    },
+    {
+      "name": "prop.test.logging.level.root",
+      "description": "Logging level for root logger.",
+      "defaultValue": "INFO"
+    }
+  ]
+}

--- a/sbs/axelix-spring-boot-4-starter/src/test/resources/META-INF/spring.factories
+++ b/sbs/axelix-spring-boot-4-starter/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,4 @@
+org.springframework.test.context.TestExecutionListener=\
+digital.pragmatech.testing.SpringTestProfilerListener
+org.springframework.context.ApplicationContextInitializer=\
+digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer

--- a/sbs/axelix-spring-boot-4-starter/src/test/resources/application.yaml
+++ b/sbs/axelix-spring-boot-4-starter/src/test/resources/application.yaml
@@ -1,3 +1,48 @@
+axelix:
+  sbs:
+    auth:
+      jwt:
+        lifespan: 3h
+        algorithm: "HMAC512"
+        signing-key: "22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff"
+
+spring:
+  info:
+    git:
+      location: classpath:other/git.properties
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - env
+          - configprops
+          - axelix-loggers
+          - axelix-thread-dump
+          - axelix-gc
+          - axelix-metrics
+          - axelix-heap-dump
+          - axelix-caches
+          - axelix-scheduled
+          - axelix-metadata
+          - axelix-details
+          - axelix-conditions
+          - axelix-configprops
+          - axelix-beans
+          - axelix-env
+          - axelix-transactions-monitoring
+
 logging:
   level:
     org.apache.kafka: WARN

--- a/sbs/axelix-spring-boot-4-starter/src/test/resources/other/git.properties
+++ b/sbs/axelix-spring-boot-4-starter/src/test/resources/other/git.properties
@@ -1,0 +1,9 @@
+git.branch=main
+
+git.commit.id.abbrev=a8b0929
+git.commit.time=1761249922
+git.commit.user.email=mikhailpolivakha@email.com
+git.commit.user.name=Mikhail Polivakha
+
+git.build.time=2024-11-28T17\:37\:52+03\:00
+git.build.version=3.5.0-SNAPSHOT


### PR DESCRIPTION
The test-layer differences from the Spring Boot 3 starter are a couple of Boot 4 test-stack **API renames** (`@MockBean` → `@MockitoBean`, `@AutoConfigureTestRestTemplate`) plus a few **behavioral expectation changes** that come from upstream (newer Hibernate, sanitizer, GitProperties).

**Changed test classes (excluding pure import-relocation files):**
- `core/master/DefaultServiceMetadataAssemblerTest` — `@MockBean` → `@MockitoBean`
- `core/auth/JwtAuthorizationFilterTest` — `@AutoConfigureTestRestTemplate` now required
- `core/transactions/TransactionMonitoringEndpointTest` — SQL column order (newer Hibernate)
- `core/env/DefaultEnvironmentServiceTest` — sanitizer now emits `null`
- `core/master/CommitIdPluginShortBuildInfoProviderTest` — git build time → epoch millis
- `src/test/resources/application.yaml` — exposed endpoint-id list (test config)


 `@coderabbitai ignore`