### PR TITLE
GH-1118 Made the website landing pull the most recent version of Axelix for installation

### DIFF
--- a/website/src/app/layout.tsx
+++ b/website/src/app/layout.tsx
@@ -16,6 +16,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import { Footer, Header, Metric } from "@/components";
+import { AxelixVersionProvider } from "@/hooks/useAxelixVersion";
 
 import type { Metadata } from "next";
 import { Golos_Text, JetBrains_Mono } from "next/font/google";
@@ -42,10 +43,12 @@ export default function RootLayout({
     return (
         <html lang="en" className={`${golosText.variable} ${jetBrainsMono.variable}`}>
             <body>
-                <Metric />
-                <Header />
-                <main>{children}</main>
-                <Footer />
+                <AxelixVersionProvider>
+                    <Metric />
+                    <Header />
+                    <main>{children}</main>
+                    <Footer />
+                </AxelixVersionProvider>
             </body>
         </html>
     );

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -26,7 +26,7 @@ export default function Page() {
             <Reveal>
                 <ReferenceApp />
             </Reveal>
-                <HowExactly />
+            <HowExactly />
             <Reveal>
                 <Capabilities />
             </Reveal>

--- a/website/src/components/Footer/FooterVersion.tsx
+++ b/website/src/components/Footer/FooterVersion.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+"use client";
+import { useAxelixVersion } from "@/hooks/useAxelixVersion";
+
+export const FooterVersion = () => {
+    const { version } = useAxelixVersion();
+
+    return <span>v{version ?? "1.0.0"}</span>;
+};

--- a/website/src/components/Footer/index.tsx
+++ b/website/src/components/Footer/index.tsx
@@ -17,6 +17,7 @@
  */
 import { DiscordIcon, EmailIcon, ExternalLinkIcon, GithubIcon, LinkedinIcon, LogoIcon, XTwitterIcon } from "@/assets";
 
+import { FooterVersion } from "./FooterVersion";
 import styles from "./styles.module.css";
 
 const Footer = () => {
@@ -153,7 +154,7 @@ const Footer = () => {
                 <div className={styles.Bottom}>
                     <span>© 2026 Axelix Labs</span>
                     <div className={styles.Meta}>
-                        <span>v1.0.0</span>
+                        <FooterVersion />
                         <span className={styles.DotSep}></span>
                         <span>Open Core</span>
                         <span className={styles.DotSep}></span>

--- a/website/src/components/Install/InstallTopSection/index.tsx
+++ b/website/src/components/Install/InstallTopSection/index.tsx
@@ -23,7 +23,8 @@ export const InstallTopSection = () => {
             <div>
                 <span className={styles.Eyebrow}>Install</span>
                 <h2 className={styles.Title}>
-                    Install Axelix Master. Add library & plugin - <span className="UnderlinedText">that&#39;s all you need</span>
+                    Install Axelix Master. Add library & plugin -{" "}
+                    <span className="UnderlinedText">that&#39;s all you need</span>
                 </h2>
             </div>
             <p className={styles.IntroText}>

--- a/website/src/components/Install/Installer/PluginMini/index.tsx
+++ b/website/src/components/Install/Installer/PluginMini/index.tsx
@@ -16,6 +16,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import { CopyIcon } from "@/assets";
+import { useAxelixVersion } from "@/hooks/useAxelixVersion";
 
 import { useRef, useState } from "react";
 
@@ -29,7 +30,8 @@ export const PluginMini = ({ activeSnippetRef }: IProps) => {
     const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
     const timers = useRef<Array<ReturnType<typeof setTimeout> | null>>([null, null, null]);
 
-    const axelixActualVersion = `1.0.0`;
+    const { version } = useAxelixVersion();
+    const axelixActualVersion = version ?? "1.0.0";
 
     const blocks: { label: string; code: string }[] = [
         {

--- a/website/src/components/Install/Installer/Snippets/AxelixVersion/index.tsx
+++ b/website/src/components/Install/Installer/Snippets/AxelixVersion/index.tsx
@@ -15,7 +15,18 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-export interface INavLink {
-    href: string;
-    label: string;
+import { IAxelixVersionData } from "@/models";
+
+import styles from "./styles.module.css";
+
+interface IProps {
+    axelixVersionData: IAxelixVersionData;
 }
+
+export const AxelixVersion = ({ axelixVersionData }: IProps) => {
+    if (axelixVersionData.loading) {
+        return <span className={styles.VersionSkeleton} />;
+    }
+
+    return <>{axelixVersionData.version}</>;
+};

--- a/website/src/components/Install/Installer/Snippets/AxelixVersion/styles.module.css
+++ b/website/src/components/Install/Installer/Snippets/AxelixVersion/styles.module.css
@@ -1,0 +1,23 @@
+.VersionSkeleton {
+    display: inline-block;
+    width: 70px;
+    height: 16px;
+    border-radius: 4px;
+    vertical-align: middle;
+    background: linear-gradient(90deg,
+            rgb(189 224 143 / 15%) 25%,
+            rgb(189 224 143 / 25%) 50%,
+            rgb(189 224 143 / 15%) 75%);
+    background-size: 200% 100%;
+    animation: skeleton-shimmer 1.5s infinite;
+}
+
+@keyframes skeleton-shimmer {
+    0% {
+        background-position: 200% 0;
+    }
+
+    100% {
+        background-position: -200% 0;
+    }
+}

--- a/website/src/components/Install/Installer/Snippets/ComposeSnippet/index.tsx
+++ b/website/src/components/Install/Installer/Snippets/ComposeSnippet/index.tsx
@@ -15,13 +15,17 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+import { IAxelixVersionData } from "@/models";
+
+import { AxelixVersion } from "../AxelixVersion";
 import styles from "../shared.module.css";
 
 interface IProps {
     refEl: any;
+    axelixVersionData: IAxelixVersionData;
 }
 
-export const ComposeSnippet = ({ refEl }: IProps) => {
+export const ComposeSnippet = ({ refEl, axelixVersionData }: IProps) => {
     return (
         <pre
             className={styles.Snippet}
@@ -40,7 +44,10 @@ export const ComposeSnippet = ({ refEl }: IProps) => {
                 <span className={styles.Line}>
                     {"    "}
                     <span className={styles.At}>image</span>:{" "}
-                    <span className={styles.St}>ghcr.io/axelixlabs/axelix:v1.0.0</span>
+                    <span className={styles.St}>
+                        ghcr.io/axelixlabs/axelix:
+                        <AxelixVersion axelixVersionData={axelixVersionData} />
+                    </span>
                 </span>
                 <span className={styles.Line}>
                     {"    "}

--- a/website/src/components/Install/Installer/Snippets/DockerSnippet/index.tsx
+++ b/website/src/components/Install/Installer/Snippets/DockerSnippet/index.tsx
@@ -15,13 +15,17 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+import { IAxelixVersionData } from "@/models";
+
+import { AxelixVersion } from "../AxelixVersion";
 import styles from "../shared.module.css";
 
 interface IProps {
     refEl: any;
+    axelixVersionData: IAxelixVersionData;
 }
 
-export const DockerSnippet = ({ refEl }: IProps) => {
+export const DockerSnippet = ({ refEl, axelixVersionData }: IProps) => {
     return (
         <pre
             className={styles.Snippet}
@@ -63,7 +67,10 @@ export const DockerSnippet = ({ refEl }: IProps) => {
                 </span>
                 <span className={styles.Line}>
                     {"    "}
-                    <span className={styles.St}>ghcr.io/axelixlabs/axelix:v1.0.0</span>
+                    <span className={styles.St}>
+                        ghcr.io/axelixlabs/axelix:
+                        <AxelixVersion axelixVersionData={axelixVersionData} />
+                    </span>
                 </span>
             </code>
         </pre>

--- a/website/src/components/Install/Installer/Snippets/K8sSnippet/index.tsx
+++ b/website/src/components/Install/Installer/Snippets/K8sSnippet/index.tsx
@@ -15,6 +15,9 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+import { useAxelixVersion } from "@/hooks/useAxelixVersion";
+
+import { AxelixVersion } from "../AxelixVersion";
 import styles from "../shared.module.css";
 
 interface IProps {
@@ -22,6 +25,8 @@ interface IProps {
 }
 
 export const K8sSnippet = ({ refEl }: IProps) => {
+    const axelixVersionData = useAxelixVersion();
+
     return (
         <pre
             className={styles.Snippet}
@@ -51,7 +56,10 @@ export const K8sSnippet = ({ refEl }: IProps) => {
                 </span>
                 <span className={styles.Line}>
                     {"    "}
-                    <span className={styles.Ar}>--version</span> <span className={styles.St}>1.0.0</span>{" "}
+                    <span className={styles.Ar}>--version</span>{" "}
+                    <span className={styles.St}>
+                        <AxelixVersion axelixVersionData={axelixVersionData} />
+                    </span>{" "}
                     <span className={styles.Nl}>\</span>
                 </span>
                 <span className={styles.Line}>

--- a/website/src/components/Install/Installer/StarterMini/index.tsx
+++ b/website/src/components/Install/Installer/StarterMini/index.tsx
@@ -16,6 +16,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import { CopyIcon } from "@/assets";
+import { useAxelixVersion } from "@/hooks/useAxelixVersion";
 
 import { useRef, useState } from "react";
 
@@ -30,7 +31,8 @@ export const StarterMini = ({ artifact, activeSnippetRef }: IProps) => {
     const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
     const timers = useRef<Array<ReturnType<typeof setTimeout> | null>>([null, null, null]);
 
-    const axelixActualVersion = `1.0.0`;
+    const { version } = useAxelixVersion();
+    const axelixActualVersion = version ?? "1.0.0";
 
     const blocks: { label: string; code: string }[] = [
         {

--- a/website/src/components/Install/Installer/index.tsx
+++ b/website/src/components/Install/Installer/index.tsx
@@ -16,7 +16,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 "use client";
-import { EInstallConfigurationVariant, EInstallMethod, EInstallOpenSelect, ESpringBootVariant } from "@/models";
+import {
+    EInstallConfigurationVariant,
+    EInstallMethod,
+    EInstallOpenSelect,
+    ESpringBootVariant,
+    IAxelixVersionData,
+    IGithubReleaseResponseBody,
+} from "@/models";
 import { installSpringBootArtifact } from "@/utils";
 
 import { BareMetal } from "./Snippets/BareMetal";
@@ -46,6 +53,10 @@ export const Installer = () => {
     const activeSnippetRef = useRef<HTMLElement>(null);
 
     const [openSelect, setOpenSelect] = useState<EInstallOpenSelect>(EInstallOpenSelect.NULL);
+    const [axelixVersionData, setAxelixVersionData] = useState<IAxelixVersionData>({
+        version: null,
+        loading: true,
+    });
 
     const selectRef = useRef<HTMLDivElement>(null);
 
@@ -61,6 +72,44 @@ export const Installer = () => {
         }
         document.addEventListener("click", onClick);
         return () => document.removeEventListener("click", onClick);
+    }, []);
+
+    // TODO: In the future, split this component into smaller components
+    useEffect(() => {
+        async function fetchAxelixVersion() {
+            try {
+                setAxelixVersionData((prev) => ({
+                    ...prev,
+                    loading: true,
+                }));
+
+                const response = await fetch("https://api.github.com/repos/axelixlabs/axelix/releases/latest");
+
+                if (!response.ok) {
+                    throw new Error();
+                }
+
+                const data: IGithubReleaseResponseBody = await response.json();
+                const version = data.tag_name;
+
+                setAxelixVersionData((prev) => ({
+                    ...prev,
+                    version: version,
+                }));
+            } catch {
+                setAxelixVersionData((prev) => ({
+                    ...prev,
+                    version: "<VERSION>",
+                }));
+            } finally {
+                setAxelixVersionData((prev) => ({
+                    ...prev,
+                    loading: false,
+                }));
+            }
+        }
+
+        fetchAxelixVersion();
     }, []);
 
     return (
@@ -88,10 +137,10 @@ export const Installer = () => {
                             )}
 
                             {installStep === 1 && installMethod === EInstallMethod.DOCKER && (
-                                <DockerSnippet refEl={activeSnippetRef} />
+                                <DockerSnippet refEl={activeSnippetRef} axelixVersionData={axelixVersionData} />
                             )}
                             {installStep === 1 && installMethod === EInstallMethod.COMPOSE && (
-                                <ComposeSnippet refEl={activeSnippetRef} />
+                                <ComposeSnippet refEl={activeSnippetRef} axelixVersionData={axelixVersionData} />
                             )}
                             {installStep === 1 && installMethod === EInstallMethod.K8S && (
                                 <K8sSnippet refEl={activeSnippetRef} />

--- a/website/src/components/Install/Installer/index.tsx
+++ b/website/src/components/Install/Installer/index.tsx
@@ -16,14 +16,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 "use client";
-import {
-    EInstallConfigurationVariant,
-    EInstallMethod,
-    EInstallOpenSelect,
-    ESpringBootVariant,
-    IAxelixVersionData,
-    IGithubReleaseResponseBody,
-} from "@/models";
+import { useAxelixVersion } from "@/hooks/useAxelixVersion";
+import { EInstallConfigurationVariant, EInstallMethod, EInstallOpenSelect, ESpringBootVariant } from "@/models";
 import { installSpringBootArtifact } from "@/utils";
 
 import { BareMetal } from "./Snippets/BareMetal";
@@ -53,10 +47,7 @@ export const Installer = () => {
     const activeSnippetRef = useRef<HTMLElement>(null);
 
     const [openSelect, setOpenSelect] = useState<EInstallOpenSelect>(EInstallOpenSelect.NULL);
-    const [axelixVersionData, setAxelixVersionData] = useState<IAxelixVersionData>({
-        version: null,
-        loading: true,
-    });
+    const axelixVersionData = useAxelixVersion();
 
     const selectRef = useRef<HTMLDivElement>(null);
 
@@ -75,43 +66,6 @@ export const Installer = () => {
     }, []);
 
     // TODO: In the future, split this component into smaller components
-    useEffect(() => {
-        async function fetchAxelixVersion() {
-            try {
-                setAxelixVersionData((prev) => ({
-                    ...prev,
-                    loading: true,
-                }));
-
-                const response = await fetch("https://api.github.com/repos/axelixlabs/axelix/releases/latest");
-
-                if (!response.ok) {
-                    throw new Error();
-                }
-
-                const data: IGithubReleaseResponseBody = await response.json();
-                const version = data.tag_name;
-
-                setAxelixVersionData((prev) => ({
-                    ...prev,
-                    version: version,
-                }));
-            } catch {
-                setAxelixVersionData((prev) => ({
-                    ...prev,
-                    version: "1.0.0",
-                }));
-            } finally {
-                setAxelixVersionData((prev) => ({
-                    ...prev,
-                    loading: false,
-                }));
-            }
-        }
-
-        fetchAxelixVersion();
-    }, []);
-
     return (
         <>
             <div className={styles.InstallerWrapper}>

--- a/website/src/components/Install/Installer/index.tsx
+++ b/website/src/components/Install/Installer/index.tsx
@@ -99,7 +99,7 @@ export const Installer = () => {
             } catch {
                 setAxelixVersionData((prev) => ({
                     ...prev,
-                    version: "<VERSION>",
+                    version: "1.0.0",
                 }));
             } finally {
                 setAxelixVersionData((prev) => ({

--- a/website/src/hooks/useAxelixVersion.tsx
+++ b/website/src/hooks/useAxelixVersion.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+"use client";
+import { IAxelixVersionData, IGithubReleaseResponseBody } from "@/models";
+
+import { ReactNode, createContext, useContext, useEffect, useState } from "react";
+
+const AxelixVersionContext = createContext<IAxelixVersionData>({
+    version: null,
+    loading: true,
+});
+
+/**
+ * Fetches the current Axelix version once (from the latest GitHub release) and
+ * shares it with every consumer via {@link useAxelixVersion}. All Axelix
+ * artifacts ship under the same version, so a single fetch serves the whole page.
+ *
+ * The GitHub release tag carries a leading `v` (e.g. `v1.0.0`) that is stripped
+ * here, since the published Docker image tag and the Maven/Gradle/Helm
+ * coordinates are all versioned without the prefix.
+ */
+export const AxelixVersionProvider = ({ children }: { children: ReactNode }) => {
+    const [axelixVersionData, setAxelixVersionData] = useState<IAxelixVersionData>({
+        version: null,
+        loading: true,
+    });
+
+    useEffect(() => {
+        async function fetchAxelixVersion() {
+            try {
+                const response = await fetch("https://api.github.com/repos/axelixlabs/axelix/releases/latest");
+
+                if (!response.ok) {
+                    throw new Error();
+                }
+
+                const data: IGithubReleaseResponseBody = await response.json();
+
+                setAxelixVersionData((prev) => ({
+                    ...prev,
+                    version: data.tag_name.replace(/^v/, ""),
+                }));
+            } catch {
+                setAxelixVersionData((prev) => ({
+                    ...prev,
+                    version: "1.0.0",
+                }));
+            } finally {
+                setAxelixVersionData((prev) => ({
+                    ...prev,
+                    loading: false,
+                }));
+            }
+        }
+
+        fetchAxelixVersion();
+    }, []);
+
+    return <AxelixVersionContext.Provider value={axelixVersionData}>{children}</AxelixVersionContext.Provider>;
+};
+
+export const useAxelixVersion = () => useContext(AxelixVersionContext);

--- a/website/src/models/interfaces/index.ts
+++ b/website/src/models/interfaces/index.ts
@@ -44,3 +44,12 @@ export interface IInstallMethodData {
     description: string;
     href: string;
 }
+
+export interface IGithubReleaseResponseBody {
+    tag_name: string;
+}
+
+export interface IAxelixVersionData {
+    version: string | null;
+    loading: boolean;
+}


### PR DESCRIPTION
Closes GH-1118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installation snippets for Docker and Compose now show the current application version fetched at runtime and receive version data from the installer.
  * Installer fetches the latest release and supplies version info to snippets, displaying a placeholder while loading.

* **Style**
  * Added a green shimmer-loading skeleton for version displays to indicate loading state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->