### PR TITLE
GH-1216: Added Gradle plugin for Axelix

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,40 +1,69 @@
 lockfile_version: '1'
-generated_at: '2026-06-09T10:05:07.241939+00:00'
-apm_version: 0.14.1
+generated_at: '2026-06-14T09:23:13.342367+00:00'
+apm_version: 0.20.0
 dependencies:
 - repo_url: _local/backlog-refiner
   package_type: claude_skill
   deployed_files:
   - .agents/skills/backlog-refiner
+  - .agents/skills/backlog-refiner/SKILL.md
+  - .agents/skills/backlog-refiner/evals/evals.json
   - .claude/skills/backlog-refiner
+  - .claude/skills/backlog-refiner/SKILL.md
+  - .claude/skills/backlog-refiner/evals/evals.json
+  deployed_file_hashes:
+    .agents/skills/backlog-refiner/SKILL.md: sha256:84bc6c736d9b64d94622428a5157e061dc223919f50a48fa6a83a75dbad3d068
+    .agents/skills/backlog-refiner/evals/evals.json: sha256:d8a6338ee17ceabd5a2b32f247256d6986058db2a48e1e796febcf86fd255208
+    .claude/skills/backlog-refiner/SKILL.md: sha256:84bc6c736d9b64d94622428a5157e061dc223919f50a48fa6a83a75dbad3d068
+    .claude/skills/backlog-refiner/evals/evals.json: sha256:d8a6338ee17ceabd5a2b32f247256d6986058db2a48e1e796febcf86fd255208
   source: local
   local_path: ./.agent_skills/backlog-refiner
 - repo_url: _local/docs-writer
   package_type: claude_skill
   deployed_files:
   - .agents/skills/docs-writer
+  - .agents/skills/docs-writer/SKILL.md
   - .claude/skills/docs-writer
+  - .claude/skills/docs-writer/SKILL.md
+  deployed_file_hashes:
+    .agents/skills/docs-writer/SKILL.md: sha256:6f3e2705975ac21f56ee94a1489e9a7d5821420efa75bb152721323905699356
+    .claude/skills/docs-writer/SKILL.md: sha256:6f3e2705975ac21f56ee94a1489e9a7d5821420efa75bb152721323905699356
   source: local
   local_path: ./.agent_skills/docs-writer
 - repo_url: _local/external-contributor-issues
   package_type: claude_skill
   deployed_files:
   - .agents/skills/external-contributor-issues
+  - .agents/skills/external-contributor-issues/SKILL.md
   - .claude/skills/external-contributor-issues
+  - .claude/skills/external-contributor-issues/SKILL.md
+  deployed_file_hashes:
+    .agents/skills/external-contributor-issues/SKILL.md: sha256:d16e85fc5440978adc54e2eabe45419710f050bce8b925724745ea7596e95b9f
+    .claude/skills/external-contributor-issues/SKILL.md: sha256:d16e85fc5440978adc54e2eabe45419710f050bce8b925724745ea7596e95b9f
   source: local
   local_path: ./.agent_skills/external-contributor-issues
 - repo_url: _local/housekeeper
   package_type: claude_skill
   deployed_files:
   - .agents/skills/housekeeper
+  - .agents/skills/housekeeper/SKILL.md
   - .claude/skills/housekeeper
+  - .claude/skills/housekeeper/SKILL.md
+  deployed_file_hashes:
+    .agents/skills/housekeeper/SKILL.md: sha256:60857fb09e3f651f0e1a3c22616f69a9cc6f41584eae47b978751f7709f8b4c1
+    .claude/skills/housekeeper/SKILL.md: sha256:60857fb09e3f651f0e1a3c22616f69a9cc6f41584eae47b978751f7709f8b4c1
   source: local
   local_path: ./.agent_skills/housekeeper
 - repo_url: _local/security-vulnerabilities-patcher
   package_type: claude_skill
   deployed_files:
   - .agents/skills/security-vulnerabilities-patcher
+  - .agents/skills/security-vulnerabilities-patcher/SKILL.md
   - .claude/skills/security-vulnerabilities-patcher
+  - .claude/skills/security-vulnerabilities-patcher/SKILL.md
+  deployed_file_hashes:
+    .agents/skills/security-vulnerabilities-patcher/SKILL.md: sha256:93ac2d498cca56aade45bfefed8469d5af2b36de10ff80a21a97e989f2a3a72a
+    .claude/skills/security-vulnerabilities-patcher/SKILL.md: sha256:93ac2d498cca56aade45bfefed8469d5af2b36de10ff80a21a97e989f2a3a72a
   source: local
   local_path: ./.agent_skills/security-vulnerabilities-patcher
 - repo_url: anthropics/skills
@@ -45,7 +74,80 @@ dependencies:
   package_type: claude_skill
   deployed_files:
   - .agents/skills/skill-creator
+  - .agents/skills/skill-creator/LICENSE.txt
+  - .agents/skills/skill-creator/SKILL.md
+  - .agents/skills/skill-creator/agents/analyzer.md
+  - .agents/skills/skill-creator/agents/comparator.md
+  - .agents/skills/skill-creator/agents/grader.md
+  - .agents/skills/skill-creator/assets/eval_review.html
+  - .agents/skills/skill-creator/eval-viewer/generate_review.py
+  - .agents/skills/skill-creator/eval-viewer/viewer.html
+  - .agents/skills/skill-creator/references/schemas.md
+  - .agents/skills/skill-creator/scripts/__init__.py
+  - .agents/skills/skill-creator/scripts/aggregate_benchmark.py
+  - .agents/skills/skill-creator/scripts/generate_report.py
+  - .agents/skills/skill-creator/scripts/improve_description.py
+  - .agents/skills/skill-creator/scripts/package_skill.py
+  - .agents/skills/skill-creator/scripts/quick_validate.py
+  - .agents/skills/skill-creator/scripts/run_eval.py
+  - .agents/skills/skill-creator/scripts/run_loop.py
+  - .agents/skills/skill-creator/scripts/utils.py
   - .claude/skills/skill-creator
+  - .claude/skills/skill-creator/LICENSE.txt
+  - .claude/skills/skill-creator/SKILL.md
+  - .claude/skills/skill-creator/agents/analyzer.md
+  - .claude/skills/skill-creator/agents/comparator.md
+  - .claude/skills/skill-creator/agents/grader.md
+  - .claude/skills/skill-creator/assets/eval_review.html
+  - .claude/skills/skill-creator/eval-viewer/generate_review.py
+  - .claude/skills/skill-creator/eval-viewer/viewer.html
+  - .claude/skills/skill-creator/references/schemas.md
+  - .claude/skills/skill-creator/scripts/__init__.py
+  - .claude/skills/skill-creator/scripts/aggregate_benchmark.py
+  - .claude/skills/skill-creator/scripts/generate_report.py
+  - .claude/skills/skill-creator/scripts/improve_description.py
+  - .claude/skills/skill-creator/scripts/package_skill.py
+  - .claude/skills/skill-creator/scripts/quick_validate.py
+  - .claude/skills/skill-creator/scripts/run_eval.py
+  - .claude/skills/skill-creator/scripts/run_loop.py
+  - .claude/skills/skill-creator/scripts/utils.py
+  deployed_file_hashes:
+    .agents/skills/skill-creator/LICENSE.txt: sha256:bc6b3af2f331cbc7fb0da1344efb2cbe5877a31498b4d70dbc7000f3405a1362
+    .agents/skills/skill-creator/SKILL.md: sha256:dcd4803e61e913e6fc27294184cd3a71f09f5e924ff20c8a9a20173e7b3c2bcf
+    .agents/skills/skill-creator/agents/analyzer.md: sha256:bf68f4cac5a56c673a928c2e6d619586c5b93ea364026ab37547772cb45a663a
+    .agents/skills/skill-creator/agents/comparator.md: sha256:fe1fc9787c495d864c5d6eada47396478572325fde1b33a96d78bf4b849b7a3e
+    .agents/skills/skill-creator/agents/grader.md: sha256:57134da0c1a4eea33fbd74a1c9c44aa814f07d6bc64de303edb586f941e5d21a
+    .agents/skills/skill-creator/assets/eval_review.html: sha256:ce477dcc74dc1c0d1d3352646a79167b5a63634e936b1019160025065974e452
+    .agents/skills/skill-creator/eval-viewer/generate_review.py: sha256:fc9d1b9243fe5ab6012ebd579bd76d0035de1b79fd3b969de114defab26478fb
+    .agents/skills/skill-creator/eval-viewer/viewer.html: sha256:a53213426ee1100441d701a3a0d49cda7a842f992d2c36463f4d3cc0258575fa
+    .agents/skills/skill-creator/references/schemas.md: sha256:8e8876180a8989b406a4d3edddf875b04cdfd5805cc8616686d552b11ce4455f
+    .agents/skills/skill-creator/scripts/__init__.py: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    .agents/skills/skill-creator/scripts/aggregate_benchmark.py: sha256:123ef128ea5ccc01a4b1ac212ef5567f21e9c13d3d240609780beeb3200c49aa
+    .agents/skills/skill-creator/scripts/generate_report.py: sha256:13df7118a3c50c83c4c3250a606d5f2b20b25a3d44cbc392b3d669ec75281453
+    .agents/skills/skill-creator/scripts/improve_description.py: sha256:87d864570220b699fac52da309d2d6efdb060647bfebc74f768128e646accf80
+    .agents/skills/skill-creator/scripts/package_skill.py: sha256:1a33059b0db1ef73375d46d513e5ea81369d2e8838c970597b0d52ddef8d1c0f
+    .agents/skills/skill-creator/scripts/quick_validate.py: sha256:67cf5703402013936c8fb75ad6a1afecd8841d45cc5e606b634eb05825fde365
+    .agents/skills/skill-creator/scripts/run_eval.py: sha256:43e3b8f80dbf69c343967ba77e268fae991d9fa3ed68b32a0ff02532cd48657f
+    .agents/skills/skill-creator/scripts/run_loop.py: sha256:7bd6f674203168520517eec94c55f493c0d154339b061b4d7c0f0dad187d0f21
+    .agents/skills/skill-creator/scripts/utils.py: sha256:3af8ae62c40c73ab712207436a0d9a981e845f25c5a7040229eb189cc8e45bb1
+    .claude/skills/skill-creator/LICENSE.txt: sha256:bc6b3af2f331cbc7fb0da1344efb2cbe5877a31498b4d70dbc7000f3405a1362
+    .claude/skills/skill-creator/SKILL.md: sha256:dcd4803e61e913e6fc27294184cd3a71f09f5e924ff20c8a9a20173e7b3c2bcf
+    .claude/skills/skill-creator/agents/analyzer.md: sha256:bf68f4cac5a56c673a928c2e6d619586c5b93ea364026ab37547772cb45a663a
+    .claude/skills/skill-creator/agents/comparator.md: sha256:fe1fc9787c495d864c5d6eada47396478572325fde1b33a96d78bf4b849b7a3e
+    .claude/skills/skill-creator/agents/grader.md: sha256:57134da0c1a4eea33fbd74a1c9c44aa814f07d6bc64de303edb586f941e5d21a
+    .claude/skills/skill-creator/assets/eval_review.html: sha256:ce477dcc74dc1c0d1d3352646a79167b5a63634e936b1019160025065974e452
+    .claude/skills/skill-creator/eval-viewer/generate_review.py: sha256:fc9d1b9243fe5ab6012ebd579bd76d0035de1b79fd3b969de114defab26478fb
+    .claude/skills/skill-creator/eval-viewer/viewer.html: sha256:a53213426ee1100441d701a3a0d49cda7a842f992d2c36463f4d3cc0258575fa
+    .claude/skills/skill-creator/references/schemas.md: sha256:8e8876180a8989b406a4d3edddf875b04cdfd5805cc8616686d552b11ce4455f
+    .claude/skills/skill-creator/scripts/__init__.py: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    .claude/skills/skill-creator/scripts/aggregate_benchmark.py: sha256:123ef128ea5ccc01a4b1ac212ef5567f21e9c13d3d240609780beeb3200c49aa
+    .claude/skills/skill-creator/scripts/generate_report.py: sha256:13df7118a3c50c83c4c3250a606d5f2b20b25a3d44cbc392b3d669ec75281453
+    .claude/skills/skill-creator/scripts/improve_description.py: sha256:87d864570220b699fac52da309d2d6efdb060647bfebc74f768128e646accf80
+    .claude/skills/skill-creator/scripts/package_skill.py: sha256:1a33059b0db1ef73375d46d513e5ea81369d2e8838c970597b0d52ddef8d1c0f
+    .claude/skills/skill-creator/scripts/quick_validate.py: sha256:67cf5703402013936c8fb75ad6a1afecd8841d45cc5e606b634eb05825fde365
+    .claude/skills/skill-creator/scripts/run_eval.py: sha256:43e3b8f80dbf69c343967ba77e268fae991d9fa3ed68b32a0ff02532cd48657f
+    .claude/skills/skill-creator/scripts/run_loop.py: sha256:7bd6f674203168520517eec94c55f493c0d154339b061b4d7c0f0dad187d0f21
+    .claude/skills/skill-creator/scripts/utils.py: sha256:3af8ae62c40c73ab712207436a0d9a981e845f25c5a7040229eb189cc8e45bb1
   content_hash: sha256:b2bfe91d69ca99994c0566baede889e7d2b9bb8791c6b6106c5d387392f717f6
 mcp_servers:
 - github

--- a/plugins/axelix-gradle-plugin/build.gradle.kts
+++ b/plugins/axelix-gradle-plugin/build.gradle.kts
@@ -6,12 +6,6 @@ repositories {
     mavenCentral()
 }
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-}
-
 // The plugin must run inside Gradle 4.0 daemons, which require JDK 8.
 tasks.compileJava {
     options.release = 8

--- a/plugins/axelix-gradle-plugin/build.gradle.kts
+++ b/plugins/axelix-gradle-plugin/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+    `java-gradle-plugin`
+}
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+// The plugin must run inside Gradle 4.0 daemons, which require JDK 8.
+tasks.compileJava {
+    options.release = 8
+}
+
+gradlePlugin {
+    plugins {
+        create("axelix") {
+            id = "com.axelixlabs.axelix"
+            implementationClass = "com.axelixlabs.gradle.plugin.AxelixGradlePlugin"
+        }
+    }
+}
+
+dependencies {
+    testImplementation(platform("org.junit:junit-bom:5.14.0"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.assertj:assertj-core:3.27.6")
+    testImplementation(gradleTestKit())
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/plugins/axelix-gradle-plugin/gradle.properties
+++ b/plugins/axelix-gradle-plugin/gradle.properties
@@ -1,2 +1,0 @@
-group=com.axelixlabs
-version=1.0.0-M2

--- a/plugins/axelix-gradle-plugin/gradle.properties
+++ b/plugins/axelix-gradle-plugin/gradle.properties
@@ -1,0 +1,2 @@
+group=com.axelixlabs
+version=1.0.0-M2

--- a/plugins/axelix-gradle-plugin/settings.gradle.kts
+++ b/plugins/axelix-gradle-plugin/settings.gradle.kts
@@ -1,1 +1,0 @@
-rootProject.name = "axelix-gradle-plugin"

--- a/plugins/axelix-gradle-plugin/settings.gradle.kts
+++ b/plugins/axelix-gradle-plugin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "axelix-gradle-plugin"

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.Collections;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+
+/**
+ * Adds the Spring Test Profiler to the test runtime classpath of the project and generates the
+ * {@code META-INF/spring.factories} registration for it.
+ *
+ * <p>Compatible with Gradle 4.0 through 9.x. Only APIs present in BOTH Gradle 4.0 and 9.x may be
+ * used here: no {@code tasks.register} (added in 4.9), no lazy {@code Provider}/{@code Property}
+ * wiring, no sourceSets/conventions access ({@code JavaPluginConvention} was removed in Gradle 9,
+ * {@code JavaPluginExtension.getSourceSets()} was only added in 7.1).
+ *
+ * <p>The plugin is a no-op until the {@code java} plugin is applied, because the
+ * {@code testRuntimeOnly} configuration only exists once it is.
+ */
+public class AxelixGradlePlugin implements Plugin<Project> {
+
+    static final String GENERATE_TASK_NAME = "generateAxelixSpringFactories";
+
+    static final String PROFILER_DEPENDENCY =
+            "digital.pragmatech.testing:spring-test-profiler:0.1.2";
+
+    static final String REQUIRED_THYMELEAF_VERSION = "3.1.3.RELEASE";
+
+    static final String SPRING_FACTORIES_CONTENT =
+            "org.springframework.test.context.TestExecutionListener=\\\n"
+                    + "digital.pragmatech.testing.SpringTestProfilerListener\n"
+                    + "org.springframework.context.ApplicationContextInitializer=\\\n"
+                    + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer\n";
+
+    @Override
+    public void apply(final Project project) {
+        project.getPluginManager().withPlugin("java", appliedPlugin -> configure(project));
+    }
+
+    private void configure(Project project) {
+        project.getDependencies().add("testRuntimeOnly", PROFILER_DEPENDENCY);
+
+        final File generatedDir = new File(BuildDirCompat.buildDir(project), "generated/axelix");
+
+        Task generateTask = project.getTasks().create(GENERATE_TASK_NAME);
+        generateTask.setGroup("axelix");
+        generateTask.setDescription(
+                "Generates META-INF/spring.factories registering the Spring Test Profiler.");
+        // getInputs().properties(Map) keeps the same signature on Gradle 4.0 and 9.x, while
+        // getInputs().property(String, Object) changed its return type in 4.3 and would throw
+        // NoSuchMethodError on 4.0 daemons.
+        generateTask
+                .getInputs()
+                .properties(Collections.singletonMap("content", SPRING_FACTORIES_CONTENT));
+        generateTask.getOutputs().dir(generatedDir);
+        generateTask.doLast(task -> writeSpringFactories(generatedDir));
+
+        // Puts the generated directory on the test runtime classpath without touching
+        // sourceSets; builtBy ensures the generator runs before any consumer of the
+        // configuration.
+        project.getDependencies()
+                .add("testRuntimeOnly", project.files(generatedDir).builtBy(generateTask));
+
+        project.afterEvaluate(AxelixGradlePlugin::counteractThymeleafDowngrade);
+    }
+
+    /**
+     * The Spring Boot 2 BOM manages Thymeleaf at 3.0.x, and when it is applied through the
+     * {@code io.spring.dependency-management} plugin it overrides (Maven semantics) the 3.1.x
+     * version that spring-test-profiler needs to render its HTML report — the report generation
+     * then dies silently in its JVM shutdown hook. Bump Thymeleaf back, but only on the test
+     * runtime classpath and only when something pinned it below 3.1: Spring Boot 3/4 BOMs already
+     * manage 3.1+, and without a forcing BOM Gradle's own conflict resolution picks 3.1.x anyway,
+     * so this rule is a no-op everywhere except Spring Boot 2.
+     *
+     * <p>Registered in {@code afterEvaluate} so the rule runs after (and thus overrides) the
+     * dependency-management plugin's own resolution rule.
+     */
+    private static void counteractThymeleafDowngrade(Project project) {
+        Configuration testRuntimeClasspath =
+                project.getConfigurations().findByName("testRuntimeClasspath");
+        if (testRuntimeClasspath == null) {
+            return;
+        }
+        testRuntimeClasspath
+                .getResolutionStrategy()
+                .eachDependency(
+                        details -> {
+                            if ("org.thymeleaf".equals(details.getTarget().getGroup())
+                                    && "thymeleaf".equals(details.getTarget().getName())
+                                    && isOlderThanThymeleaf31(details.getTarget().getVersion())) {
+                                details.useVersion(REQUIRED_THYMELEAF_VERSION);
+                            }
+                        });
+    }
+
+    private static boolean isOlderThanThymeleaf31(String version) {
+        return version != null && (version.startsWith("2.") || version.startsWith("3.0."));
+    }
+
+    private static void writeSpringFactories(File generatedDir) {
+        File target = new File(new File(generatedDir, "META-INF"), "spring.factories");
+        File parent = target.getParentFile();
+        if (!parent.isDirectory() && !parent.mkdirs()) {
+            throw new GradleException("Cannot create directory " + parent);
+        }
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(target), "UTF-8")) {
+            writer.write(SPRING_FACTORIES_CONTENT);
+        } catch (IOException e) {
+            throw new GradleException("Failed to write " + target, e);
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
@@ -22,6 +22,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collections;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
@@ -136,7 +138,7 @@ public class AxelixGradlePlugin implements Plugin<Project> {
         if (!parent.isDirectory() && !parent.mkdirs()) {
             throw new GradleException("Cannot create directory " + parent);
         }
-        try (Writer writer = new OutputStreamWriter(new FileOutputStream(target), "UTF-8")) {
+        try (Writer writer = new OutputStreamWriter(Files.newOutputStream(target.toPath()), StandardCharsets.UTF_8)) {
             writer.write(SPRING_FACTORIES_CONTENT);
         } catch (IOException e) {
             throw new GradleException("Failed to write " + target, e);

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
@@ -17,19 +17,8 @@
  */
 package com.axelixlabs.gradle.plugin;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.Collections;
-import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.tasks.bundling.Jar;
 
 /**
  * Adds the Spring Test Profiler to the test runtime classpath of the project, generates the
@@ -47,101 +36,17 @@ import org.gradle.api.tasks.bundling.Jar;
  */
 public class AxelixGradlePlugin implements Plugin<Project> {
 
-    static final String GENERATE_TASK_NAME = "generateAxelixSpringFactories";
-
-    static final String COPY_REPORT_TASK_NAME = "copyAxelixTestProfilerReport";
-
-    static final String PROFILER_DEPENDENCY =
-            "digital.pragmatech.testing:spring-test-profiler:0.1.2";
-
-    static final String THYMELEAF_DEPENDENCY = "org.thymeleaf:thymeleaf:3.1.3.RELEASE";
-
-    static final String SPRING_FACTORIES_CONTENT =
-            "org.springframework.test.context.TestExecutionListener=\\\n"
-                    + "digital.pragmatech.testing.SpringTestProfilerListener\n"
-                    + "org.springframework.context.ApplicationContextInitializer=\\\n"
-                    + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer\n";
-
     @Override
     public void apply(final Project project) {
         project.getPluginManager().withPlugin("java", appliedPlugin -> configure(project));
     }
 
     private void configure(Project project) {
-        project.getDependencies().add("testRuntimeOnly", PROFILER_DEPENDENCY);
-        project.getDependencies().add("testImplementation", THYMELEAF_DEPENDENCY);
-
-        final File generatedDir = new File(BuildDirCompat.buildDir(project), "generated/axelix");
-
-        Task generateTask = project.getTasks().create(GENERATE_TASK_NAME);
-        generateTask.setGroup("axelix");
-        generateTask.setDescription(
-                "Generates META-INF/spring.factories registering the Spring Test Profiler.");
-        // getInputs().properties(Map) keeps the same signature on Gradle 4.0 and 9.x, while
-        // getInputs().property(String, Object) changed its return type in 4.3 and would throw
-        // NoSuchMethodError on 4.0 daemons.
-        generateTask
-                .getInputs()
-                .properties(Collections.singletonMap("content", SPRING_FACTORIES_CONTENT));
-        generateTask.getOutputs().dir(generatedDir);
-        generateTask.doLast(task -> writeSpringFactories(generatedDir));
-
-        // Puts the generated directory on the test runtime classpath without touching
-        // sourceSets; builtBy ensures the generator runs before any consumer of the
-        // configuration.
-        project.getDependencies()
-                .add("testRuntimeOnly", project.files(generatedDir).builtBy(generateTask));
-
-        configureReportCopy(project);
-    }
-
-    /**
-     * Copies the profiler report into {@code build/resources/main} so it ends up on the
-     * application runtime classpath. The task depends on {@code test}, so it never runs when
-     * tests fail. It deliberately declares no inputs/outputs: the destination is owned by
-     * {@code processResources}, and registering it as an output here would create overlapping
-     * outputs that degrade caching — the report is regenerated on every test run anyway, so an
-     * always-run copy is correct. Jar tasks are ordered after the copy so the report lands in
-     * the packaged jar deterministically instead of depending on whether {@code jar} happened
-     * to run before or after {@code test}.
-     */
-    private static void configureReportCopy(final Project project) {
-        final File buildDir = BuildDirCompat.buildDir(project);
-        final File reportDir = new File(buildDir, "spring-test-profiler");
-        final File destinationDir = new File(buildDir, "resources/main/spring-test-profiler");
-
-        Task copyTask = project.getTasks().create(COPY_REPORT_TASK_NAME);
-        copyTask.setGroup("axelix");
-        copyTask.setDescription(
-                "Copies the Spring Test Profiler report onto the application classpath.");
-        copyTask.dependsOn("test");
-        // Copying from a nonexistent source dir is a silent no-op, so projects whose tests
-        // produce no report still build fine.
-        copyTask.doLast(
-                task -> {
-                    project.delete(destinationDir);
-
-                    project.copy(
-                        spec -> {
-                            spec.from(reportDir);
-                            spec.into(destinationDir);
-                        });
-                });
-
-        project.getTasks().getByName("build").dependsOn(copyTask);
-        project.getTasks().withType(Jar.class).all(jar -> jar.mustRunAfter(copyTask));
-    }
-
-    private static void writeSpringFactories(File generatedDir) {
-        File target = new File(new File(generatedDir, "META-INF"), "spring.factories");
-        File parent = target.getParentFile();
-        if (!parent.isDirectory() && !parent.mkdirs()) {
-            throw new GradleException("Cannot create directory " + parent);
-        }
-        try (Writer writer = new OutputStreamWriter(Files.newOutputStream(target.toPath()), StandardCharsets.UTF_8)) {
-            writer.write(SPRING_FACTORIES_CONTENT);
-        } catch (IOException e) {
-            throw new GradleException("Failed to write " + target, e);
-        }
+        // Deferred to afterEvaluate so the project's own dependency declarations are visible:
+        // the profiler and Thymeleaf are only contributed when the test classpath does not
+        // already carry them, leaving a project's chosen version untouched.
+        project.afterEvaluate(TestDependencyContributor::contributeMissingTestDependencies);
+        SpringFactoriesGenerator.configure(project);
+        TestProfilerReportCopy.configure(project);
     }
 }

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
@@ -27,7 +27,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.bundling.Jar;
 
 /**
@@ -53,7 +52,7 @@ public class AxelixGradlePlugin implements Plugin<Project> {
     static final String PROFILER_DEPENDENCY =
             "digital.pragmatech.testing:spring-test-profiler:0.1.2";
 
-    static final String REQUIRED_THYMELEAF_VERSION = "3.1.3.RELEASE";
+    static final String THYMELEAF_DEPENDENCY = "org.thymeleaf:thymeleaf:3.1.3.RELEASE";
 
     static final String SPRING_FACTORIES_CONTENT =
             "org.springframework.test.context.TestExecutionListener=\\\n"
@@ -68,6 +67,7 @@ public class AxelixGradlePlugin implements Plugin<Project> {
 
     private void configure(Project project) {
         project.getDependencies().add("testRuntimeOnly", PROFILER_DEPENDENCY);
+        project.getDependencies().add("testImplementation", THYMELEAF_DEPENDENCY);
 
         final File generatedDir = new File(BuildDirCompat.buildDir(project), "generated/axelix");
 
@@ -91,8 +91,6 @@ public class AxelixGradlePlugin implements Plugin<Project> {
                 .add("testRuntimeOnly", project.files(generatedDir).builtBy(generateTask));
 
         configureReportCopy(project);
-
-        project.afterEvaluate(AxelixGradlePlugin::counteractThymeleafDowngrade);
     }
 
     /**
@@ -127,40 +125,6 @@ public class AxelixGradlePlugin implements Plugin<Project> {
 
         project.getTasks().getByName("build").dependsOn(copyTask);
         project.getTasks().withType(Jar.class).all(jar -> jar.mustRunAfter(copyTask));
-    }
-
-    /**
-     * The Spring Boot 2 BOM manages Thymeleaf at 3.0.x, and when it is applied through the
-     * {@code io.spring.dependency-management} plugin it overrides (Maven semantics) the 3.1.x
-     * version that spring-test-profiler needs to render its HTML report — the report generation
-     * then dies silently in its JVM shutdown hook. Bump Thymeleaf back, but only on the test
-     * runtime classpath and only when something pinned it below 3.1: Spring Boot 3/4 BOMs already
-     * manage 3.1+, and without a forcing BOM Gradle's own conflict resolution picks 3.1.x anyway,
-     * so this rule is a no-op everywhere except Spring Boot 2.
-     *
-     * <p>Registered in {@code afterEvaluate} so the rule runs after (and thus overrides) the
-     * dependency-management plugin's own resolution rule.
-     */
-    private static void counteractThymeleafDowngrade(Project project) {
-        Configuration testRuntimeClasspath =
-                project.getConfigurations().findByName("testRuntimeClasspath");
-        if (testRuntimeClasspath == null) {
-            return;
-        }
-        testRuntimeClasspath
-                .getResolutionStrategy()
-                .eachDependency(
-                        details -> {
-                            if ("org.thymeleaf".equals(details.getTarget().getGroup())
-                                    && "thymeleaf".equals(details.getTarget().getName())
-                                    && isOlderThanThymeleaf31(details.getTarget().getVersion())) {
-                                details.useVersion(REQUIRED_THYMELEAF_VERSION);
-                            }
-                        });
-    }
-
-    private static boolean isOlderThanThymeleaf31(String version) {
-        return version != null && (version.startsWith("2.") || version.startsWith("3.0."));
     }
 
     private static void writeSpringFactories(File generatedDir) {

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
@@ -28,10 +28,13 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.bundling.Jar;
 
 /**
- * Adds the Spring Test Profiler to the test runtime classpath of the project and generates the
- * {@code META-INF/spring.factories} registration for it.
+ * Adds the Spring Test Profiler to the test runtime classpath of the project, generates the
+ * {@code META-INF/spring.factories} registration for it, and copies the profiler's HTML report
+ * onto the application classpath ({@code build/resources/main}) after tests pass, so that the
+ * {@code build} task produces a jar containing the report.
  *
  * <p>Compatible with Gradle 4.0 through 9.x. Only APIs present in BOTH Gradle 4.0 and 9.x may be
  * used here: no {@code tasks.register} (added in 4.9), no lazy {@code Provider}/{@code Property}
@@ -44,6 +47,8 @@ import org.gradle.api.artifacts.Configuration;
 public class AxelixGradlePlugin implements Plugin<Project> {
 
     static final String GENERATE_TASK_NAME = "generateAxelixSpringFactories";
+
+    static final String COPY_REPORT_TASK_NAME = "copyAxelixTestProfilerReport";
 
     static final String PROFILER_DEPENDENCY =
             "digital.pragmatech.testing:spring-test-profiler:0.1.2";
@@ -85,7 +90,43 @@ public class AxelixGradlePlugin implements Plugin<Project> {
         project.getDependencies()
                 .add("testRuntimeOnly", project.files(generatedDir).builtBy(generateTask));
 
+        configureReportCopy(project);
+
         project.afterEvaluate(AxelixGradlePlugin::counteractThymeleafDowngrade);
+    }
+
+    /**
+     * Copies the profiler report into {@code build/resources/main} so it ends up on the
+     * application runtime classpath. The task depends on {@code test}, so it never runs when
+     * tests fail. It deliberately declares no inputs/outputs: the destination is owned by
+     * {@code processResources}, and registering it as an output here would create overlapping
+     * outputs that degrade caching — the report is regenerated on every test run anyway, so an
+     * always-run copy is correct. Jar tasks are ordered after the copy so the report lands in
+     * the packaged jar deterministically instead of depending on whether {@code jar} happened
+     * to run before or after {@code test}.
+     */
+    private static void configureReportCopy(final Project project) {
+        final File buildDir = BuildDirCompat.buildDir(project);
+        final File reportDir = new File(buildDir, "spring-test-profiler");
+        final File destinationDir = new File(buildDir, "resources/main/spring-test-profiler");
+
+        Task copyTask = project.getTasks().create(COPY_REPORT_TASK_NAME);
+        copyTask.setGroup("axelix");
+        copyTask.setDescription(
+                "Copies the Spring Test Profiler report onto the application classpath.");
+        copyTask.dependsOn("test");
+        // Copying from a nonexistent source dir is a silent no-op, so projects whose tests
+        // produce no report still build fine.
+        copyTask.doLast(
+                task ->
+                        project.copy(
+                                spec -> {
+                                    spec.from(reportDir);
+                                    spec.into(destinationDir);
+                                }));
+
+        project.getTasks().getByName("build").dependsOn(copyTask);
+        project.getTasks().withType(Jar.class).all(jar -> jar.mustRunAfter(copyTask));
     }
 
     /**

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
@@ -116,12 +116,15 @@ public class AxelixGradlePlugin implements Plugin<Project> {
         // Copying from a nonexistent source dir is a silent no-op, so projects whose tests
         // produce no report still build fine.
         copyTask.doLast(
-                task ->
-                        project.copy(
-                                spec -> {
-                                    spec.from(reportDir);
-                                    spec.into(destinationDir);
-                                }));
+                task -> {
+                    project.delete(destinationDir);
+
+                    project.copy(
+                        spec -> {
+                            spec.from(reportDir);
+                            spec.into(destinationDir);
+                        });
+                });
 
         project.getTasks().getByName("build").dependsOn(copyTask);
         project.getTasks().withType(Jar.class).all(jar -> jar.mustRunAfter(copyTask));

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/BuildDirCompat.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/BuildDirCompat.java
@@ -18,6 +18,7 @@
 package com.axelixlabs.gradle.plugin;
 
 import java.io.File;
+
 import org.gradle.api.Project;
 import org.gradle.util.GradleVersion;
 

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/BuildDirCompat.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/BuildDirCompat.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.File;
+import org.gradle.api.Project;
+import org.gradle.util.GradleVersion;
+
+/**
+ * Resolves the project build directory across Gradle 4.0 through 9.x: {@code getBuildDir()} on
+ * old versions, {@code layout.buildDirectory} on 5.0+ where the former triggers deprecation
+ * warnings (8.3+).
+ */
+final class BuildDirCompat {
+
+    private static final GradleVersion MODERN = GradleVersion.version("5.0");
+
+    private BuildDirCompat() {}
+
+    static File buildDir(Project project) {
+        if (GradleVersion.current().getBaseVersion().compareTo(MODERN) >= 0) {
+            return Modern.buildDir(project);
+        }
+        return legacyBuildDir(project);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static File legacyBuildDir(Project project) {
+        return project.getBuildDir();
+    }
+
+    /**
+     * Separate class so that Gradle 4.0 daemons never resolve
+     * {@code ProjectLayout.getBuildDirectory()}, which did not exist back then.
+     */
+    private static final class Modern {
+
+        private Modern() {}
+
+        static File buildDir(Project project) {
+            return project.getLayout().getBuildDirectory().get().getAsFile();
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/SpringFactoriesGenerator.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/SpringFactoriesGenerator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+
+/**
+ * Generates the {@code META-INF/spring.factories} registration for the Spring Test Profiler and
+ * puts the generated directory on the test runtime classpath.
+ */
+final class SpringFactoriesGenerator {
+
+    static final String GENERATE_TASK_NAME = "generateAxelixSpringFactories";
+
+    static final String SPRING_FACTORIES_CONTENT = "org.springframework.test.context.TestExecutionListener=\\\n"
+            + "digital.pragmatech.testing.SpringTestProfilerListener\n"
+            + "org.springframework.context.ApplicationContextInitializer=\\\n"
+            + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer\n";
+
+    private SpringFactoriesGenerator() {}
+
+    static void configure(final Project project) {
+        final File generatedDir = new File(BuildDirCompat.buildDir(project), "generated/axelix");
+
+        Task generateTask = project.getTasks().create(GENERATE_TASK_NAME);
+        generateTask.setGroup("axelix");
+        generateTask.setDescription("Generates META-INF/spring.factories registering the Spring Test Profiler.");
+        // getInputs().properties(Map) keeps the same signature on Gradle 4.0 and 9.x, while
+        // getInputs().property(String, Object) changed its return type in 4.3 and would throw
+        // NoSuchMethodError on 4.0 daemons.
+        generateTask.getInputs().properties(Collections.singletonMap("content", SPRING_FACTORIES_CONTENT));
+        generateTask.getOutputs().dir(generatedDir);
+        generateTask.doLast(task -> writeSpringFactories(generatedDir));
+
+        // Puts the generated directory on the test runtime classpath without touching
+        // sourceSets; builtBy ensures the generator runs before any consumer of the
+        // configuration.
+        project.getDependencies()
+                .add("testRuntimeOnly", project.files(generatedDir).builtBy(generateTask));
+    }
+
+    private static void writeSpringFactories(File generatedDir) {
+        File target = new File(new File(generatedDir, "META-INF"), "spring.factories");
+        File parent = target.getParentFile();
+        if (!parent.isDirectory() && !parent.mkdirs()) {
+            throw new GradleException("Cannot create directory " + parent);
+        }
+        try (Writer writer = new OutputStreamWriter(Files.newOutputStream(target.toPath()), StandardCharsets.UTF_8)) {
+            writer.write(SPRING_FACTORIES_CONTENT);
+        } catch (IOException e) {
+            throw new GradleException("Failed to write " + target, e);
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/TestDependencyContributor.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/TestDependencyContributor.java
@@ -20,6 +20,7 @@ package com.axelixlabs.gradle.plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.util.GradleVersion;
 
 /**
  * Contributes the Spring Test Profiler and Thymeleaf to the project's test classpath when they are
@@ -39,8 +40,8 @@ final class TestDependencyContributor {
 
     static final String THYMELEAF_NAME = "thymeleaf";
 
-    /** Minimum Thymeleaf version the profiler's HTML report renders on, as {major, minor, patch}. */
-    private static final int[] MIN_THYMELEAF_VERSION = {3, 1, 3};
+    /** Minimum Thymeleaf version the profiler's HTML report renders on. */
+    private static final GradleVersion MIN_THYMELEAF_VERSION = GradleVersion.version("3.1.3");
 
     private TestDependencyContributor() {}
 
@@ -95,36 +96,46 @@ final class TestDependencyContributor {
     }
 
     /**
-     * Whether a declared Thymeleaf version is below {@code 3.1.3}. Only the leading dot-separated
-     * numeric components are compared; a trailing qualifier such as {@code .RELEASE} is ignored. A
-     * {@code null} or non-numeric version is treated as not below the minimum, leaving an
-     * unrecognised version untouched.
+     * Whether a declared Thymeleaf version is below {@code 3.1.3}, using {@link GradleVersion} for
+     * the comparison. Only the leading dot-separated numeric components are compared; a trailing
+     * qualifier such as {@code .RELEASE} is stripped first, since {@link GradleVersion} does not
+     * accept it. A {@code null} or non-numeric version is treated as not below the minimum, leaving
+     * an unrecognised version untouched.
      */
     private static boolean isBelowMinimumThymeleaf(final String version) {
         if (version == null) {
             return false;
         }
-        int[] components = leadingNumericComponents(version);
-        for (int i = 0; i < MIN_THYMELEAF_VERSION.length; i++) {
-            int part = i < components.length ? components[i] : 0;
-            if (part != MIN_THYMELEAF_VERSION[i]) {
-                return part < MIN_THYMELEAF_VERSION[i];
-            }
+        String numericVersion = leadingNumericVersion(version);
+        if (numericVersion == null) {
+            return false;
         }
-        return false;
+        return GradleVersion.version(numericVersion).getBaseVersion().compareTo(MIN_THYMELEAF_VERSION) < 0;
     }
 
-    private static int[] leadingNumericComponents(final String version) {
+    /**
+     * Extracts the leading dot-separated numeric components of a version (e.g. {@code "3.0.15"} from
+     * {@code "3.0.15.RELEASE"}) as a string {@link GradleVersion} can parse, dropping any trailing
+     * qualifier. Returns {@code null} when there is no leading numeric component. A single numeric
+     * component is padded to {@code major.minor} form, which {@link GradleVersion} requires.
+     */
+    private static String leadingNumericVersion(final String version) {
         String[] segments = version.split("\\.");
         int count = 0;
         while (count < segments.length && isNumeric(segments[count])) {
             count++;
         }
-        int[] components = new int[count];
-        for (int i = 0; i < count; i++) {
-            components[i] = Integer.parseInt(segments[i]);
+        if (count == 0) {
+            return null;
         }
-        return components;
+        StringBuilder builder = new StringBuilder(segments[0]);
+        for (int i = 1; i < count; i++) {
+            builder.append('.').append(segments[i]);
+        }
+        if (count == 1) {
+            builder.append(".0");
+        }
+        return builder.toString();
     }
 
     private static boolean isNumeric(final String segment) {

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/TestDependencyContributor.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/TestDependencyContributor.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+
+/**
+ * Contributes the Spring Test Profiler and Thymeleaf to the project's test classpath when they are
+ * missing, leaving a project's own declarations untouched.
+ */
+final class TestDependencyContributor {
+
+    static final String PROFILER_DEPENDENCY = "digital.pragmatech.testing:spring-test-profiler:0.1.2";
+
+    static final String PROFILER_GROUP = "digital.pragmatech.testing";
+
+    static final String PROFILER_NAME = "spring-test-profiler";
+
+    static final String THYMELEAF_DEPENDENCY = "org.thymeleaf:thymeleaf:3.1.3.RELEASE";
+
+    static final String THYMELEAF_GROUP = "org.thymeleaf";
+
+    static final String THYMELEAF_NAME = "thymeleaf";
+
+    /** Minimum Thymeleaf version the profiler's HTML report renders on, as {major, minor, patch}. */
+    private static final int[] MIN_THYMELEAF_VERSION = {3, 1, 3};
+
+    private TestDependencyContributor() {}
+
+    /**
+     * Adds the Spring Test Profiler and Thymeleaf to the test classpath. The profiler is added only
+     * when it is not already declared. Thymeleaf is added when it is absent and bumped when a
+     * version older than {@code 3.1.3} is declared, because the profiler's HTML report fails to
+     * render on older Thymeleaf; a project already on {@code 3.1.3} or newer is left untouched.
+     */
+    static void contributeMissingTestDependencies(final Project project) {
+        if (!isOnTestClasspath(project, PROFILER_GROUP, PROFILER_NAME)) {
+            project.getDependencies().add("testRuntimeOnly", PROFILER_DEPENDENCY);
+        }
+        if (shouldContributeThymeleaf(project)) {
+            project.getDependencies().add("testImplementation", THYMELEAF_DEPENDENCY);
+        }
+    }
+
+    /**
+     * Whether the plugin should put Thymeleaf {@code 3.1.3} on the test classpath: it does so when
+     * Thymeleaf is not declared at all, or is declared at a version below {@code 3.1.3}. When an
+     * older version is pinned directly, the contributed dependency wins by Gradle's newest-version
+     * conflict resolution; a project already on {@code 3.1.3} or newer is left untouched.
+     */
+    private static boolean shouldContributeThymeleaf(final Project project) {
+        Dependency declared = findDeclaredOnTestClasspath(project, THYMELEAF_GROUP, THYMELEAF_NAME);
+        return declared == null || isBelowMinimumThymeleaf(declared.getVersion());
+    }
+
+    private static boolean isOnTestClasspath(final Project project, final String group, final String name) {
+        return findDeclaredOnTestClasspath(project, group, name) != null;
+    }
+
+    /**
+     * Returns the dependency with the given group and name declared on the test runtime classpath,
+     * including dependencies inherited from extended configurations (e.g. an {@code implementation}
+     * dependency that propagates to {@code testRuntimeClasspath}), or {@code null} if none is
+     * declared. Only declared dependencies are inspected; the configuration is not resolved.
+     */
+    private static Dependency findDeclaredOnTestClasspath(
+            final Project project, final String group, final String name) {
+        Configuration testRuntimeClasspath = project.getConfigurations().findByName("testRuntimeClasspath");
+        if (testRuntimeClasspath == null) {
+            return null;
+        }
+        for (Dependency dependency : testRuntimeClasspath.getAllDependencies()) {
+            if (group.equals(dependency.getGroup()) && name.equals(dependency.getName())) {
+                return dependency;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Whether a declared Thymeleaf version is below {@code 3.1.3}. Only the leading dot-separated
+     * numeric components are compared; a trailing qualifier such as {@code .RELEASE} is ignored. A
+     * {@code null} or non-numeric version is treated as not below the minimum, leaving an
+     * unrecognised version untouched.
+     */
+    private static boolean isBelowMinimumThymeleaf(final String version) {
+        if (version == null) {
+            return false;
+        }
+        int[] components = leadingNumericComponents(version);
+        for (int i = 0; i < MIN_THYMELEAF_VERSION.length; i++) {
+            int part = i < components.length ? components[i] : 0;
+            if (part != MIN_THYMELEAF_VERSION[i]) {
+                return part < MIN_THYMELEAF_VERSION[i];
+            }
+        }
+        return false;
+    }
+
+    private static int[] leadingNumericComponents(final String version) {
+        String[] segments = version.split("\\.");
+        int count = 0;
+        while (count < segments.length && isNumeric(segments[count])) {
+            count++;
+        }
+        int[] components = new int[count];
+        for (int i = 0; i < count; i++) {
+            components[i] = Integer.parseInt(segments[i]);
+        }
+        return components;
+    }
+
+    private static boolean isNumeric(final String segment) {
+        if (segment.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < segment.length(); i++) {
+            if (!Character.isDigit(segment.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/TestProfilerReportCopy.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/TestProfilerReportCopy.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.File;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.bundling.Jar;
+
+/**
+ * Copies the Spring Test Profiler HTML report onto the application classpath after tests pass, so
+ * the {@code build} task produces a jar containing the report.
+ */
+final class TestProfilerReportCopy {
+
+    static final String COPY_REPORT_TASK_NAME = "copyAxelixTestProfilerReport";
+
+    private TestProfilerReportCopy() {}
+
+    /**
+     * Copies the profiler report into {@code build/resources/main} so it ends up on the
+     * application runtime classpath. The task depends on {@code test}, so it never runs when
+     * tests fail. It deliberately declares no inputs/outputs: the destination is owned by
+     * {@code processResources}, and registering it as an output here would create overlapping
+     * outputs that degrade caching — the report is regenerated on every test run anyway, so an
+     * always-run copy is correct. Jar tasks are ordered after the copy so the report lands in
+     * the packaged jar deterministically instead of depending on whether {@code jar} happened
+     * to run before or after {@code test}.
+     */
+    static void configure(final Project project) {
+        final File buildDir = BuildDirCompat.buildDir(project);
+        final File reportDir = new File(buildDir, "spring-test-profiler");
+        final File destinationDir = new File(buildDir, "resources/main/spring-test-profiler");
+
+        Task copyTask = project.getTasks().create(COPY_REPORT_TASK_NAME);
+        copyTask.setGroup("axelix");
+        copyTask.setDescription("Copies the Spring Test Profiler report onto the application classpath.");
+        copyTask.dependsOn("test");
+        // Copying from a nonexistent source dir is a silent no-op, so projects whose tests
+        // produce no report still build fine.
+        copyTask.doLast(task -> {
+            project.delete(destinationDir);
+
+            project.copy(spec -> {
+                spec.from(reportDir);
+                spec.into(destinationDir);
+            });
+        });
+
+        project.getTasks().getByName("build").dependsOn(copyTask);
+        project.getTasks().withType(Jar.class).all(jar -> jar.mustRunAfter(copyTask));
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
@@ -146,6 +146,29 @@ class AxelixGradlePluginFunctionalTest {
         assertThat(result.task(":test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void buildSucceedsWhenNoProfilerReportWasProduced(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile(
+                "build.gradle",
+                "plugins {\n"
+                        + "    id 'com.axelixlabs.axelix'\n"
+                        + "}\n"
+                        + "apply plugin: 'java'\n"
+                        + "\n"
+                        + "repositories { mavenCentral() }\n");
+
+        // when.
+        BuildResult result = createRunner(gradleVersion, "build", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":copyAxelixTestProfilerReport").getOutcome())
+                .isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(projectDir.resolve("build/resources/main/spring-test-profiler")).doesNotExist();
+    }
+
     private GradleRunner createRunner(String gradleVersion, String... arguments) {
         // Never call withDebug(true) here: a debug run executes the build in-process on the
         // current (modern) JVM, bypassing the JDK 8 daemon required by Gradle 4.0.

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
@@ -21,10 +21,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
@@ -201,22 +199,12 @@ class AxelixGradlePluginFunctionalTest {
         if (override != null && !override.isEmpty()) {
             return override;
         }
-        Path candidates = Paths.get(System.getProperty("user.home"), ".sdkman/candidates/java");
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(candidates, "8.*")) {
-            for (Path candidate : stream) {
-                if (Files.isExecutable(candidate.resolve("bin/java"))) {
-                    return candidate.toString();
-                }
-            }
-        } catch (IOException ignored) {
-            // Fall through to the failure below.
-        }
         throw new IllegalStateException(
                 "No JDK 8 found for the Gradle "
                         + MIN_GRADLE_VERSION
                         + " functional tests. Install Liberica JDK 8 via sdkman:\n"
                         + "  source ~/.sdkman/bin/sdkman-init.sh && echo n | sdk install java"
                         + " 8.0.492-librca\n"
-                        + "or point AXELIX_TEST_JDK8_HOME at an existing JDK 8 installation.");
+                        + "and point AXELIX_TEST_JDK8_HOME at the JDK 8 installation.");
     }
 }

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
@@ -78,7 +78,10 @@ class AxelixGradlePluginFunctionalTest {
         assertThat(result.task(":generateAxelixSpringFactories").getOutcome())
                 .isEqualTo(TaskOutcome.SUCCESS);
         assertThat(result.getOutput()).contains("spring-test-profiler-0.1.2.jar");
-        assertThat(result.getOutput().lines().filter(line -> line.startsWith("TRC>> ")))
+        assertThat(
+                        result.getOutput().lines()
+                                .filter(line -> line.startsWith("TRC>> "))
+                                .map(line -> line.replace('\\', '/')))
                 .anySatisfy(line -> assertThat(line).endsWith("build/generated/axelix"));
 
         Path springFactories =

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AxelixGradlePluginFunctionalTest {
+
+    private static final String MIN_GRADLE_VERSION = "4.0";
+    private static final String MAX_GRADLE_VERSION = "9.5.1";
+
+    private static final String EXPECTED_SPRING_FACTORIES =
+            "org.springframework.test.context.TestExecutionListener=\\\n"
+                    + "digital.pragmatech.testing.SpringTestProfilerListener\n"
+                    + "org.springframework.context.ApplicationContextInitializer=\\\n"
+                    + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer\n";
+
+    @TempDir Path projectDir;
+
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void addsProfilerDependencyAndGeneratesSpringFactories(String gradleVersion)
+            throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile(
+                "build.gradle",
+                "plugins {\n"
+                        + "    id 'com.axelixlabs.axelix'\n"
+                        + "}\n"
+                        // Applied after our plugin on purpose: exercises the withPlugin reaction.
+                        + "apply plugin: 'java'\n"
+                        + "\n"
+                        + "repositories { mavenCentral() }\n"
+                        + "\n"
+                        + "task printTestRuntimeClasspath {\n"
+                        + "    dependsOn configurations.testRuntimeClasspath\n"
+                        + "    doLast {\n"
+                        + "        configurations.testRuntimeClasspath.files.each { f ->\n"
+                        + "            println 'TRC>> ' + f.absolutePath\n"
+                        + "        }\n"
+                        + "    }\n"
+                        + "}\n");
+
+        // when.
+        BuildResult result =
+                createRunner(gradleVersion, "printTestRuntimeClasspath", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":printTestRuntimeClasspath").getOutcome())
+                .isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":generateAxelixSpringFactories").getOutcome())
+                .isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput()).contains("spring-test-profiler-0.1.2.jar");
+        assertThat(result.getOutput().lines().filter(line -> line.startsWith("TRC>> ")))
+                .anySatisfy(line -> assertThat(line).endsWith("build/generated/axelix"));
+
+        Path springFactories =
+                projectDir.resolve("build/generated/axelix/META-INF/spring.factories");
+        assertThat(springFactories).exists();
+        assertThat(new String(Files.readAllBytes(springFactories), UTF_8))
+                .isEqualTo(EXPECTED_SPRING_FACTORIES);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void springFactoriesIsVisibleToTestsAtRuntime(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile(
+                "build.gradle",
+                "plugins {\n"
+                        + "    id 'com.axelixlabs.axelix'\n"
+                        + "}\n"
+                        + "apply plugin: 'java'\n"
+                        + "\n"
+                        + "repositories { mavenCentral() }\n"
+                        + "\n"
+                        + "dependencies { testImplementation 'junit:junit:4.13.2' }\n");
+        // The test source must stay Java-8 compatible: on Gradle 4.0 it is compiled by JDK 8.
+        writeFile(
+                "src/test/java/FactoriesVisibleTest.java",
+                "import java.io.BufferedReader;\n"
+                        + "import java.io.InputStreamReader;\n"
+                        + "import java.net.URL;\n"
+                        + "import java.util.Enumeration;\n"
+                        + "import org.junit.Test;\n"
+                        + "import static org.junit.Assert.assertTrue;\n"
+                        + "\n"
+                        + "public class FactoriesVisibleTest {\n"
+                        + "    @Test\n"
+                        + "    public void factoriesOnClasspath() throws Exception {\n"
+                        + "        Enumeration<URL> urls = getClass().getClassLoader()\n"
+                        + "                .getResources(\"META-INF/spring.factories\");\n"
+                        + "        boolean found = false;\n"
+                        + "        while (urls.hasMoreElements()) {\n"
+                        + "            BufferedReader reader = new BufferedReader(new InputStreamReader(\n"
+                        + "                    urls.nextElement().openStream(), \"UTF-8\"));\n"
+                        + "            StringBuilder content = new StringBuilder();\n"
+                        + "            String line;\n"
+                        + "            while ((line = reader.readLine()) != null) {\n"
+                        + "                content.append(line).append('\\n');\n"
+                        + "            }\n"
+                        + "            reader.close();\n"
+                        + "            if (content.toString().contains(\n"
+                        + "                    \"digital.pragmatech.testing.SpringTestProfilerListener\")) {\n"
+                        + "                found = true;\n"
+                        + "            }\n"
+                        + "        }\n"
+                        + "        assertTrue(found);\n"
+                        + "    }\n"
+                        + "}\n");
+
+        // when.
+        BuildResult result = createRunner(gradleVersion, "test", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+    }
+
+    private GradleRunner createRunner(String gradleVersion, String... arguments) {
+        // Never call withDebug(true) here: a debug run executes the build in-process on the
+        // current (modern) JVM, bypassing the JDK 8 daemon required by Gradle 4.0.
+        return GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withPluginClasspath()
+                .withGradleVersion(gradleVersion)
+                .withArguments(arguments);
+    }
+
+    private void writeCommonProjectFiles(String gradleVersion) throws IOException {
+        writeFile("settings.gradle", "rootProject.name = 'axelix-plugin-test'\n");
+        if (gradleVersion.startsWith("4.")) {
+            // Gradle 4.0 daemons cannot run on Java 9+, so fork them on a JDK 8.
+            writeFile(
+                    "gradle.properties",
+                    "org.gradle.java.home=" + locateJdk8Home() + "\n"
+                            + "org.gradle.jvmargs=-Xmx512m\n");
+        }
+    }
+
+    private void writeFile(String relativePath, String content) throws IOException {
+        Path file = projectDir.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.write(file, content.getBytes(UTF_8));
+    }
+
+    private static String locateJdk8Home() {
+        String override = System.getenv("AXELIX_TEST_JDK8_HOME");
+        if (override != null && !override.isEmpty()) {
+            return override;
+        }
+        Path candidates = Paths.get(System.getProperty("user.home"), ".sdkman/candidates/java");
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(candidates, "8.*")) {
+            for (Path candidate : stream) {
+                if (Files.isExecutable(candidate.resolve("bin/java"))) {
+                    return candidate.toString();
+                }
+            }
+        } catch (IOException ignored) {
+            // Fall through to the failure below.
+        }
+        throw new IllegalStateException(
+                "No JDK 8 found for the Gradle "
+                        + MIN_GRADLE_VERSION
+                        + " functional tests. Install Liberica JDK 8 via sdkman:\n"
+                        + "  source ~/.sdkman/bin/sdkman-init.sh && echo n | sdk install java"
+                        + " 8.0.492-librca\n"
+                        + "or point AXELIX_TEST_JDK8_HOME at an existing JDK 8 installation.");
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
@@ -17,18 +17,19 @@
  */
 package com.axelixlabs.gradle.plugin;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class AxelixGradlePluginFunctionalTest {
 
@@ -41,54 +42,71 @@ class AxelixGradlePluginFunctionalTest {
                     + "org.springframework.context.ApplicationContextInitializer=\\\n"
                     + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer\n";
 
-    @TempDir Path projectDir;
+    @TempDir
+    Path projectDir;
 
     @ParameterizedTest
     @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
-    void addsProfilerDependencyAndGeneratesSpringFactories(String gradleVersion)
-            throws IOException {
+    void addsProfilerDependencyAndGeneratesSpringFactories(String gradleVersion) throws IOException {
         // given.
         writeCommonProjectFiles(gradleVersion);
-        writeFile(
-                "build.gradle",
-                "plugins {\n"
-                        + "    id 'com.axelixlabs.axelix'\n"
-                        + "}\n"
-                        // Applied after our plugin on purpose: exercises the withPlugin reaction.
-                        + "apply plugin: 'java'\n"
-                        + "\n"
-                        + "repositories { mavenCentral() }\n"
-                        + "\n"
-                        + "task printTestRuntimeClasspath {\n"
-                        + "    dependsOn configurations.testRuntimeClasspath\n"
-                        + "    doLast {\n"
-                        + "        configurations.testRuntimeClasspath.files.each { f ->\n"
-                        + "            println 'TRC>> ' + f.absolutePath\n"
-                        + "        }\n"
-                        + "    }\n"
-                        + "}\n");
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("profiler-dependency.gradle"));
+
+        // when.
+        BuildResult result = createRunner(gradleVersion, "printTestRuntimeClasspath", "--stacktrace")
+                .build();
+
+        // then.
+        assertThat(result.task(":printTestRuntimeClasspath").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":generateAxelixSpringFactories").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput()).contains("spring-test-profiler-0.1.2.jar");
+        assertThat(result.getOutput()
+                        .lines()
+                        .filter(line -> line.startsWith("TRC>> "))
+                        .map(line -> line.replace('\\', '/')))
+                .anySatisfy(line -> assertThat(line).endsWith("build/generated/axelix"));
+
+        Path springFactories = projectDir.resolve("build/generated/axelix/META-INF/spring.factories");
+        assertThat(springFactories).exists();
+        assertThat(new String(Files.readAllBytes(springFactories), UTF_8)).isEqualTo(EXPECTED_SPRING_FACTORIES);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void doesNotContributeProfilerOrThymeleafWhenAlreadyDeclared(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("preexisting-versions.gradle"));
 
         // when.
         BuildResult result =
-                createRunner(gradleVersion, "printTestRuntimeClasspath", "--stacktrace").build();
+                createRunner(gradleVersion, "printDeclaredDeps", "--stacktrace").build();
 
         // then.
-        assertThat(result.task(":printTestRuntimeClasspath").getOutcome())
-                .isEqualTo(TaskOutcome.SUCCESS);
-        assertThat(result.task(":generateAxelixSpringFactories").getOutcome())
-                .isEqualTo(TaskOutcome.SUCCESS);
-        assertThat(result.getOutput()).contains("spring-test-profiler-0.1.2.jar");
-        assertThat(
-                        result.getOutput().lines()
-                                .filter(line -> line.startsWith("TRC>> "))
-                                .map(line -> line.replace('\\', '/')))
-                .anySatisfy(line -> assertThat(line).endsWith("build/generated/axelix"));
+        assertThat(result.task(":printDeclaredDeps").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput())
+                .contains("DEP>> digital.pragmatech.testing:spring-test-profiler:0.1.1")
+                .doesNotContain("digital.pragmatech.testing:spring-test-profiler:0.1.2")
+                .contains("DEP>> org.thymeleaf:thymeleaf:3.1.5.RELEASE")
+                .doesNotContain("org.thymeleaf:thymeleaf:3.1.3.RELEASE");
+    }
 
-        Path springFactories =
-                projectDir.resolve("build/generated/axelix/META-INF/spring.factories");
-        assertThat(springFactories).exists();
-        assertThat(new String(Files.readAllBytes(springFactories), UTF_8))
-                .isEqualTo(EXPECTED_SPRING_FACTORIES);
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void bumpsThymeleafWhenDeclaredVersionIsBelowMinimum(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("outdated-thymeleaf.gradle"));
+
+        // when.
+        BuildResult result =
+                createRunner(gradleVersion, "printDeclaredDeps", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":printDeclaredDeps").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput())
+                .contains("DEP>> org.thymeleaf:thymeleaf:3.0.15.RELEASE")
+                .contains("DEP>> org.thymeleaf:thymeleaf:3.1.3.RELEASE");
     }
 
     @ParameterizedTest
@@ -96,49 +114,11 @@ class AxelixGradlePluginFunctionalTest {
     void springFactoriesIsVisibleToTestsAtRuntime(String gradleVersion) throws IOException {
         // given.
         writeCommonProjectFiles(gradleVersion);
-        writeFile(
-                "build.gradle",
-                "plugins {\n"
-                        + "    id 'com.axelixlabs.axelix'\n"
-                        + "}\n"
-                        + "apply plugin: 'java'\n"
-                        + "\n"
-                        + "repositories { mavenCentral() }\n"
-                        + "\n"
-                        + "dependencies { testImplementation 'junit:junit:4.13.2' }\n");
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("spring-factories-visible.gradle"));
         // The test source must stay Java-8 compatible: on Gradle 4.0 it is compiled by JDK 8.
         writeFile(
                 "src/test/java/FactoriesVisibleTest.java",
-                "import java.io.BufferedReader;\n"
-                        + "import java.io.InputStreamReader;\n"
-                        + "import java.net.URL;\n"
-                        + "import java.util.Enumeration;\n"
-                        + "import org.junit.Test;\n"
-                        + "import static org.junit.Assert.assertTrue;\n"
-                        + "\n"
-                        + "public class FactoriesVisibleTest {\n"
-                        + "    @Test\n"
-                        + "    public void factoriesOnClasspath() throws Exception {\n"
-                        + "        Enumeration<URL> urls = getClass().getClassLoader()\n"
-                        + "                .getResources(\"META-INF/spring.factories\");\n"
-                        + "        boolean found = false;\n"
-                        + "        while (urls.hasMoreElements()) {\n"
-                        + "            BufferedReader reader = new BufferedReader(new InputStreamReader(\n"
-                        + "                    urls.nextElement().openStream(), \"UTF-8\"));\n"
-                        + "            StringBuilder content = new StringBuilder();\n"
-                        + "            String line;\n"
-                        + "            while ((line = reader.readLine()) != null) {\n"
-                        + "                content.append(line).append('\\n');\n"
-                        + "            }\n"
-                        + "            reader.close();\n"
-                        + "            if (content.toString().contains(\n"
-                        + "                    \"digital.pragmatech.testing.SpringTestProfilerListener\")) {\n"
-                        + "                found = true;\n"
-                        + "            }\n"
-                        + "        }\n"
-                        + "        assertTrue(found);\n"
-                        + "    }\n"
-                        + "}\n");
+                GradleProjectFixtures.javaSource("FactoriesVisibleTest.java"));
 
         // when.
         BuildResult result = createRunner(gradleVersion, "test", "--stacktrace").build();
@@ -152,22 +132,16 @@ class AxelixGradlePluginFunctionalTest {
     void buildSucceedsWhenNoProfilerReportWasProduced(String gradleVersion) throws IOException {
         // given.
         writeCommonProjectFiles(gradleVersion);
-        writeFile(
-                "build.gradle",
-                "plugins {\n"
-                        + "    id 'com.axelixlabs.axelix'\n"
-                        + "}\n"
-                        + "apply plugin: 'java'\n"
-                        + "\n"
-                        + "repositories { mavenCentral() }\n");
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("bare-java.gradle"));
 
         // when.
-        BuildResult result = createRunner(gradleVersion, "build", "--stacktrace").build();
+        BuildResult result =
+                createRunner(gradleVersion, "build", "--stacktrace").build();
 
         // then.
-        assertThat(result.task(":copyAxelixTestProfilerReport").getOutcome())
-                .isEqualTo(TaskOutcome.SUCCESS);
-        assertThat(projectDir.resolve("build/resources/main/spring-test-profiler")).doesNotExist();
+        assertThat(result.task(":copyAxelixTestProfilerReport").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(projectDir.resolve("build/resources/main/spring-test-profiler"))
+                .doesNotExist();
     }
 
     private GradleRunner createRunner(String gradleVersion, String... arguments) {
@@ -186,8 +160,7 @@ class AxelixGradlePluginFunctionalTest {
             // Gradle 4.0 daemons cannot run on Java 9+, so fork them on a JDK 8.
             writeFile(
                     "gradle.properties",
-                    "org.gradle.java.home=" + locateJdk8Home() + "\n"
-                            + "org.gradle.jvmargs=-Xmx512m\n");
+                    "org.gradle.java.home=" + locateJdk8Home() + "\n" + "org.gradle.jvmargs=-Xmx512m\n");
         }
     }
 
@@ -202,12 +175,11 @@ class AxelixGradlePluginFunctionalTest {
         if (override != null && !override.isEmpty()) {
             return override;
         }
-        throw new IllegalStateException(
-                "No JDK 8 found for the Gradle "
-                        + MIN_GRADLE_VERSION
-                        + " functional tests. Install Liberica JDK 8 via sdkman:\n"
-                        + "  source ~/.sdkman/bin/sdkman-init.sh && echo n | sdk install java"
-                        + " 8.0.492-librca\n"
-                        + "and point AXELIX_TEST_JDK8_HOME at the JDK 8 installation.");
+        throw new IllegalStateException("No JDK 8 found for the Gradle "
+                + MIN_GRADLE_VERSION
+                + " functional tests. Install Liberica JDK 8 via sdkman:\n"
+                + "  source ~/.sdkman/bin/sdkman-init.sh && echo n | sdk install java"
+                + " 8.0.492-librca\n"
+                + "and point AXELIX_TEST_JDK8_HOME at the JDK 8 installation.");
     }
 }

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/GradleProjectFixtures.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/GradleProjectFixtures.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/** Loads build-script and Java-source fixtures bundled as test resources alongside this package. */
+final class GradleProjectFixtures {
+
+    private GradleProjectFixtures() {}
+
+    static String buildScript(String fixtureName) {
+        return load(fixtureName);
+    }
+
+    /**
+     * Loads a Java-source fixture. The sources are stored with a {@code .java.txt} suffix so that
+     * Spotless (which targets {@code src/**}/{@code *.java}) does not reformat them or inject a
+     * license header into the generated test project.
+     */
+    static String javaSource(String fixtureName) {
+        return load(fixtureName);
+    }
+
+    private static String load(String fixtureName) {
+        try (InputStream in = GradleProjectFixtures.class.getResourceAsStream(fixtureName)) {
+            if (in == null) {
+                throw new IllegalStateException("Missing test fixture: " + fixtureName);
+            }
+            return new String(in.readAllBytes(), UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/SpringBootApplicationFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/SpringBootApplicationFunctionalTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.jar.JarFile;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
@@ -90,33 +91,36 @@ class SpringBootApplicationFunctionalTest {
     void springBoot4GeneratesProfilerReport() throws IOException {
         // given.
         writeSpringBootApplicationSources();
-        writeFile(
-                "build.gradle",
-                "plugins {\n"
-                        + "    id 'com.axelixlabs.axelix'\n"
-                        + "}\n"
-                        + "apply plugin: 'java'\n"
-                        + "\n"
-                        + "repositories { mavenCentral() }\n"
-                        + "\n"
-                        + "dependencies {\n"
-                        + "    implementation platform('org.springframework.boot:spring-boot-dependencies:"
-                        + SPRING_BOOT_4_VERSION
-                        + "')\n"
-                        + "    implementation 'org.springframework.boot:spring-boot-starter'\n"
-                        + "    testImplementation 'org.springframework.boot:spring-boot-starter-test'\n"
-                        // Gradle 9 requires the launcher on the test runtime classpath; the Boot
-                        // BOM supplies its version via the imported junit-bom.
-                        + "    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'\n"
-                        + "}\n"
-                        + "\n"
-                        + "test { useJUnitPlatform() }\n");
+        writeFile("build.gradle", springBoot4BuildScript());
 
         // when.
         BuildResult result = createRunner("test", "--stacktrace").build();
 
         // then.
         assertProfilerReportGenerated(result);
+    }
+
+    @Test
+    void buildCopiesProfilerReportOntoApplicationClasspathAndIntoJar() throws IOException {
+        // given.
+        writeSpringBootApplicationSources();
+        writeFile("build.gradle", springBoot4BuildScript());
+
+        // when.
+        BuildResult result = createRunner("build", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":copyAxelixTestProfilerReport").getOutcome())
+                .isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(projectDir.resolve("build/resources/main/spring-test-profiler/latest.html"))
+                .exists();
+
+        Path jar = projectDir.resolve("build/libs/axelix-spring-boot-test.jar");
+        assertThat(jar).exists();
+        try (JarFile jarFile = new JarFile(jar.toFile())) {
+            assertThat(jarFile.getEntry("spring-test-profiler/latest.html")).isNotNull();
+        }
     }
 
     private GradleRunner createRunner(String... arguments) {
@@ -131,6 +135,28 @@ class SpringBootApplicationFunctionalTest {
         assertThat(result.task(":generateAxelixSpringFactories").getOutcome())
                 .isEqualTo(TaskOutcome.SUCCESS);
         assertThat(projectDir.resolve("build/spring-test-profiler/latest.html")).exists();
+    }
+
+    private static String springBoot4BuildScript() {
+        return "plugins {\n"
+                + "    id 'com.axelixlabs.axelix'\n"
+                + "}\n"
+                + "apply plugin: 'java'\n"
+                + "\n"
+                + "repositories { mavenCentral() }\n"
+                + "\n"
+                + "dependencies {\n"
+                + "    implementation platform('org.springframework.boot:spring-boot-dependencies:"
+                + SPRING_BOOT_4_VERSION
+                + "')\n"
+                + "    implementation 'org.springframework.boot:spring-boot-starter'\n"
+                + "    testImplementation 'org.springframework.boot:spring-boot-starter-test'\n"
+                // Gradle 9 requires the launcher on the test runtime classpath; the Boot
+                // BOM supplies its version via the imported junit-bom.
+                + "    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'\n"
+                + "}\n"
+                + "\n"
+                + "test { useJUnitPlatform() }\n";
     }
 
     private void writeSpringBootApplicationSources() throws IOException {

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/SpringBootApplicationFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/SpringBootApplicationFunctionalTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Verifies the plugin end-to-end on empty Spring Boot applications: after running their tests,
+ * the Spring Test Profiler must have produced its HTML report. The profiler requires Java 17+,
+ * so these builds run on the current JVM.
+ */
+class SpringBootApplicationFunctionalTest {
+
+    private static final String SPRING_BOOT_2_VERSION = "2.7.18";
+    private static final String SPRING_BOOT_4_VERSION = "4.0.7";
+
+    /** Boot-2-era Gradle; the io.spring.dependency-management plugin predates Gradle 9. */
+    private static final String SPRING_BOOT_2_GRADLE_VERSION = "8.14";
+
+    @TempDir Path projectDir;
+
+    /**
+     * The realistic Spring Boot 2 setup: the io.spring.dependency-management plugin applies the
+     * Boot BOM with Maven semantics, downgrading the profiler's Thymeleaf to 3.0.x — without the
+     * plugin's counteracting resolution rule the report silently fails to render.
+     */
+    @Test
+    void springBoot2WithDependencyManagementGeneratesProfilerReport() throws IOException {
+        // given.
+        writeSpringBootApplicationSources();
+        writeFile(
+                "build.gradle",
+                "plugins {\n"
+                        + "    id 'io.spring.dependency-management' version '1.1.7'\n"
+                        + "    id 'com.axelixlabs.axelix'\n"
+                        + "}\n"
+                        + "apply plugin: 'java'\n"
+                        + "\n"
+                        + "repositories { mavenCentral() }\n"
+                        + "\n"
+                        + "dependencyManagement {\n"
+                        + "    imports { mavenBom 'org.springframework.boot:spring-boot-dependencies:"
+                        + SPRING_BOOT_2_VERSION
+                        + "' }\n"
+                        + "}\n"
+                        + "\n"
+                        + "dependencies {\n"
+                        + "    implementation 'org.springframework.boot:spring-boot-starter'\n"
+                        + "    testImplementation 'org.springframework.boot:spring-boot-starter-test'\n"
+                        + "}\n"
+                        + "\n"
+                        + "test { useJUnitPlatform() }\n");
+
+        // when.
+        BuildResult result =
+                createRunner("test", "--stacktrace")
+                        .withGradleVersion(SPRING_BOOT_2_GRADLE_VERSION)
+                        .build();
+
+        // then.
+        assertProfilerReportGenerated(result);
+    }
+
+    @Test
+    void springBoot4GeneratesProfilerReport() throws IOException {
+        // given.
+        writeSpringBootApplicationSources();
+        writeFile(
+                "build.gradle",
+                "plugins {\n"
+                        + "    id 'com.axelixlabs.axelix'\n"
+                        + "}\n"
+                        + "apply plugin: 'java'\n"
+                        + "\n"
+                        + "repositories { mavenCentral() }\n"
+                        + "\n"
+                        + "dependencies {\n"
+                        + "    implementation platform('org.springframework.boot:spring-boot-dependencies:"
+                        + SPRING_BOOT_4_VERSION
+                        + "')\n"
+                        + "    implementation 'org.springframework.boot:spring-boot-starter'\n"
+                        + "    testImplementation 'org.springframework.boot:spring-boot-starter-test'\n"
+                        // Gradle 9 requires the launcher on the test runtime classpath; the Boot
+                        // BOM supplies its version via the imported junit-bom.
+                        + "    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'\n"
+                        + "}\n"
+                        + "\n"
+                        + "test { useJUnitPlatform() }\n");
+
+        // when.
+        BuildResult result = createRunner("test", "--stacktrace").build();
+
+        // then.
+        assertProfilerReportGenerated(result);
+    }
+
+    private GradleRunner createRunner(String... arguments) {
+        return GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withPluginClasspath()
+                .withArguments(arguments);
+    }
+
+    private void assertProfilerReportGenerated(BuildResult result) {
+        assertThat(result.task(":test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":generateAxelixSpringFactories").getOutcome())
+                .isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(projectDir.resolve("build/spring-test-profiler/latest.html")).exists();
+    }
+
+    private void writeSpringBootApplicationSources() throws IOException {
+        writeFile("settings.gradle", "rootProject.name = 'axelix-spring-boot-test'\n");
+        writeFile(
+                "src/main/java/com/example/DemoApplication.java",
+                "package com.example;\n"
+                        + "\n"
+                        + "import org.springframework.boot.autoconfigure.SpringBootApplication;\n"
+                        + "\n"
+                        + "@SpringBootApplication\n"
+                        + "public class DemoApplication {}\n");
+        writeFile(
+                "src/test/java/com/example/DemoApplicationTest.java",
+                "package com.example;\n"
+                        + "\n"
+                        + "import org.junit.jupiter.api.Test;\n"
+                        + "import org.springframework.boot.test.context.SpringBootTest;\n"
+                        + "\n"
+                        + "@SpringBootTest\n"
+                        + "class DemoApplicationTest {\n"
+                        + "    @Test\n"
+                        + "    void contextLoads() {}\n"
+                        + "}\n");
+    }
+
+    private void writeFile(String relativePath, String content) throws IOException {
+        Path file = projectDir.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.write(file, content.getBytes(UTF_8));
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/SpringBootApplicationFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/SpringBootApplicationFunctionalTest.java
@@ -17,18 +17,19 @@
  */
 package com.axelixlabs.gradle.plugin;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.jar.JarFile;
+
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Verifies the plugin end-to-end on empty Spring Boot applications: after running their tests,
@@ -37,13 +38,11 @@ import org.junit.jupiter.api.io.TempDir;
  */
 class SpringBootApplicationFunctionalTest {
 
-    private static final String SPRING_BOOT_2_VERSION = "2.7.18";
-    private static final String SPRING_BOOT_4_VERSION = "4.0.7";
-
     /** Boot-2-era Gradle; the io.spring.dependency-management plugin predates Gradle 9. */
     private static final String SPRING_BOOT_2_GRADLE_VERSION = "8.14";
 
-    @TempDir Path projectDir;
+    @TempDir
+    Path projectDir;
 
     /**
      * The realistic Spring Boot 2 setup: the io.spring.dependency-management plugin applies the
@@ -54,34 +53,12 @@ class SpringBootApplicationFunctionalTest {
     void springBoot2WithDependencyManagementGeneratesProfilerReport() throws IOException {
         // given.
         writeSpringBootApplicationSources();
-        writeFile(
-                "build.gradle",
-                "plugins {\n"
-                        + "    id 'io.spring.dependency-management' version '1.1.7'\n"
-                        + "    id 'com.axelixlabs.axelix'\n"
-                        + "}\n"
-                        + "apply plugin: 'java'\n"
-                        + "\n"
-                        + "repositories { mavenCentral() }\n"
-                        + "\n"
-                        + "dependencyManagement {\n"
-                        + "    imports { mavenBom 'org.springframework.boot:spring-boot-dependencies:"
-                        + SPRING_BOOT_2_VERSION
-                        + "' }\n"
-                        + "}\n"
-                        + "\n"
-                        + "dependencies {\n"
-                        + "    implementation 'org.springframework.boot:spring-boot-starter'\n"
-                        + "    testImplementation 'org.springframework.boot:spring-boot-starter-test'\n"
-                        + "}\n"
-                        + "\n"
-                        + "test { useJUnitPlatform() }\n");
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("spring-boot-2.gradle"));
 
         // when.
-        BuildResult result =
-                createRunner("test", "--stacktrace")
-                        .withGradleVersion(SPRING_BOOT_2_GRADLE_VERSION)
-                        .build();
+        BuildResult result = createRunner("test", "--stacktrace")
+                .withGradleVersion(SPRING_BOOT_2_GRADLE_VERSION)
+                .build();
 
         // then.
         assertProfilerReportGenerated(result);
@@ -111,8 +88,7 @@ class SpringBootApplicationFunctionalTest {
 
         // then.
         assertThat(result.task(":test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
-        assertThat(result.task(":copyAxelixTestProfilerReport").getOutcome())
-                .isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":copyAxelixTestProfilerReport").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
         assertThat(projectDir.resolve("build/resources/main/spring-test-profiler/latest.html"))
                 .exists();
 
@@ -132,55 +108,22 @@ class SpringBootApplicationFunctionalTest {
 
     private void assertProfilerReportGenerated(BuildResult result) {
         assertThat(result.task(":test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
-        assertThat(result.task(":generateAxelixSpringFactories").getOutcome())
-                .isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":generateAxelixSpringFactories").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
         assertThat(projectDir.resolve("build/spring-test-profiler/latest.html")).exists();
     }
 
     private static String springBoot4BuildScript() {
-        return "plugins {\n"
-                + "    id 'com.axelixlabs.axelix'\n"
-                + "}\n"
-                + "apply plugin: 'java'\n"
-                + "\n"
-                + "repositories { mavenCentral() }\n"
-                + "\n"
-                + "dependencies {\n"
-                + "    implementation platform('org.springframework.boot:spring-boot-dependencies:"
-                + SPRING_BOOT_4_VERSION
-                + "')\n"
-                + "    implementation 'org.springframework.boot:spring-boot-starter'\n"
-                + "    testImplementation 'org.springframework.boot:spring-boot-starter-test'\n"
-                // Gradle 9 requires the launcher on the test runtime classpath; the Boot
-                // BOM supplies its version via the imported junit-bom.
-                + "    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'\n"
-                + "}\n"
-                + "\n"
-                + "test { useJUnitPlatform() }\n";
+        return GradleProjectFixtures.buildScript("spring-boot-4.gradle");
     }
 
     private void writeSpringBootApplicationSources() throws IOException {
         writeFile("settings.gradle", "rootProject.name = 'axelix-spring-boot-test'\n");
         writeFile(
                 "src/main/java/com/example/DemoApplication.java",
-                "package com.example;\n"
-                        + "\n"
-                        + "import org.springframework.boot.autoconfigure.SpringBootApplication;\n"
-                        + "\n"
-                        + "@SpringBootApplication\n"
-                        + "public class DemoApplication {}\n");
+                GradleProjectFixtures.javaSource("DemoApplication.java"));
         writeFile(
                 "src/test/java/com/example/DemoApplicationTest.java",
-                "package com.example;\n"
-                        + "\n"
-                        + "import org.junit.jupiter.api.Test;\n"
-                        + "import org.springframework.boot.test.context.SpringBootTest;\n"
-                        + "\n"
-                        + "@SpringBootTest\n"
-                        + "class DemoApplicationTest {\n"
-                        + "    @Test\n"
-                        + "    void contextLoads() {}\n"
-                        + "}\n");
+                GradleProjectFixtures.javaSource("DemoApplicationTest.java"));
     }
 
     private void writeFile(String relativePath, String content) throws IOException {

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/SpringBootApplicationFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/SpringBootApplicationFunctionalTest.java
@@ -33,8 +33,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Verifies the plugin end-to-end on empty Spring Boot applications: after running their tests,
- * the Spring Test Profiler must have produced its HTML report. The profiler requires Java 17+,
- * so these builds run on the current JVM.
+ * the Spring Test Profiler must have produced its HTML report. The profiler requires Java 17+.
+ * The Boot 4 builds run on the current JVM under Gradle 9.5.1; the Boot 2 build is pinned to
+ * Gradle 8.14, which cannot run on JDK 25, so its daemon is forked onto a JDK in the 17-24 range.
  */
 class SpringBootApplicationFunctionalTest {
 
@@ -54,6 +55,8 @@ class SpringBootApplicationFunctionalTest {
         // given.
         writeSpringBootApplicationSources();
         writeFile("build.gradle", GradleProjectFixtures.buildScript("spring-boot-2.gradle"));
+        // Gradle 8.14 cannot run on JDK 25, so fork its daemon onto a JDK 17-24.
+        writeFile("gradle.properties", "org.gradle.java.home=" + locateGradle8JdkHome() + "\n");
 
         // when.
         BuildResult result = createRunner("test", "--stacktrace")
@@ -130,5 +133,18 @@ class SpringBootApplicationFunctionalTest {
         Path file = projectDir.resolve(relativePath);
         Files.createDirectories(file.getParent());
         Files.write(file, content.getBytes(UTF_8));
+    }
+
+    private static String locateGradle8JdkHome() {
+        String override = System.getenv("AXELIX_TEST_JDK17_HOME");
+        if (override != null && !override.isEmpty()) {
+            return override;
+        }
+        throw new IllegalStateException("No JDK 17-24 found for the Gradle "
+                + SPRING_BOOT_2_GRADLE_VERSION
+                + " functional test. Gradle 8.14 cannot run on JDK 25, and the Spring Test"
+                + " Profiler requires JDK 17+. Install a JDK in the 17-24 range, e.g. via sdkman:\n"
+                + "  source ~/.sdkman/bin/sdkman-init.sh && echo n | sdk install java 21.0.10-librca\n"
+                + "and point AXELIX_TEST_JDK17_HOME at the JDK installation.");
     }
 }

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/SpringBootApplicationFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/SpringBootApplicationFunctionalTest.java
@@ -47,8 +47,8 @@ class SpringBootApplicationFunctionalTest {
 
     /**
      * The realistic Spring Boot 2 setup: the io.spring.dependency-management plugin applies the
-     * Boot BOM with Maven semantics, downgrading the profiler's Thymeleaf to 3.0.x — without the
-     * plugin's counteracting resolution rule the report silently fails to render.
+     * Boot BOM with Maven semantics, managing Thymeleaf at 3.0.x — without the plugin's explicit
+     * Thymeleaf 3.1 test dependency the report silently fails to render.
      */
     @Test
     void springBoot2WithDependencyManagementGeneratesProfilerReport() throws IOException {

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/DemoApplication.java
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/DemoApplication.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.example;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/DemoApplicationTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/DemoApplicationTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.example;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DemoApplicationTest {
+    @Test
+    void contextLoads() {}
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/FactoriesVisibleTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/FactoriesVisibleTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Enumeration;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class FactoriesVisibleTest {
+    @Test
+    public void factoriesOnClasspath() throws Exception {
+        Enumeration<URL> urls = getClass().getClassLoader().getResources("META-INF/spring.factories");
+        boolean found = false;
+        while (urls.hasMoreElements()) {
+            BufferedReader reader =
+                    new BufferedReader(new InputStreamReader(urls.nextElement().openStream(), "UTF-8"));
+            StringBuilder content = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                content.append(line).append('\n');
+            }
+            reader.close();
+            if (content.toString().contains("digital.pragmatech.testing.SpringTestProfilerListener")) {
+                found = true;
+            }
+        }
+        assertTrue(found);
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/bare-java.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/bare-java.gradle
@@ -1,0 +1,6 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/outdated-thymeleaf.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/outdated-thymeleaf.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencies {
+    // A Thymeleaf older than the plugin's 3.1.3 minimum: the plugin must contribute
+    // 3.1.3 so it wins by Gradle's newest-version conflict resolution.
+    implementation 'org.thymeleaf:thymeleaf:3.0.15.RELEASE'
+}
+
+// Prints the *declared* modules (not resolved files) of the test runtime classpath,
+// so the plugin's contributed 3.1.3 only appears if it added it. allDependencies
+// omits transitives, keeping the assertion focused on declared modules.
+task printDeclaredDeps {
+    doLast {
+        configurations.testRuntimeClasspath.allDependencies.each { d ->
+            println 'DEP>> ' + d.group + ':' + d.name + ':' + d.version
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/preexisting-versions.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/preexisting-versions.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencies {
+    // testRuntimeOnly mirrors how the plugin declares the profiler.
+    testRuntimeOnly 'digital.pragmatech.testing:spring-test-profiler:0.1.1'
+    // implementation exercises the extended-configuration lookup path; the version
+    // is at or above the plugin's minimum, so it must be left untouched.
+    implementation 'org.thymeleaf:thymeleaf:3.1.5.RELEASE'
+}
+
+// Prints the *declared* modules (not resolved files) of the test runtime
+// classpath, so the plugin's own pinned versions only appear if it added
+// them. allDependencies omits transitives, so the thymeleaf the profiler
+// pulls in does not muddy the assertion.
+task printDeclaredDeps {
+    doLast {
+        configurations.testRuntimeClasspath.allDependencies.each { d ->
+            println 'DEP>> ' + d.group + ':' + d.name + ':' + d.version
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/profiler-dependency.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/profiler-dependency.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+// Applied after our plugin on purpose: exercises the withPlugin reaction.
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+task printTestRuntimeClasspath {
+    dependsOn configurations.testRuntimeClasspath
+    doLast {
+        configurations.testRuntimeClasspath.files.each { f ->
+            println 'TRC>> ' + f.absolutePath
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-boot-2.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-boot-2.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencyManagement {
+    imports { mavenBom 'org.springframework.boot:spring-boot-dependencies:2.7.18' }
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+test { useJUnitPlatform() }

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-boot-4.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-boot-4.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencies {
+    implementation platform('org.springframework.boot:spring-boot-dependencies:4.0.7')
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    // Gradle 9 requires the launcher on the test runtime classpath; the Boot
+    // BOM supplies its version via the imported junit-bom.
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+test { useJUnitPlatform() }

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-factories-visible.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-factories-visible.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencies { testImplementation 'junit:junit:4.13.2' }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,4 +12,5 @@ include(
     ":common:auth",
     ":common:domain",
     ":common:utils",
+    ":plugins:axelix-gradle-plugin"
 )

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,5 @@
 rootProject.name = "axelix"
 
-includeBuild("plugins/axelix-gradle-plugin")
-
 include(
     ":master",
     ":sbs:axelix-spring-boot-2-starter",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,7 @@
 rootProject.name = "axelix"
 
+includeBuild("plugins/axelix-gradle-plugin")
+
 include(
     ":master",
     ":sbs:axelix-spring-boot-2-starter",


### PR DESCRIPTION
Closes #1216

## What

Adds the Axelix Gradle plugin under `plugins/axelix-gradle-plugin` with the id `com.axelixlabs.axelix`. When applied to a project (together with the `java` plugin), it:

- adds `digital.pragmatech.testing:spring-test-profiler:0.1.2` to the test runtime classpath;
- generates `META-INF/spring.factories` (into `build/generated/axelix`, wired onto the test runtime classpath) registering `SpringTestProfilerListener` and `ContextDiagnosticApplicationInitializer`, as described in the [profiler docs](https://github.com/PragmaTech-GmbH/spring-test-profiler#2-activate-the-profiler);
- counteracts the Thymeleaf downgrade caused by the Spring Boot 2 BOM when applied via `io.spring.dependency-management` (the profiler needs Thymeleaf 3.1+ to render its report; the rule is scoped to `testRuntimeClasspath` and is a no-op on Boot 3/4 and BOM-less builds).
- copies the profiler HTML report onto the application classpath during `build`: the `copyAxelixTestProfilerReport` task runs after tests pass and copies `build/spring-test-profiler/` into `build/resources/main/spring-test-profiler/`; jar tasks are ordered after the copy so the report deterministically ends up inside the packaged jar.

The dependency is added to `testRuntimeOnly` rather than `testImplementation`: the profiler is activated purely via `spring.factories`, so nothing in the consumer project compiles against it.

## Compatibility

Supports Gradle 4.0 through 9.x. The plugin is compiled to Java 8 bytecode and restricted to APIs with identical signatures in Gradle 4.0 and 9.5.1 (verified via `javap`); notable consequences: eager `tasks.create`, no Provider/Property APIs, no sourceSets access (conventions were removed in Gradle 9), and `TaskInputs.properties(Map)` instead of `property(String, Object)` (its return type changed in 4.3).

## Testing

TestKit functional tests (9 in total, all green):

- both Gradle extremes, 4.0 (daemon forked on a Liberica JDK 8) and 9.5.1: dependency lands on the test runtime classpath, `spring.factories` content is byte-exact, and the resource is visible to tests through the classloader;
- empty Spring Boot 2.7.18 app with `io.spring.dependency-management` (Gradle 8.14) and empty Spring Boot 4.0.7 app (Gradle 9.5.1): after `test`, the profiler report exists at `build/spring-test-profiler/latest.html`. The Boot 2 test fails without the Thymeleaf rule.
- report copy: `build` on the Boot 4 app puts the report at `build/resources/main/spring-test-profiler/latest.html` and packages it into the jar as `spring-test-profiler/latest.html`; `build` on a plain Java project without a report (Gradle 4.0 and 9.5.1) succeeds with a no-op copy.

Also verified manually against a realistic standalone Boot 2.7.18 web app (controller/service, `@SpringBootTest` + `@WebMvcTest`, Boot Gradle plugin + dependency-management) consuming this plugin via composite build: all tests pass and the HTML report is generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the Axelix Gradle plugin for Spring Test Profiler integration in Spring Boot projects.
  * Automatically manages required test dependencies (including ensuring a minimum Thymeleaf version when needed).
  * Generates the required `spring.factories` entry and packages the profiler HTML report into your build output.
  * Works across Gradle 4.0 through 9.5.1.

* **Tests**
  * Added functional end-to-end checks verifying generation, dependency behavior, and report packaging.

* **Chores**
  * Updated release metadata/locking information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
