### PR TITLE
[SECURITY] Fix code scanning alerts for OpenSSL image CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ FROM eclipse-temurin:25-jre-alpine AS final
 
 VOLUME /tmp
 
+RUN apk add --no-cache --upgrade \
+    "openssl>=3.5.7-r0" \
+    "libssl3>=3.5.7-r0" \
+    "libcrypto3>=3.5.7-r0"
+
 # Configure non-root user
 RUN adduser -S axelix
 USER axelix


### PR DESCRIPTION
## Summary
- Upgrade Alpine `openssl`, `libssl3`, and `libcrypto3` packages in the runtime Docker image to `>=3.5.7-r0`, addressing Trivy image findings including high-severity OpenSSL CVE-2026-45447.
- Remove a no-op `.replace(/ /g, " ")` in the website install copy snippet, resolving CodeQL alert `js/identity-replacement`.
- No public API or contract changes; this is a patch-safe security remediation.

## Test plan
- [x] `docker build --progress=plain --tag axelix-local:security-scan --file Dockerfile .`
- [x] Verified built image contains `openssl-3.5.7-r0`, `libssl3-3.5.7-r0`, and `libcrypto3-3.5.7-r0`
- [x] Confirmed no public API or contract changes were introduced

## Attribution
- Authored by: Cursor

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code snippet copying to clipboard to preserve exact spacing

* **Chores**
  * Updated runtime security dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->