### PR TITLE
GH-1074 Added a restriction preventing user deletion under certain conditions

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApi.java
@@ -38,6 +38,7 @@ import com.axelixlabs.axelix.master.api.external.request.user.UserUpdateRequest;
 import com.axelixlabs.axelix.master.api.external.swagger.DefaultApiResponse;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.SecurityAutoConfiguration;
 import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
+import com.axelixlabs.axelix.master.exception.auth.UserNotDeletedException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 import com.axelixlabs.axelix.master.service.state.UserService;
 
@@ -83,9 +84,12 @@ public class UserManagementApi {
     @ApiResponse(description = "No Content", responseCode = "204")
     @DeleteMapping(path = ApiPaths.UsersManagementApi.USERS_DELETE)
     public ResponseEntity<Void> deleteUser(@RequestBody UserDeleteRequest request) {
-
-        userService.deleteById(request.id());
-        return ResponseEntity.noContent().build();
+        try {
+            userService.deleteByIdToLocalUser(request.id());
+            return ResponseEntity.noContent().build();
+        } catch (UserNotDeletedException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
     }
 
     @DefaultApiResponse(summary = "Update a user")

--- a/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UserNotDeletedException.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UserNotDeletedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.exception.auth;
+
+import com.axelixlabs.axelix.master.domain.UserOrigin;
+import com.axelixlabs.axelix.master.service.state.UserService;
+
+/**
+ * Thrown when a user deletion did not affect any record, i.e. no user exists with the given id or the
+ * user is not a {@link UserOrigin#LOCAL} user (only local users may be deleted).
+ *
+ * @see UserService
+ * @author Sergey Cherkasov
+ */
+public class UserNotDeletedException extends RuntimeException {
+
+    public UserNotDeletedException(String id) {
+        super("User with id '%s' was not deleted: it does not exist or is not a LOCAL user".formatted(id));
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/UserRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/UserRepository.java
@@ -60,4 +60,8 @@ public interface UserRepository extends ListCrudRepository<UserEntity, String> {
             @Param("password") @Nullable String password,
             @Param("roles") UserEntity.Roles roles,
             @Param("lastLoginAt") @Nullable Instant lastLoginAt);
+
+    @Modifying
+    @Query("DELETE FROM users WHERE id = :id AND user_origin = 'LOCAL'")
+    int deleteByIdToLocalUser(@Param("id") String id);
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseUserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseUserService.java
@@ -36,6 +36,7 @@ import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
+import com.axelixlabs.axelix.master.exception.auth.UserNotDeletedException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 
@@ -94,8 +95,10 @@ public class DatabaseUserService implements UserService {
     }
 
     @Override
-    public void deleteById(String id) {
-        userRepository.deleteById(id);
+    public void deleteByIdToLocalUser(String id) {
+        if (userRepository.deleteByIdToLocalUser(id) == 0) {
+            throw new UserNotDeletedException(id);
+        }
     }
 
     @Override

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/UserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/UserService.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.Nullable;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
+import com.axelixlabs.axelix.master.exception.auth.UserNotDeletedException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 
 /**
@@ -68,11 +69,15 @@ public interface UserService {
     void createFromOidc(String username, @Nullable String email, String role);
 
     /**
-     * Deletes the user with the given identifier. No-op if the user does not exist.
+     * Deletes the user with the given identifier, but only if it is a {@link UserOrigin#LOCAL} user.
+     * Throws {@link UserNotDeletedException} if no user exists with the given id or its origin is not
+     * {@link UserOrigin#LOCAL} (e.g. an {@link UserOrigin#OIDC} user is never deleted).
      *
      * @param id Unique identifier of the user to delete.
+     * @throws UserNotDeletedException if no user was deleted because none exists with that id or it is not a
+     *                                 {@link UserOrigin#LOCAL} user.
      */
-    void deleteById(String id);
+    void deleteByIdToLocalUser(String id) throws UserNotDeletedException;
 
     /**
      * Returns all managed users.

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
@@ -272,6 +272,45 @@ public class UserManagementApiTest {
     }
 
     @Test
+    void shouldReturnBadRequest_whenDeletingNonExistentUser() {
+        // language=json
+        String request = """
+                {
+                  "id":"non-existent-id"
+                }
+                """;
+
+        // when.
+        ResponseEntity<Void> response = restTemplate
+                .withRole(SUPER_ADMIN)
+                .exchange(USERS_DELETE_PATH, HttpMethod.DELETE, defaultEntity(request), Void.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void shouldReturnBadRequest_whenDeletingNonLocalUser() {
+        UserEntity user = insertUser("oidcUser", "oidc@example.com", null, Set.of("VIEWER"), UserOrigin.OIDC);
+
+        // language=json
+        String request = """
+                {
+                  "id":"%s"
+                }
+                """.formatted(user.id());
+
+        // when.
+        ResponseEntity<Void> response = restTemplate
+                .withRole(SUPER_ADMIN)
+                .exchange(USERS_DELETE_PATH, HttpMethod.DELETE, defaultEntity(request), Void.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(userRepository.findById(user.id())).isPresent();
+    }
+
+    @Test
     void shouldUpdateAllUserFields() {
         // given.
         UserEntity user = insertUser("oldName", "old@example.com", "oldPass", Set.of("VIEWER"), UserOrigin.LOCAL);

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
@@ -32,6 +32,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
+import com.axelixlabs.axelix.master.exception.auth.UserNotDeletedException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 
@@ -151,21 +152,46 @@ abstract class DatabaseUserServiceTest {
     }
 
     @Test
-    void deleteAllById_shouldRemoveUser() {
+    void deleteByIdToLocalUser_shouldRemoveLocalUser() {
         userService.createLocal("alice", "alice@example.com", "p", "VIEWER");
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
-        userService.deleteById(existing.id());
-
-        // then.
+        assertThatCode(() -> userService.deleteByIdToLocalUser(existing.id()))
+                // then.
+                .doesNotThrowAnyException();
         assertThat(userRepository.findById(existing.id())).isEmpty();
     }
 
     @Test
-    void deleteAllById_shouldBeNoOpWhenUserDoesNotExist() {
+    void deleteByIdToLocalUser_shouldNotRemoveOidcUser() {
+        userService.createFromOidc("bob", "bob@example.com", "VIEWER");
+        UserEntity existing = userRepository.findByUsername("bob").orElseThrow();
+
         // when.
-        assertThatCode(() -> userService.deleteById("non-existent-id")).doesNotThrowAnyException();
+        assertThatThrownBy(() -> userService.deleteByIdToLocalUser(existing.id()))
+                // then.
+                .isInstanceOf(UserNotDeletedException.class);
+
+        Optional<UserEntity> stillPresent = userRepository.findById(existing.id());
+        assertThat(stillPresent).isPresent();
+        assertThat(stillPresent.get().userOrigin()).isEqualTo(UserOrigin.OIDC);
+    }
+
+    @Test
+    void deleteByIdToLocalUser_nonExistentId_shouldThrow() {
+        userService.createLocal("alice", "alice@example.com", "p", "VIEWER");
+        userService.createFromOidc("bob", "bob@example.com", "VIEWER");
+        UserEntity localUser = userRepository.findByUsername("alice").orElseThrow();
+        UserEntity oidcUser = userRepository.findByUsername("bob").orElseThrow();
+
+        // when.
+        assertThatThrownBy(() -> userService.deleteByIdToLocalUser("non-existent-id"))
+                // then.
+                .isInstanceOf(UserNotDeletedException.class);
+
+        assertThat(userRepository.findById(localUser.id())).isPresent();
+        assertThat(userRepository.findById(oidcUser.id())).isPresent();
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deletion now only removes locally created users; attempts to delete external or non-existent users return HTTP 400 instead of silently succeeding.
* **Tests**
  * Added integration tests covering successful local deletions and verifying 400 responses while preserving non-local or missing user records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

* **Changes**
  - `UserRepository` — `deleteById` renamed to `deleteByIdToLocalUser` to reflect the `LOCAL`-only semantics.
  - `UserService` / `DatabaseUserService` — `deleteById` renamed to `deleteByIdToLocalUser` to reflect the `LOCAL`-only semantics. **Javadoc** updated to state that
  non-existent and non-`LOCAL` (`OIDC`) users are a no-op.
  - Condition 2 already enforced: the entire `UserManagementApi` controller is gated by a class-level
  `@ConditionalOnProperty(prefix="axelix.master.auth.options.local", name="enabled", havingValue="true")`, so the `DELETE` endpoint is not exposed (404) when
  local auth is off. No code change required.