### PR TITLE
GH-1156 Added a confirmation modal for destructive actions

### DIFF
--- a/master/front-end/src/hooks/useAuthority.ts
+++ b/master/front-end/src/hooks/useAuthority.ts
@@ -15,12 +15,12 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { type TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 
-import type { AppDispatch, RootState } from "store";
+import type { EAuthorities } from "models";
+import type { RootState } from "store";
 
-export const useAppDispatch: () => AppDispatch = useDispatch;
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
-
-export { useConfirmableAction } from "./useConfirmableAction";
-export { useAuthority } from "./useAuthority";
+export const useAuthority = (authority: EAuthorities): boolean => {
+    const authorities = useSelector((state: RootState) => state.authorities);
+    return authorities.includes(authority);
+};

--- a/master/front-end/src/hooks/useConfirmableAction.tsx
+++ b/master/front-end/src/hooks/useConfirmableAction.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import { ExclamationCircleFilled } from "@ant-design/icons";
+
+import { App } from "antd";
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+interface IConfirmableActionOptions {
+    /**
+     * Modal title.
+     */
+    title: ReactNode;
+
+    /**
+     * Modal content.
+     */
+    content?: ReactNode;
+
+    /**
+     * Callback executed after the confirmation.
+     */
+    onOk: () => void;
+
+    /**
+     * Optional text for the confirmation button.
+     */
+    okText?: string;
+
+    /**
+     * Optional text for the cancel button.
+     */
+    cancelText?: string;
+}
+
+export const useConfirmableAction = () => {
+    const { modal } = App.useApp();
+    const { t } = useTranslation();
+
+    return ({ title, content, onOk, okText, cancelText }: IConfirmableActionOptions): void => {
+        modal.confirm({
+            icon: <ExclamationCircleFilled />,
+            title: title,
+            content: content,
+            centered: true,
+            okText: okText ?? t("confirm"),
+            cancelText: cancelText ?? t("cancel"),
+            onOk: onOk,
+        });
+    };
+};

--- a/master/front-end/src/i18n/locales/en.json
+++ b/master/front-end/src/i18n/locales/en.json
@@ -5,6 +5,7 @@
     "copyFailed": "Failed to copy",
     "propertyChangedSuccessfully": "Property Changed",
     "saved": "Saved",
+    "confirm": "Confirm",
     "cancel": "Cancel",
     "status": "Status",
     "on": "ON",

--- a/master/front-end/src/i18n/locales/en.json
+++ b/master/front-end/src/i18n/locales/en.json
@@ -111,7 +111,15 @@
         "enabled": "Cache is enabled at runtime",
         "disabled": "Cache is disabled at runtime",
         "estimatedEntrySize": "Entries count",
-        "statistics": "Statistics"
+        "statistics": "Statistics",
+        "clearAllCachesTitle": "Clear all caches?",
+        "clearAllCachesDescription": "Are you sure you want to clear all caches?",
+        "disableThisCacheTitle": "Disable this cache?",
+        "enableThisCacheTitle": "Enable this cache?",
+        "disableThisCacheDescription": "Are you sure you want to disable this cache?",
+        "enableThisCacheDescription": "Are you sure you want to enable this cache?",
+        "clearThisCacheTitle": "Clear this cache?",
+        "clearThisCacheDescription": "Are you sure you want to clear this cache?"
     },
     "Authentication": {
         "welcome": "Welcome",
@@ -176,7 +184,13 @@
         "fixedTaskIntervalChangeSuccess": "The interval has been changed",
         "cronExpressionChangeSuccess": "Cron expression has been changed",
         "enterNewCron": "Enter New Cron",
-        "enterNewInterval": "Enter new Interval"
+        "enterNewInterval": "Enter new Interval",
+        "runThisTaskTitle": "Run this task?",
+        "runThisTaskDescription": "Are you sure you want to run this scheduled task?",
+        "disableThisTaskTitle": "Disable this task?",
+        "enableThisTaskTitle": "Enable this task?",
+        "disableThisTaskDescription": "Are you sure you want to disable this scheduled task?",
+        "enableThisTaskDescription": "Are you sure you want to enable this scheduled task?"
     },
     "Error": {
         "title": "Error",

--- a/master/front-end/src/i18n/locales/ru.json
+++ b/master/front-end/src/i18n/locales/ru.json
@@ -111,7 +111,15 @@
         "ratio": "Соотношение hits/total",
         "disabled": "Кэш выключен",
         "estimatedEntrySize": "Количество записей",
-        "statistics": "Статистика"
+        "statistics": "Статистика",
+        "clearAllCachesTitle": "Очистить весь кэш?",
+        "clearAllCachesDescription": "Вы уверены, что хотите очистить весь кэш?",
+        "disableThisCacheTitle": "Отключить этот кэш?",
+        "enableThisCacheTitle": "Включить этот кэш?",
+        "disableThisCacheDescription": "Вы уверены, что хотите отключить этот кэш?",
+        "enableThisCacheDescription": "Вы уверены, что хотите включить этот кэш?",
+        "clearThisCacheTitle": "Очистить этот кэш?",
+        "clearThisCacheDescription": "Вы уверены, что хотите очистить этот кэш?"
     },
     "Authentication": {
         "welcome": "Добро пожаловать",
@@ -176,7 +184,13 @@
         "fixedTaskIntervalChangeSuccess": "Интервал был изменён",
         "cronExpressionChangeSuccess": "Cron-выражение было изменено",
         "enterNewCron": "Введите новый Cron",
-        "enterNewInterval": "Введите новый интервал"
+        "enterNewInterval": "Введите новый интервал",
+        "runThisTaskTitle": "Запустить эту задачу?",
+        "runThisTaskDescription": "Вы уверены, что хотите запустить эту запланированную задачу?",
+        "disableThisTaskTitle": "Отключить эту задачу?",
+        "enableThisTaskTitle": "Включить эту задачу?",
+        "disableThisTaskDescription": "Вы уверены, что хотите отключить эту задачу?",
+        "enableThisTaskDescription": "Вы уверены, что хотите включить эту задачу?"
     },
     "Error": {
         "title": "Ошибка",

--- a/master/front-end/src/i18n/locales/ru.json
+++ b/master/front-end/src/i18n/locales/ru.json
@@ -5,6 +5,7 @@
     "copyFailed": "Не удалось скопировать",
     "propertyChangedSuccessfully": "Свойство Изменено",
     "saved": "Сохранено",
+    "confirm": "Подтвердить",
     "cancel": "Отмена",
     "status": "Статус",
     "on": "ВКЛ",

--- a/master/front-end/src/pages/Caches/CacheStatusSwitch/index.tsx
+++ b/master/front-end/src/pages/Caches/CacheStatusSwitch/index.tsx
@@ -15,10 +15,11 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { App, Switch } from "antd";
+import { ExclamationCircleFilled } from "@ant-design/icons";
+
+import { App, Modal, Switch } from "antd";
 import type { AxiosError } from "axios";
-import { type MouseEvent, useState } from "react";
-import * as React from "react";
+import { type KeyboardEvent, type MouseEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router";
 
@@ -48,25 +49,34 @@ export const CacheStatusSwitch = ({ cacheManagerName, cache }: IProps) => {
     const { message } = App.useApp();
     const [mutationRequest, setMutationRequest] = useState(StatelessRequest.inactive());
 
-    const switchTaskStatus = (e: MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLButtonElement>) => {
+    const switchTaskStatus = (e: MouseEvent<HTMLElement> | KeyboardEvent<HTMLButtonElement>) => {
         e.stopPropagation();
-        setMutationRequest(StatelessRequest.loading());
 
-        const requestBody = {
-            instanceId: instanceId!,
-            cacheManagerName: cacheManagerName,
-            cacheName: cache.name,
-        };
+        Modal.confirm({
+            icon: <ExclamationCircleFilled />,
+            title: cache.enabled ? t("Caches.disableThisCacheTitle") : t("Caches.enableThisCacheTitle"),
+            content: cache.enabled ? t("Caches.disableThisCacheDescription") : t("Caches.enableThisCacheDescription"),
+            centered: true,
+            onOk() {
+                setMutationRequest(StatelessRequest.loading());
 
-        (cache.enabled ? disableCache(requestBody) : enableCache(requestBody))
-            .then(() => {
-                message.success(cache.enabled ? t("Caches.disabled") : t("Caches.enabled"));
-                cache.enabled = !cache.enabled;
-                setMutationRequest(StatelessRequest.success());
-            })
-            .catch((error: AxiosError<IErrorResponse>) => {
-                setMutationRequest(StatelessRequest.error(extractErrorCode(error?.response?.data)));
-            });
+                const requestBody = {
+                    instanceId: instanceId!,
+                    cacheManagerName: cacheManagerName,
+                    cacheName: cache.name,
+                };
+
+                (cache.enabled ? disableCache(requestBody) : enableCache(requestBody))
+                    .then(() => {
+                        message.success(cache.enabled ? t("Caches.disabled") : t("Caches.enabled"));
+                        cache.enabled = !cache.enabled;
+                        setMutationRequest(StatelessRequest.success());
+                    })
+                    .catch((error: AxiosError<IErrorResponse>) => {
+                        setMutationRequest(StatelessRequest.error(extractErrorCode(error?.response?.data)));
+                    });
+            },
+        });
     };
 
     return (

--- a/master/front-end/src/pages/Caches/CacheStatusSwitch/index.tsx
+++ b/master/front-end/src/pages/Caches/CacheStatusSwitch/index.tsx
@@ -15,9 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { ExclamationCircleFilled } from "@ant-design/icons";
-
-import { App, Modal, Switch } from "antd";
+import { App, Switch } from "antd";
 import type { AxiosError } from "axios";
 import { type KeyboardEvent, type MouseEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,7 +23,7 @@ import { useParams } from "react-router";
 
 import { NoRequiredAuthorityTooltip } from "components";
 import { extractErrorCode } from "helpers";
-import { useAuthority } from "hooks";
+import { useAuthority, useConfirmableAction } from "hooks";
 import { EAuthorities, type ICacheData, type IErrorResponse, StatelessRequest } from "models";
 import { disableCache, enableCache } from "services";
 
@@ -47,16 +45,15 @@ export const CacheStatusSwitch = ({ cacheManagerName, cache }: IProps) => {
     const { t } = useTranslation();
     const { instanceId } = useParams();
     const { message } = App.useApp();
+    const confirmAction = useConfirmableAction();
     const [mutationRequest, setMutationRequest] = useState(StatelessRequest.inactive());
 
     const switchTaskStatus = (e: MouseEvent<HTMLElement> | KeyboardEvent<HTMLButtonElement>) => {
         e.stopPropagation();
 
-        Modal.confirm({
-            icon: <ExclamationCircleFilled />,
+        confirmAction({
             title: cache.enabled ? t("Caches.disableThisCacheTitle") : t("Caches.enableThisCacheTitle"),
             content: cache.enabled ? t("Caches.disableThisCacheDescription") : t("Caches.enableThisCacheDescription"),
-            centered: true,
             onOk() {
                 setMutationRequest(StatelessRequest.loading());
 

--- a/master/front-end/src/pages/Caches/SingleCacheHeader/index.tsx
+++ b/master/front-end/src/pages/Caches/SingleCacheHeader/index.tsx
@@ -15,9 +15,9 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { ReloadOutlined } from "@ant-design/icons";
+import { ExclamationCircleFilled, ReloadOutlined } from "@ant-design/icons";
 
-import { App, Button } from "antd";
+import { App, Button, Modal } from "antd";
 import type { AxiosError } from "axios";
 import { type MouseEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -56,19 +56,28 @@ export const SingleCacheHeader = ({ cacheManagerName, cache }: IProps) => {
 
     const clearCacheClickHandler = (e: MouseEvent<HTMLElement>): void => {
         e.stopPropagation();
-        setClearSingleCache(StatelessRequest.loading());
-        clearCacheData({
-            instanceId: instanceId!,
-            cacheName: cache.name,
-            cacheManager: cacheManagerName,
-        })
-            .then(() => {
-                setClearSingleCache(StatelessRequest.success());
-                message.success(t("Caches.cleared"));
-            })
-            .catch((error: AxiosError<IErrorResponse>) => {
-                setClearSingleCache(StatelessRequest.error(extractErrorCode(error?.response?.data)));
-            });
+
+        Modal.confirm({
+            icon: <ExclamationCircleFilled />,
+            title: t("Caches.clearThisCacheTitle"),
+            content: t("Caches.clearThisCacheDescription"),
+            centered: true,
+            onOk() {
+                setClearSingleCache(StatelessRequest.loading());
+                clearCacheData({
+                    instanceId: instanceId!,
+                    cacheName: cache.name,
+                    cacheManager: cacheManagerName,
+                })
+                    .then(() => {
+                        setClearSingleCache(StatelessRequest.success());
+                        message.success(t("Caches.cleared"));
+                    })
+                    .catch((error: AxiosError<IErrorResponse>) => {
+                        setClearSingleCache(StatelessRequest.error(extractErrorCode(error?.response?.data)));
+                    });
+            },
+        });
     };
 
     return (

--- a/master/front-end/src/pages/Caches/SingleCacheHeader/index.tsx
+++ b/master/front-end/src/pages/Caches/SingleCacheHeader/index.tsx
@@ -15,9 +15,9 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { ExclamationCircleFilled, ReloadOutlined } from "@ant-design/icons";
+import { ReloadOutlined } from "@ant-design/icons";
 
-import { App, Button, Modal } from "antd";
+import { App, Button } from "antd";
 import type { AxiosError } from "axios";
 import { type MouseEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,7 +25,7 @@ import { useParams } from "react-router";
 
 import { NoRequiredAuthorityTooltip, TooltipWithCopy } from "components";
 import { extractErrorCode } from "helpers";
-import { useAuthority } from "hooks";
+import { useAuthority, useConfirmableAction } from "hooks";
 import { EAuthorities, type ICacheData, type IErrorResponse, StatelessRequest } from "models";
 import { clearCacheData } from "services";
 
@@ -51,17 +51,16 @@ export const SingleCacheHeader = ({ cacheManagerName, cache }: IProps) => {
     const { instanceId } = useParams();
     const { t } = useTranslation();
     const { message } = App.useApp();
+    const confirmAction = useConfirmableAction();
 
     const [clearSingleCache, setClearSingleCache] = useState(StatelessRequest.inactive());
 
     const clearCacheClickHandler = (e: MouseEvent<HTMLElement>): void => {
         e.stopPropagation();
 
-        Modal.confirm({
-            icon: <ExclamationCircleFilled />,
+        confirmAction({
             title: t("Caches.clearThisCacheTitle"),
             content: t("Caches.clearThisCacheDescription"),
-            centered: true,
             onOk() {
                 setClearSingleCache(StatelessRequest.loading());
                 clearCacheData({

--- a/master/front-end/src/pages/Caches/index.tsx
+++ b/master/front-end/src/pages/Caches/index.tsx
@@ -15,9 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { ExclamationCircleFilled } from "@ant-design/icons";
-
-import { App, Button, Modal } from "antd";
+import { App, Button } from "antd";
 import type { AxiosError } from "axios";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,7 +23,7 @@ import { useParams } from "react-router";
 
 import { EmptyHandler, Loader, NoRequiredAuthorityTooltip, PageSearch } from "components";
 import { extractErrorCode, fetchData, filterCacheManagers } from "helpers";
-import { useAuthority } from "hooks";
+import { useAuthority, useConfirmableAction } from "hooks";
 import { EAuthorities, type ICachesResponseBody, type IErrorResponse, StatefulRequest, StatelessRequest } from "models";
 import { clearAllCachesData, getCachesData } from "services";
 
@@ -38,6 +36,7 @@ const Caches = () => {
     const { t } = useTranslation();
     const { instanceId } = useParams();
     const { message } = App.useApp();
+    const confirmAction = useConfirmableAction();
 
     const [search, setSearch] = useState<string>("");
 
@@ -57,11 +56,9 @@ const Caches = () => {
     }
 
     const clearAllCachesClickHandler = (): void => {
-        Modal.confirm({
-            icon: <ExclamationCircleFilled />,
+        confirmAction({
             title: t("Caches.clearAllCachesTitle"),
             content: t("Caches.clearAllCachesDescription"),
-            centered: true,
             onOk() {
                 if (instanceId) {
                     setClearAllCaches(StatelessRequest.loading());

--- a/master/front-end/src/pages/Caches/index.tsx
+++ b/master/front-end/src/pages/Caches/index.tsx
@@ -15,7 +15,9 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { App, Button } from "antd";
+import { ExclamationCircleFilled } from "@ant-design/icons";
+
+import { App, Button, Modal } from "antd";
 import type { AxiosError } from "axios";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -55,22 +57,30 @@ const Caches = () => {
     }
 
     const clearAllCachesClickHandler = (): void => {
-        if (instanceId) {
-            setClearAllCaches(StatelessRequest.loading());
+        Modal.confirm({
+            icon: <ExclamationCircleFilled />,
+            title: t("Caches.clearAllCachesTitle"),
+            content: t("Caches.clearAllCachesDescription"),
+            centered: true,
+            onOk() {
+                if (instanceId) {
+                    setClearAllCaches(StatelessRequest.loading());
 
-            clearAllCachesData(instanceId)
-                .then((value) => {
-                    if (value.status === 200) {
-                        setClearAllCaches(StatelessRequest.success());
-                        message.success(t("Caches.cleared"));
-                    } else {
-                        setClearAllCaches(StatelessRequest.error(""));
-                    }
-                })
-                .catch((error: AxiosError<IErrorResponse>) => {
-                    setClearAllCaches(StatelessRequest.error(extractErrorCode(error?.response?.data)));
-                });
-        }
+                    clearAllCachesData(instanceId)
+                        .then((value) => {
+                            if (value.status === 200) {
+                                setClearAllCaches(StatelessRequest.success());
+                                message.success(t("Caches.cleared"));
+                            } else {
+                                setClearAllCaches(StatelessRequest.error(""));
+                            }
+                        })
+                        .catch((error: AxiosError<IErrorResponse>) => {
+                            setClearAllCaches(StatelessRequest.error(extractErrorCode(error?.response?.data)));
+                        });
+                }
+            },
+        });
     };
 
     const requiredCacheManagers = cacheData.response!.cacheManagers;

--- a/master/front-end/src/pages/ScheduledTasks/ForceRunTask/index.tsx
+++ b/master/front-end/src/pages/ScheduledTasks/ForceRunTask/index.tsx
@@ -15,7 +15,9 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { App, Button } from "antd";
+import { ExclamationCircleFilled } from "@ant-design/icons";
+
+import { App, Button, Modal } from "antd";
 import type { AxiosError } from "axios";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -46,19 +48,27 @@ export const ForceRunTask = ({ trigger }: IProps) => {
     const [forceRunTaskData, setForceRunTaskData] = useState(StatelessRequest.inactive());
 
     const forceRunClickHandler = (): void => {
-        setForceRunTaskData(StatelessRequest.loading());
+        Modal.confirm({
+            icon: <ExclamationCircleFilled />,
+            title: t("ScheduledTasks.runThisTaskTitle"),
+            content: t("ScheduledTasks.runThisTaskDescription"),
+            centered: true,
+            onOk() {
+                setForceRunTaskData(StatelessRequest.loading());
 
-        forceRunTask({
-            instanceId: instanceId!,
-            trigger: trigger,
-        })
-            .then(() => {
-                setForceRunTaskData(StatelessRequest.success());
-                message.success(t("ScheduledTasks.runSuccess"));
-            })
-            .catch((error: AxiosError<IErrorResponse>) => {
-                setForceRunTaskData(StatelessRequest.error(extractErrorCode(error?.response?.data)));
-            });
+                forceRunTask({
+                    instanceId: instanceId!,
+                    trigger: trigger,
+                })
+                    .then(() => {
+                        setForceRunTaskData(StatelessRequest.success());
+                        message.success(t("ScheduledTasks.runSuccess"));
+                    })
+                    .catch((error: AxiosError<IErrorResponse>) => {
+                        setForceRunTaskData(StatelessRequest.error(extractErrorCode(error?.response?.data)));
+                    });
+            },
+        });
     };
 
     return (

--- a/master/front-end/src/pages/ScheduledTasks/ForceRunTask/index.tsx
+++ b/master/front-end/src/pages/ScheduledTasks/ForceRunTask/index.tsx
@@ -15,9 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { ExclamationCircleFilled } from "@ant-design/icons";
-
-import { App, Button, Modal } from "antd";
+import { App, Button } from "antd";
 import type { AxiosError } from "axios";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,7 +23,7 @@ import { useParams } from "react-router";
 
 import { NoRequiredAuthorityTooltip } from "components";
 import { extractErrorCode } from "helpers";
-import { useAuthority } from "hooks";
+import { useAuthority, useConfirmableAction } from "hooks";
 import { EAuthorities, type IErrorResponse, StatelessRequest } from "models";
 import { forceRunTask } from "services";
 
@@ -44,15 +42,14 @@ export const ForceRunTask = ({ trigger }: IProps) => {
 
     const { instanceId } = useParams();
     const { message } = App.useApp();
+    const confirmAction = useConfirmableAction();
 
     const [forceRunTaskData, setForceRunTaskData] = useState(StatelessRequest.inactive());
 
     const forceRunClickHandler = (): void => {
-        Modal.confirm({
-            icon: <ExclamationCircleFilled />,
+        confirmAction({
             title: t("ScheduledTasks.runThisTaskTitle"),
             content: t("ScheduledTasks.runThisTaskDescription"),
-            centered: true,
             onOk() {
                 setForceRunTaskData(StatelessRequest.loading());
 

--- a/master/front-end/src/pages/ScheduledTasks/ScheduledTasksStatusSwitch/index.tsx
+++ b/master/front-end/src/pages/ScheduledTasks/ScheduledTasksStatusSwitch/index.tsx
@@ -15,7 +15,9 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { App, Switch } from "antd";
+import { ExclamationCircleFilled } from "@ant-design/icons";
+
+import { App, Modal, Switch } from "antd";
 import type { AxiosError } from "axios";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -44,24 +46,35 @@ export const ScheduledTasksStatusSwitch = ({ runnable }: IProps) => {
     const [mutationRequest, setMutationRequest] = useState(StatelessRequest.inactive());
 
     const switchTaskStatus = () => {
-        setMutationRequest(StatelessRequest.loading());
+        Modal.confirm({
+            icon: <ExclamationCircleFilled />,
+            title: runnable.enabled
+                ? t("ScheduledTasks.disableThisTaskTitle")
+                : t("ScheduledTasks.enableThisTaskTitle"),
+            content: runnable.enabled
+                ? t("ScheduledTasks.disableThisTaskDescription")
+                : t("ScheduledTasks.enableThisTaskDescription"),
+            centered: true,
+            onOk() {
+                setMutationRequest(StatelessRequest.loading());
 
-        updateScheduledTasksStatus({
-            force: false,
-            instanceId: instanceId!,
-            statusType: runnable.enabled ? "disable" : "enable",
-            trigger: runnable.runnable.target,
-        })
-            .then(() => {
-                message.success(runnable.enabled ? t("ScheduledTasks.disabled") : t("ScheduledTasks.enabled"));
-                runnable.enabled = !runnable.enabled;
-                setMutationRequest(StatelessRequest.success());
-            })
-            .catch((error: AxiosError<IErrorResponse>) => {
-                setMutationRequest(StatelessRequest.error(extractErrorCode(error?.response?.data)));
-            });
+                updateScheduledTasksStatus({
+                    force: false,
+                    instanceId: instanceId!,
+                    statusType: runnable.enabled ? "disable" : "enable",
+                    trigger: runnable.runnable.target,
+                })
+                    .then(() => {
+                        message.success(runnable.enabled ? t("ScheduledTasks.disabled") : t("ScheduledTasks.enabled"));
+                        runnable.enabled = !runnable.enabled;
+                        setMutationRequest(StatelessRequest.success());
+                    })
+                    .catch((error: AxiosError<IErrorResponse>) => {
+                        setMutationRequest(StatelessRequest.error(extractErrorCode(error?.response?.data)));
+                    });
+            },
+        });
     };
-
     return (
         <>
             <NoRequiredAuthorityTooltip disabled={!scheduledTasksAccess}>

--- a/master/front-end/src/pages/ScheduledTasks/ScheduledTasksStatusSwitch/index.tsx
+++ b/master/front-end/src/pages/ScheduledTasks/ScheduledTasksStatusSwitch/index.tsx
@@ -15,9 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import { ExclamationCircleFilled } from "@ant-design/icons";
-
-import { App, Modal, Switch } from "antd";
+import { App, Switch } from "antd";
 import type { AxiosError } from "axios";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -25,7 +23,7 @@ import { useParams } from "react-router";
 
 import { NoRequiredAuthorityTooltip } from "components";
 import { extractErrorCode } from "helpers";
-import { useAuthority } from "hooks";
+import { useAuthority, useConfirmableAction } from "hooks";
 import { EAuthorities, type IErrorResponse, type IRunnable, StatelessRequest } from "models";
 import { updateScheduledTasksStatus } from "services";
 
@@ -42,19 +40,18 @@ export const ScheduledTasksStatusSwitch = ({ runnable }: IProps) => {
     const { t } = useTranslation();
     const { instanceId } = useParams();
     const { message } = App.useApp();
+    const confirmAction = useConfirmableAction();
 
     const [mutationRequest, setMutationRequest] = useState(StatelessRequest.inactive());
 
     const switchTaskStatus = () => {
-        Modal.confirm({
-            icon: <ExclamationCircleFilled />,
+        confirmAction({
             title: runnable.enabled
                 ? t("ScheduledTasks.disableThisTaskTitle")
                 : t("ScheduledTasks.enableThisTaskTitle"),
             content: runnable.enabled
                 ? t("ScheduledTasks.disableThisTaskDescription")
                 : t("ScheduledTasks.enableThisTaskDescription"),
-            centered: true,
             onOk() {
                 setMutationRequest(StatelessRequest.loading());
 


### PR DESCRIPTION
Closes GH-1156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirmation dialogs now appear before clearing all caches, clearing a single cache, toggling cache status, running a scheduled task, and enabling/disabling scheduled tasks.
  * Added new English and Russian i18n strings for a shared “Confirm” button plus cache- and scheduled-task-specific confirmation titles and descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->