### PR TITLE
GH-1050 Remove the clearing stats api for the transactional data

### DIFF
--- a/common/domain/src/main/java/com/axelixlabs/axelix/common/domain/ActuatorEndpoints.java
+++ b/common/domain/src/main/java/com/axelixlabs/axelix/common/domain/ActuatorEndpoints.java
@@ -131,8 +131,6 @@ public class ActuatorEndpoints implements Iterable<ActuatorEndpoint> {
     // @Transaction monitoring
     public static final ActuatorEndpoint TRANSACTION_STATS_GET =
             endpoint("/axelix-transactions-monitoring", HttpMethod.GET);
-    public static final ActuatorEndpoint TRANSACTION_STATS_CLEAR =
-            endpoint("/axelix-transactions-monitoring", HttpMethod.DELETE);
 
     // Feign Client
     public static final ActuatorEndpoint GET_FEIGN_CLIENT = endpoint("/axelix-feign", HttpMethod.GET);

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/TransactionMonitoringApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/TransactionMonitoringApi.java
@@ -22,7 +22,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -60,14 +59,5 @@ public class TransactionMonitoringApi {
     public byte[] getTransactionFeed(@PathVariable("instanceId") String instanceId) {
         return endpointInvoker.invoke(
                 InstanceId.of(instanceId), ActuatorEndpoints.TRANSACTION_STATS_GET, NoHttpPayload.INSTANCE);
-    }
-
-    @DefaultApiResponse(summary = "Clears transaction statistics for the given instance.")
-    @ApiResponse(description = "OK", responseCode = "200")
-    @InstanceIdParameter
-    @DeleteMapping(path = ApiPaths.TransactionMonitoringApi.INSTANCE_ID)
-    public void clearTransactionStats(@PathVariable("instanceId") String instanceId) {
-        endpointInvoker.invoke(
-                InstanceId.of(instanceId), ActuatorEndpoints.TRANSACTION_STATS_CLEAR, NoHttpPayload.INSTANCE);
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/probers/EndpointProbersAutoConfiguration.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/probers/EndpointProbersAutoConfiguration.java
@@ -288,12 +288,6 @@ public class EndpointProbersAutoConfiguration {
                 instanceRegistry, ActuatorEndpoints.TRANSACTION_STATS_GET, securityContextExecutor);
     }
 
-    @Bean
-    public DiscardingAbstractEndpointProber transactionMonitoringDiscardingEndpointProber() {
-        return new DiscardingAbstractEndpointProber(
-                instanceRegistry, ActuatorEndpoints.TRANSACTION_STATS_CLEAR, securityContextExecutor);
-    }
-
     // Feign Client
     @Bean
     public ProxyingEndpointProber getFeignClientEndpointProber() {

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/TransactionMonitoringApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/TransactionMonitoringApiTest.java
@@ -18,10 +18,7 @@
 package com.axelixlabs.axelix.master.api.external.endpoint;
 
 import java.io.IOException;
-import java.net.URI;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
@@ -38,7 +35,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
@@ -161,9 +157,6 @@ class TransactionMonitoringApiTest {
                     return new MockResponse()
                             .setBody(ACTUAL_AND_EXPECTED_TRANSACTION_MONITORING_JSON)
                             .addHeader("Content-Type", APPLICATION_JSON_VALUE);
-                } else if (path.equals("/" + activeInstanceId + "/actuator/axelix-transactions-monitoring")
-                        && request.getMethod().equals("DELETE")) {
-                    return new MockResponse();
                 } else {
                     return new MockResponse().setResponseCode(404);
                 }
@@ -199,20 +192,6 @@ class TransactionMonitoringApiTest {
     }
 
     @Test
-    void shouldClearTransactionsMonitoringStats() throws InterruptedException {
-        // when.
-        restTemplate
-                .asViewer()
-                .delete("/api/external/transaction-monitoring/{instanceId}", Map.of("instanceId", activeInstanceId));
-
-        // then.
-        RecordedRequest recordedRequest = mockWebServer.takeRequest(10l, TimeUnit.SECONDS);
-        assertThat(recordedRequest.getMethod()).isEqualTo("DELETE");
-        assertThat(recordedRequest.getPath())
-                .isEqualTo("/" + activeInstanceId + "/actuator/axelix-transactions-monitoring");
-    }
-
-    @Test
     void shouldReturnInternalServerError_OnGetTransactionFeed() {
         String instanceId = UUID.randomUUID().toString();
         registry.register(createInstance(instanceId));
@@ -221,23 +200,6 @@ class TransactionMonitoringApiTest {
         ResponseEntity<String> response = restTemplate
                 .asViewer()
                 .getForEntity("/api/external/transaction-monitoring/{instanceId}", String.class, instanceId);
-
-        // then.
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
-    }
-
-    @Test
-    void shouldReturnInternalServerError_OnClearTransactionStats() {
-        String instanceId = UUID.randomUUID().toString();
-        registry.register(createInstance(instanceId));
-
-        // when.
-        ResponseEntity<String> response = restTemplate
-                .asViewer()
-                .exchange(
-                        RequestEntity.delete(URI.create("/api/external/transaction-monitoring/" + instanceId))
-                                .build(),
-                        String.class);
 
         // then.
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
@@ -256,29 +218,8 @@ class TransactionMonitoringApiTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
-    @Test
-    void shouldReturnBadRequestForUnregisteredInstance_OnClearTransactionStats() {
-        String instanceId = UUID.randomUUID().toString();
-
-        // when.
-        ResponseEntity<String> response = restTemplate
-                .asViewer()
-                .exchange(
-                        RequestEntity.delete(URI.create("/api/external/transaction-monitoring/" + instanceId))
-                                .build(),
-                        String.class);
-
-        // then.
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-    }
-
     @ProtectedEndpointTests(
             method = HttpMethod.GET,
             path = "/api/external/transaction-monitoring/00000000-0000-0000-0000-000000000001")
     void negativeAuthTestsOnGetTransactionFeed() {}
-
-    @ProtectedEndpointTests(
-            method = HttpMethod.DELETE,
-            path = "/api/external/transaction-monitoring/00000000-0000-0000-0000-000000000001")
-    void negativeAuthTestsOnClearTransactionStats() {}
 }

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpoint.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpoint.java
@@ -17,7 +17,6 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.transactions;
 
-import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 
@@ -43,10 +42,5 @@ public class TransactionMonitoringEndpoint {
     @ReadOperation
     public TransactionMonitoringFeed getTransactionStats() {
         return transactionMonitoringService.getMonitoringFeed();
-    }
-
-    @DeleteOperation
-    public void clearTransactionStats() {
-        transactionMonitoringService.clearAllStats();
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
@@ -45,7 +45,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
@@ -92,7 +91,7 @@ class TransactionMonitoringEndpointTest {
 
     @BeforeEach
     void cleanUp() {
-        transactionStatsCollector.clearAllStats();
+        transactionStatsCollector.getAllStats().clear();
     }
 
     @Test
@@ -146,26 +145,6 @@ class TransactionMonitoringEndpointTest {
         assertThatJson(responseBody)
                 .node("entrypoints[0].executionStats.medianDurationMs")
                 .isNumber();
-    }
-
-    @Test
-    void shouldClearsAllTransactionMonitoringStats() {
-        for (int i = 0; i < 3; i++) {
-            propagationTestHelper.saveRequiresNew("Johnson");
-        }
-
-        var allStats = transactionStatsCollector.getAllStats();
-
-        assertThat(allStats.size()).isGreaterThan(0);
-
-        ResponseEntity<Void> deleteResponse = restTemplate
-                .asViewer()
-                .exchange("/actuator/axelix-transactions-monitoring", HttpMethod.DELETE, null, Void.class);
-
-        assertThat(deleteResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-
-        allStats = transactionStatsCollector.getAllStats();
-        assertThat(allStats).isEmpty();
     }
 
     @Test

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
@@ -91,7 +91,7 @@ class TransactionMonitoringEndpointTest {
 
     @BeforeEach
     void cleanUp() {
-        transactionStatsCollector.getAllStats().clear();
+        transactionStatsCollector.clearStats();
     }
 
     @Test

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpoint.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpoint.java
@@ -17,7 +17,6 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.transactions;
 
-import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 
@@ -43,10 +42,5 @@ public class TransactionMonitoringEndpoint {
     @ReadOperation
     public TransactionMonitoringFeed getTransactionStats() {
         return transactionMonitoringService.getMonitoringFeed();
-    }
-
-    @DeleteOperation
-    public void clearTransactionStats() {
-        transactionMonitoringService.clearAllStats();
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
@@ -50,7 +50,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
@@ -103,7 +102,7 @@ class TransactionMonitoringEndpointTest {
 
     @BeforeEach
     void cleanUp() {
-        transactionStatsCollector.clearAllStats();
+        transactionStatsCollector.getAllStats().clear();
         meterRegistry.clear();
     }
 
@@ -163,26 +162,6 @@ class TransactionMonitoringEndpointTest {
 
         // and then. Verify that metrics were successfully published to MeterRegistry
         checkMeterRegistry(expectedClassName, "saveRequiresNew", "success", 1);
-    }
-
-    @Test
-    void shouldClearsAllTransactionMonitoringStats() {
-        for (int i = 0; i < 3; i++) {
-            propagationTestHelper.saveRequiresNew("Johnson");
-        }
-
-        var allStats = transactionStatsCollector.getAllStats();
-
-        assertThat(allStats.size()).isGreaterThan(0);
-
-        ResponseEntity<Void> deleteResponse = restTemplate
-                .asViewer()
-                .exchange("/actuator/axelix-transactions-monitoring", HttpMethod.DELETE, null, Void.class);
-
-        assertThat(deleteResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-
-        allStats = transactionStatsCollector.getAllStats();
-        assertThat(allStats).isEmpty();
     }
 
     @Test

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
@@ -102,7 +102,7 @@ class TransactionMonitoringEndpointTest {
 
     @BeforeEach
     void cleanUp() {
-        transactionStatsCollector.getAllStats().clear();
+        transactionStatsCollector.clearStats();
         meterRegistry.clear();
     }
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultTransactionMonitoringService.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultTransactionMonitoringService.java
@@ -58,11 +58,6 @@ public class DefaultTransactionMonitoringService implements TransactionMonitorin
         return new TransactionMonitoringFeed(methodStats);
     }
 
-    @Override
-    public void clearAllStats() {
-        transactionStatsCollector.clearAllStats();
-    }
-
     private TransactionalEntrypoint createTransactionalEntrypoint(
             String className, String methodName, List<TransactionRecord> transactions) {
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultTransactionStatsCollector.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultTransactionStatsCollector.java
@@ -55,9 +55,4 @@ public class DefaultTransactionStatsCollector implements TransactionStatsCollect
     public ConcurrentHashMap<MethodClassKey, SlidingWindow<TransactionRecord>> getAllStats() {
         return statsMap;
     }
-
-    @Override
-    public void clearAllStats() {
-        statsMap.clear();
-    }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultTransactionStatsCollector.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultTransactionStatsCollector.java
@@ -17,6 +17,7 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.transactions;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.axelixlabs.axelix.sbs.spring.core.SlidingWindow;
@@ -52,7 +53,12 @@ public class DefaultTransactionStatsCollector implements TransactionStatsCollect
     }
 
     @Override
-    public ConcurrentHashMap<MethodClassKey, SlidingWindow<TransactionRecord>> getAllStats() {
-        return statsMap;
+    public Map<MethodClassKey, SlidingWindow<TransactionRecord>> getAllStats() {
+        return Map.copyOf(statsMap);
+    }
+
+    @Override
+    public void clearStats() {
+        statsMap.clear();
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringService.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringService.java
@@ -31,9 +31,4 @@ public interface TransactionMonitoringService {
      * Returns a complete monitoring feed with transaction execution statistics.
      */
     TransactionMonitoringFeed getMonitoringFeed();
-
-    /**
-     * Clears all collected transaction statistics.
-     */
-    void clearAllStats();
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionStatsCollector.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionStatsCollector.java
@@ -43,9 +43,4 @@ public interface TransactionStatsCollector {
      * @return map of method keys to their transaction statistics
      */
     ConcurrentHashMap<MethodClassKey, SlidingWindow<TransactionRecord>> getAllStats();
-
-    /**
-     * Clears all collected transaction statistics.
-     */
-    void clearAllStats();
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionStatsCollector.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionStatsCollector.java
@@ -17,7 +17,7 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.transactions;
 
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
 
 import com.axelixlabs.axelix.sbs.spring.core.SlidingWindow;
 
@@ -38,9 +38,14 @@ public interface TransactionStatsCollector {
     void recordTransaction(MethodClassKey key, TransactionRecord transactionRecord);
 
     /**
-     * Returns all collected transaction statistics.
+     * Returns the copy of all collected transaction statistics.
      *
      * @return map of method keys to their transaction statistics
      */
-    ConcurrentHashMap<MethodClassKey, SlidingWindow<TransactionRecord>> getAllStats();
+    Map<MethodClassKey, SlidingWindow<TransactionRecord>> getAllStats();
+
+    /**
+     * Clears the stats
+     */
+    void clearStats();
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the ability to clear transaction statistics via the monitoring endpoint. Transaction monitoring is now read-only, supporting statistics retrieval only.

* **Tests**
  * Updated tests to align with the removal of statistics clearing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->