### PR TITLE
GH-1103 Return empty body when no scheduled tasks and 400 on unknown trigger

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -52,7 +52,6 @@ import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskReschedul
  * @since 14.10.2025
  */
 @AutoConfiguration
-@ConditionalOnBean(ScheduledAnnotationBeanPostProcessor.class)
 @ConditionalOnAvailableEndpoint(endpoint = AxelixScheduledTasksEndpoint.class)
 public class ScheduledTaskManagementAutoConfiguration {
 
@@ -75,6 +74,7 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnBean(ScheduledAnnotationBeanPostProcessor.class)
     public TaskRescheduler intervalBasedTaskRescheduler(ObjectProvider<TaskScheduler> scheduler) {
         TaskScheduler taskScheduler = requireTaskScheduler(scheduler);
 
@@ -82,6 +82,7 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnBean(ScheduledAnnotationBeanPostProcessor.class)
     public TaskRescheduler triggerBasedTaskRescheduler(ObjectProvider<TaskScheduler> scheduler) {
         TaskScheduler taskScheduler = requireTaskScheduler(scheduler);
 

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -20,9 +20,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.jspecify.annotations.NonNull;
-
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -30,7 +27,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.config.ScheduledTaskHolder;
 
@@ -74,19 +70,15 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnBean(ScheduledAnnotationBeanPostProcessor.class)
-    public TaskRescheduler intervalBasedTaskRescheduler(ObjectProvider<TaskScheduler> scheduler) {
-        TaskScheduler taskScheduler = requireTaskScheduler(scheduler);
-
-        return new IntervalBasedTaskRescheduler(taskScheduler);
+    @ConditionalOnBean(TaskScheduler.class)
+    public TaskRescheduler intervalBasedTaskRescheduler(TaskScheduler scheduler) {
+        return new IntervalBasedTaskRescheduler(scheduler);
     }
 
     @Bean
-    @ConditionalOnBean(ScheduledAnnotationBeanPostProcessor.class)
-    public TaskRescheduler triggerBasedTaskRescheduler(ObjectProvider<TaskScheduler> scheduler) {
-        TaskScheduler taskScheduler = requireTaskScheduler(scheduler);
-
-        return new TriggerBasedTaskRescheduler(taskScheduler);
+    @ConditionalOnBean(TaskScheduler.class)
+    public TaskRescheduler triggerBasedTaskRescheduler(TaskScheduler scheduler) {
+        return new TriggerBasedTaskRescheduler(scheduler);
     }
 
     @Bean
@@ -100,21 +92,6 @@ public class ScheduledTaskManagementAutoConfiguration {
     @ConditionalOnMissingBean
     public ScheduledTasksAssembler scheduledTasksAssembler(ScheduledTasksRegistry scheduledTasksRegistry) {
         return new DefaultScheduledTasksAssembler(scheduledTasksRegistry);
-    }
-
-    @NonNull
-    private static TaskScheduler requireTaskScheduler(ObjectProvider<TaskScheduler> scheduler) {
-        TaskScheduler taskScheduler = scheduler.getIfAvailable();
-
-        // TODO: Should we throw an exception here? or an annotation above the class is enough
-        // @ConditionalOnBean({ScheduledAnnotationBeanPostProcessor.class, TaskScheduler.class})
-        if (taskScheduler == null) {
-            throw new NoSuchBeanDefinitionException(String.format(
-                    "For @Scheduled-related abilities to work, Axelix requires a bean of type %s that cannot be found",
-                    TaskScheduler.class.getName()));
-        }
-
-        return taskScheduler;
     }
 
     private static ThreadPoolTaskExecutor createThreadPoolExecutor() {

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpoint.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpoint.java
@@ -62,7 +62,7 @@ public class AxelixScheduledTasksEndpoint {
             taskService.enableTask(request.getTrigger());
             return ResponseEntity.noContent().build();
             // TODO: We need to revisit exception handling here
-        } catch (Exception e) {
+        } catch (ScheduledTaskNotFoundException e) {
             return ResponseEntity.badRequest().build();
         }
     }
@@ -75,7 +75,7 @@ public class AxelixScheduledTasksEndpoint {
             taskService.disableTask(request.getTrigger(), force);
             return ResponseEntity.noContent().build();
             // TODO: We need to revisit exception handling here
-        } catch (Exception e) {
+        } catch (ScheduledTaskNotFoundException e) {
             return ResponseEntity.badRequest().build();
         }
     }
@@ -97,7 +97,7 @@ public class AxelixScheduledTasksEndpoint {
             taskService.modifyInterval(request.getTrigger(), request.getInterval());
             return ResponseEntity.noContent().build();
             // TODO: We need to revisit exception handling here
-        } catch (Exception e) {
+        } catch (ScheduledTaskNotFoundException e) {
             return ResponseEntity.badRequest().build();
         }
     }
@@ -108,7 +108,7 @@ public class AxelixScheduledTasksEndpoint {
             taskService.executeScheduledTask(request.getTrigger());
             return ResponseEntity.noContent().build();
             // TODO: We need to revisit exception handling here
-        } catch (Exception e) {
+        } catch (ScheduledTaskNotFoundException e) {
             return ResponseEntity.badRequest().build();
         }
     }

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpoint.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpoint.java
@@ -58,17 +58,26 @@ public class AxelixScheduledTasksEndpoint {
 
     @PostMapping("/enable")
     public ResponseEntity<Void> enableTask(@RequestBody ScheduledTaskToggleRequest request) {
-        taskService.enableTask(request.getTrigger());
-        return ResponseEntity.noContent().build();
+        try {
+            taskService.enableTask(request.getTrigger());
+            return ResponseEntity.noContent().build();
+            // TODO: We need to revisit exception handling here
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @PostMapping("/disable")
     public ResponseEntity<Void> disableTask(
             @RequestBody ScheduledTaskToggleRequest request,
             @RequestParam(value = "force", defaultValue = "false") boolean force) {
-
-        taskService.disableTask(request.getTrigger(), force);
-        return ResponseEntity.noContent().build();
+        try {
+            taskService.disableTask(request.getTrigger(), force);
+            return ResponseEntity.noContent().build();
+            // TODO: We need to revisit exception handling here
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @PostMapping("/modify/cron-expression")
@@ -95,7 +104,12 @@ public class AxelixScheduledTasksEndpoint {
 
     @PostMapping("/execute")
     public ResponseEntity<Void> executeScheduledTask(@RequestBody ScheduledTaskExecuteRequest request) {
-        taskService.executeScheduledTask(request.getTrigger());
-        return ResponseEntity.noContent().build();
+        try {
+            taskService.executeScheduledTask(request.getTrigger());
+            return ResponseEntity.noContent().build();
+            // TODO: We need to revisit exception handling here
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskService.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskService.java
@@ -173,6 +173,7 @@ public final class ScheduledTaskService {
 
         } catch (ScheduledTaskNotFoundException e) {
             log.warn("Task '{}' not found, cannot run now", taskId, e);
+            throw e;
         }
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -97,8 +97,6 @@ class ScheduledTaskManagementAutoConfigurationTest {
 
                     // no scheduling -> reschedulers are not created
                     assertThat(context).getBeans(TaskRescheduler.class).isEmpty();
-                    assertThat(context).doesNotHaveBean(IntervalBasedTaskRescheduler.class);
-                    assertThat(context).doesNotHaveBean(TriggerBasedTaskRescheduler.class);
                 });
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -84,15 +84,21 @@ class ScheduledTaskManagementAutoConfigurationTest {
     }
 
     @Test
-    void shouldNotActivateAutoConfiguration_whenEndpointDisabled() {
+    void shouldActivateWithoutReschedulers_whenSchedulingNotEnabled() {
         new ApplicationContextRunner()
                 .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
                 .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
                 .run(context -> {
-                    assertThat(context).doesNotHaveBean(ScheduledTaskManagementAutoConfiguration.class);
-                    assertThat(context).doesNotHaveBean(ScheduledTasksRegistry.class);
-                    assertThat(context).doesNotHaveBean(ScheduledTaskService.class);
-                    assertThat(context).doesNotHaveBean(AxelixScheduledTasksEndpoint.class);
+                    // read path is available even without @EnableScheduling
+                    assertThat(context).hasSingleBean(ScheduledTasksRegistry.class);
+                    assertThat(context).hasSingleBean(ScheduledTaskService.class);
+                    assertThat(context).hasSingleBean(ScheduledTasksAssembler.class);
+                    assertThat(context).hasSingleBean(AxelixScheduledTasksEndpoint.class);
+
+                    // no scheduling -> reschedulers are not created
+                    assertThat(context).getBeans(TaskRescheduler.class).isEmpty();
+                    assertThat(context).doesNotHaveBean(IntervalBasedTaskRescheduler.class);
+                    assertThat(context).doesNotHaveBean(TriggerBasedTaskRescheduler.class);
                 });
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpointTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpointTest.java
@@ -101,6 +101,8 @@ class AxelixScheduledTasksEndpointTest {
 
     private static final String CUSTOM_TRIGGER = "CustomTestTrigger";
 
+    private static final String NON_EXISTENT_TASK_ID = "com.example.NonExistentTask.doWork";
+
     private static volatile boolean cronFlag = false;
 
     private static volatile boolean fixedDelayFlag = false;
@@ -338,7 +340,7 @@ class AxelixScheduledTasksEndpointTest {
     void shouldReturnBadRequest_modifyIntervalForFixedDelay() {
         // language=json
         String request = String.format(
-                "{\n" + "  \"trigger\" : \"%s\",\n" + "  \"cronExpression\": \"invalid value\"\n" + "}",
+                "{\n" + "  \"trigger\" : \"%s\",\n" + "  \"interval\": \"invalid value\"\n" + "}",
                 FIXED_DELAY_TASK_ID_FOR_MODIFY);
 
         ResponseEntity<Void> response = restTemplate
@@ -372,7 +374,7 @@ class AxelixScheduledTasksEndpointTest {
     void shouldReturnBadRequest_modifyIntervalForFixedRate() {
         // language=json
         String request = String.format(
-                "{\n" + "  \"trigger\" : \"%s\",\n" + "  \"cronExpression\": \"invalid value\"\n" + "}",
+                "{\n" + "  \"trigger\" : \"%s\",\n" + "  \"interval\": \"invalid value\"\n" + "}",
                 FIXED_RATE_TASK_ID_FOR_MODIFY);
 
         ResponseEntity<Void> response = restTemplate
@@ -416,6 +418,73 @@ class AxelixScheduledTasksEndpointTest {
             assertThatJson(task).node("enabled").isEqualTo(true);
         });
         assertThat(fixedRateFlag).isTrue();
+    }
+
+    @Test
+    void shouldReturnBadRequest_enableForNonExistentTask() {
+        // language=json
+        String request = String.format("{\n" + "  \"trigger\": \"%s\"\n" + "}", NON_EXISTENT_TASK_ID);
+
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity("/actuator/axelix-scheduled-tasks/enable", defaultJsonEntity(request), Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldReturnBadRequest_disableForNonExistentTask() {
+        // language=json
+        String request = String.format("{\n" + "  \"trigger\": \"%s\"\n" + "}", NON_EXISTENT_TASK_ID);
+
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity("/actuator/axelix-scheduled-tasks/disable", defaultJsonEntity(request), Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldReturnBadRequest_executeForNonExistentTask() {
+        // language=json
+        String request = String.format("{\n" + "  \"trigger\": \"%s\"\n" + "}", NON_EXISTENT_TASK_ID);
+
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity("/actuator/axelix-scheduled-tasks/execute", defaultJsonEntity(request), Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldReturnBadRequest_modifyCronExpressionForNonExistentTask() {
+        // language=json
+        String request = String.format(
+                "{\n" + "  \"trigger\": \"%s\",\n" + "  \"cronExpression\": \"*/5 * * * * *\"\n" + "}",
+                NON_EXISTENT_TASK_ID);
+
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity(
+                        "/actuator/axelix-scheduled-tasks/modify/cron-expression",
+                        defaultJsonEntity(request),
+                        Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldReturnBadRequest_modifyIntervalForNonExistentTask() {
+        // language=json
+        String request = String.format(
+                "{\n" + "  \"trigger\": \"%s\",\n" + "  \"interval\": 555555\n" + "}", NON_EXISTENT_TASK_ID);
+
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity(
+                        "/actuator/axelix-scheduled-tasks/modify/interval", defaultJsonEntity(request), Void.class);
+
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
     }
 
     @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-scheduled-tasks")

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -51,7 +51,6 @@ import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskReschedul
  * @since 14.10.2025
  */
 @AutoConfiguration
-@ConditionalOnBean(ScheduledAnnotationBeanPostProcessor.class)
 @ConditionalOnAvailableEndpoint(endpoint = AxelixScheduledTasksEndpoint.class)
 public class ScheduledTaskManagementAutoConfiguration {
 
@@ -74,6 +73,7 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnBean(ScheduledAnnotationBeanPostProcessor.class)
     public TaskRescheduler intervalBasedTaskRescheduler(ObjectProvider<TaskScheduler> scheduler) {
         TaskScheduler taskScheduler = requireTaskScheduler(scheduler);
 
@@ -81,6 +81,7 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnBean(ScheduledAnnotationBeanPostProcessor.class)
     public TaskRescheduler triggerBasedTaskRescheduler(ObjectProvider<TaskScheduler> scheduler) {
         TaskScheduler taskScheduler = requireTaskScheduler(scheduler);
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -19,9 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import java.util.List;
 
-import org.jspecify.annotations.NonNull;
-
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -29,7 +26,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.config.ScheduledTaskHolder;
 
@@ -73,19 +69,15 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnBean(ScheduledAnnotationBeanPostProcessor.class)
-    public TaskRescheduler intervalBasedTaskRescheduler(ObjectProvider<TaskScheduler> scheduler) {
-        TaskScheduler taskScheduler = requireTaskScheduler(scheduler);
-
-        return new IntervalBasedTaskRescheduler(taskScheduler);
+    @ConditionalOnBean(TaskScheduler.class)
+    public TaskRescheduler intervalBasedTaskRescheduler(TaskScheduler scheduler) {
+        return new IntervalBasedTaskRescheduler(scheduler);
     }
 
     @Bean
-    @ConditionalOnBean(ScheduledAnnotationBeanPostProcessor.class)
-    public TaskRescheduler triggerBasedTaskRescheduler(ObjectProvider<TaskScheduler> scheduler) {
-        TaskScheduler taskScheduler = requireTaskScheduler(scheduler);
-
-        return new TriggerBasedTaskRescheduler(taskScheduler);
+    @ConditionalOnBean(TaskScheduler.class)
+    public TaskRescheduler triggerBasedTaskRescheduler(TaskScheduler scheduler) {
+        return new TriggerBasedTaskRescheduler(scheduler);
     }
 
     @Bean
@@ -99,19 +91,6 @@ public class ScheduledTaskManagementAutoConfiguration {
     @ConditionalOnMissingBean
     public ScheduledTasksAssembler scheduledTasksAssembler(ScheduledTasksRegistry scheduledTasksRegistry) {
         return new DefaultScheduledTasksAssembler(scheduledTasksRegistry);
-    }
-
-    @NonNull
-    private static TaskScheduler requireTaskScheduler(ObjectProvider<TaskScheduler> scheduler) {
-        TaskScheduler taskScheduler = scheduler.getIfAvailable();
-
-        if (taskScheduler == null) {
-            throw new NoSuchBeanDefinitionException(
-                    "For @Scheduled-related abilities to work, Axelix requires a bean of type %s that cannot be found"
-                            .formatted(TaskScheduler.class.getName()));
-        }
-
-        return taskScheduler;
     }
 
     private static ThreadPoolTaskExecutor createThreadPoolExecutor() {

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpoint.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpoint.java
@@ -64,7 +64,7 @@ public class AxelixScheduledTasksEndpoint {
             taskService.enableTask(request.getTrigger());
             return ResponseEntity.noContent().build();
             // TODO: We need to revisit exception handling here
-        } catch (Exception e) {
+        } catch (ScheduledTaskNotFoundException e) {
             return ResponseEntity.badRequest().build();
         }
     }
@@ -77,7 +77,7 @@ public class AxelixScheduledTasksEndpoint {
             taskService.disableTask(request.getTrigger(), force);
             return ResponseEntity.noContent().build();
             // TODO: We need to revisit exception handling here
-        } catch (Exception e) {
+        } catch (ScheduledTaskNotFoundException e) {
             return ResponseEntity.badRequest().build();
         }
     }
@@ -99,7 +99,7 @@ public class AxelixScheduledTasksEndpoint {
             taskService.modifyInterval(request.getTrigger(), Duration.ofMillis(request.getInterval()));
             return ResponseEntity.noContent().build();
             // TODO: We need to revisit exception handling here
-        } catch (Exception e) {
+        } catch (ScheduledTaskNotFoundException e) {
             return ResponseEntity.badRequest().build();
         }
     }
@@ -110,7 +110,7 @@ public class AxelixScheduledTasksEndpoint {
             taskService.executeScheduledTask(request.getTrigger());
             return ResponseEntity.noContent().build();
             // TODO: We need to revisit exception handling here
-        } catch (Exception e) {
+        } catch (ScheduledTaskNotFoundException e) {
             return ResponseEntity.badRequest().build();
         }
     }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpoint.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpoint.java
@@ -60,17 +60,26 @@ public class AxelixScheduledTasksEndpoint {
 
     @PostMapping("/enable")
     public ResponseEntity<Void> enableTask(@RequestBody ScheduledTaskToggleRequest request) {
-        taskService.enableTask(request.getTrigger());
-        return ResponseEntity.noContent().build();
+        try {
+            taskService.enableTask(request.getTrigger());
+            return ResponseEntity.noContent().build();
+            // TODO: We need to revisit exception handling here
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @PostMapping("/disable")
     public ResponseEntity<Void> disableTask(
             @RequestBody ScheduledTaskToggleRequest request,
             @RequestParam(value = "force", defaultValue = "false") boolean force) {
-
-        taskService.disableTask(request.getTrigger(), force);
-        return ResponseEntity.noContent().build();
+        try {
+            taskService.disableTask(request.getTrigger(), force);
+            return ResponseEntity.noContent().build();
+            // TODO: We need to revisit exception handling here
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @PostMapping("/modify/cron-expression")
@@ -97,7 +106,12 @@ public class AxelixScheduledTasksEndpoint {
 
     @PostMapping("/execute")
     public ResponseEntity<Void> executeScheduledTask(@RequestBody ScheduledTaskExecuteRequest request) {
-        taskService.executeScheduledTask(request.getTrigger());
-        return ResponseEntity.noContent().build();
+        try {
+            taskService.executeScheduledTask(request.getTrigger());
+            return ResponseEntity.noContent().build();
+            // TODO: We need to revisit exception handling here
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskService.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskService.java
@@ -174,6 +174,7 @@ public final class ScheduledTaskService {
 
         } catch (ScheduledTaskNotFoundException e) {
             log.warn("Task '{}' not found, cannot run now", taskId, e);
+            throw e;
         }
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -83,15 +83,21 @@ class ScheduledTaskManagementAutoConfigurationTest {
     }
 
     @Test
-    void shouldNotActivateAutoConfiguration_whenEndpointDisabled() {
+    void shouldActivateWithoutReschedulers_whenSchedulingNotEnabled() {
         new ApplicationContextRunner()
                 .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
                 .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
                 .run(context -> {
-                    assertThat(context).doesNotHaveBean(ScheduledTaskManagementAutoConfiguration.class);
-                    assertThat(context).doesNotHaveBean(ScheduledTasksRegistry.class);
-                    assertThat(context).doesNotHaveBean(ScheduledTaskService.class);
-                    assertThat(context).doesNotHaveBean(AxelixScheduledTasksEndpoint.class);
+                    // read path is available even without @EnableScheduling
+                    assertThat(context).hasSingleBean(ScheduledTasksRegistry.class);
+                    assertThat(context).hasSingleBean(ScheduledTaskService.class);
+                    assertThat(context).hasSingleBean(ScheduledTasksAssembler.class);
+                    assertThat(context).hasSingleBean(AxelixScheduledTasksEndpoint.class);
+
+                    // no scheduling -> reschedulers are not created
+                    assertThat(context).getBeans(TaskRescheduler.class).isEmpty();
+                    assertThat(context).doesNotHaveBean(IntervalBasedTaskRescheduler.class);
+                    assertThat(context).doesNotHaveBean(TriggerBasedTaskRescheduler.class);
                 });
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -96,8 +96,6 @@ class ScheduledTaskManagementAutoConfigurationTest {
 
                     // no scheduling -> reschedulers are not created
                     assertThat(context).getBeans(TaskRescheduler.class).isEmpty();
-                    assertThat(context).doesNotHaveBean(IntervalBasedTaskRescheduler.class);
-                    assertThat(context).doesNotHaveBean(TriggerBasedTaskRescheduler.class);
                 });
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpointTest.java
@@ -101,6 +101,8 @@ class AxelixScheduledTasksEndpointTest {
 
     private static final String CUSTOM_TRIGGER = "CustomTestTrigger";
 
+    private static final String NON_EXISTENT_TASK_ID = "com.example.NonExistentTask.doWork";
+
     private static volatile boolean cronFlag = false;
 
     private static volatile boolean fixedDelayFlag = false;
@@ -299,7 +301,7 @@ class AxelixScheduledTasksEndpointTest {
     }
 
     @Test
-    void shouldReturnBadRequest_modifyCronExpressionForCronTask() {
+    void shouldReturnBadRequest_modifyCronExpressionForCronTask_toInvalidValue() {
         // language=json
         String request = """
             {
@@ -338,12 +340,12 @@ class AxelixScheduledTasksEndpointTest {
     }
 
     @Test
-    void shouldReturnBadRequest_modifyIntervalForFixedDelay() {
+    void shouldReturnBadRequest_modifyIntervalForFixedDelay_toInvalidValue() {
         // language=json
         String request = """
                 {
                   "trigger" : "%s",
-                  "cronExpression": "invalid value"
+                  "interval": "invalid value"
                 }
                 """.formatted(FIXED_DELAY_TASK_ID_FOR_MODIFY);
 
@@ -375,12 +377,12 @@ class AxelixScheduledTasksEndpointTest {
     }
 
     @Test
-    void shouldReturnBadRequest_modifyIntervalForFixedRate() {
+    void shouldReturnBadRequest_modifyIntervalForFixedRate_toInvalidValue() {
         // language=json
         String request = """
                 {
                   "trigger" : "%s",
-                  "cronExpression": "invalid value"
+                  "interval": "invalid value"
                 }
                 """.formatted(FIXED_RATE_TASK_ID_FOR_MODIFY);
 
@@ -425,6 +427,103 @@ class AxelixScheduledTasksEndpointTest {
             assertThatJson(task).node("enabled").isEqualTo(true);
         });
         assertThat(fixedRateFlag).isTrue();
+    }
+
+    @Test
+    void shouldReturnBadRequest_enableForNonExistentTask() {
+        // language=json
+        String request = """
+                {
+                  "trigger": "%s"
+                }
+                """.formatted(NON_EXISTENT_TASK_ID);
+
+        // when
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity("/actuator/axelix-scheduled-tasks/enable", defaultJsonEntity(request), Void.class);
+
+        // then
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldReturnBadRequest_disableForNonExistentTask() {
+        // language=json
+        String request = """
+                {
+                  "trigger": "%s"
+                }
+                """.formatted(NON_EXISTENT_TASK_ID);
+
+        // when
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity("/actuator/axelix-scheduled-tasks/disable", defaultJsonEntity(request), Void.class);
+
+        // then
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldReturnBadRequest_executeForNonExistentTask() {
+        // language=json
+        String request = """
+                {
+                  "trigger": "%s"
+                }
+                """.formatted(NON_EXISTENT_TASK_ID);
+
+        // when
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity("/actuator/axelix-scheduled-tasks/execute", defaultJsonEntity(request), Void.class);
+
+        // then
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldReturnBadRequest_modifyCronExpressionForNonExistentTask() {
+        // given
+        // language=json
+        String request = """
+                {
+                  "trigger": "%s",
+                  "cronExpression": "*/5 * * * * *"
+                }
+                """.formatted(NON_EXISTENT_TASK_ID);
+
+        // when
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity(
+                        "/actuator/axelix-scheduled-tasks/modify/cron-expression",
+                        defaultJsonEntity(request),
+                        Void.class);
+
+        // then
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
+    }
+
+    @Test
+    void shouldReturnBadRequest_modifyIntervalForNonExistentTask() {
+        // language=json
+        String request = """
+                {
+                  "trigger": "%s",
+                  "interval": 555555
+                }
+                """.formatted(NON_EXISTENT_TASK_ID);
+
+        // when
+        ResponseEntity<Void> response = restTemplate
+                .asEditor()
+                .postForEntity(
+                        "/actuator/axelix-scheduled-tasks/modify/interval", defaultJsonEntity(request), Void.class);
+
+        // then
+        assertThat(response).isNotNull().returns(HttpStatus.BAD_REQUEST, ResponseEntity::getStatusCode);
     }
 
     @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-scheduled-tasks")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enable/disable/execute endpoints return 204 on success and 400 when a task is not found.
  * Executing a missing task now signals failure instead of silently ignoring it.

* **Tests**
  * Added tests for operations against non-existent task IDs.
  * Updated negative test payloads for interval modification.

* **Chores**
  * Auto-configuration now activates based on actuator endpoint availability; rescheduler components are only created when scheduling support is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->