### PR TITLE
GH-1066 Handle duplicate username/email on user create and update

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/api/error/handle/ApiErrorCodes.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/error/handle/ApiErrorCodes.java
@@ -37,7 +37,10 @@ public enum ApiErrorCodes {
     // Bad request related error codes
     BAD_REQUEST("BAD_REQUEST"),
     INSTANCE_NOT_FOUND("INSTANCE_NOT_FOUND"),
-    INVALID_CRON_EXPRESSION("INVALID_CRON_EXPRESSION");
+    INVALID_CRON_EXPRESSION("INVALID_CRON_EXPRESSION"),
+
+    // User conflict related error codes
+    USER_DUPLICATE_VALUE("USER_DUPLICATE_VALUE");
 
     /**
      * actual code that is sent from the master backend.

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/error/handle/impl/UserDuplicateValueExceptionHandler.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/error/handle/impl/UserDuplicateValueExceptionHandler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.api.error.handle.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import com.axelixlabs.axelix.master.api.error.ApiError;
+import com.axelixlabs.axelix.master.api.error.SimpleApiError;
+import com.axelixlabs.axelix.master.api.error.handle.ApiErrorCodes;
+import com.axelixlabs.axelix.master.api.error.handle.ExceptionHandler;
+import com.axelixlabs.axelix.master.exception.auth.UserDuplicateValueException;
+
+/**
+ * The exception handler for the {@link UserDuplicateValueException}.
+ *
+ * @author Sergey Cherkasov
+ */
+@Component
+public class UserDuplicateValueExceptionHandler implements ExceptionHandler<UserDuplicateValueException> {
+
+    @Override
+    public ApiError handle(UserDuplicateValueException exception) {
+        return new SimpleApiError(ApiErrorCodes.USER_DUPLICATE_VALUE.getErrorCode(), HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Override
+    public Class<UserDuplicateValueException> supported() {
+        return UserDuplicateValueException.class;
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApi.java
@@ -21,10 +21,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.jdbc.UncategorizedSQLException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -71,10 +69,7 @@ public class UserManagementApi {
             userService.createLocal(request.username(), request.email(), request.password(), request.role());
             return ResponseEntity.status(HttpStatus.CREATED).build();
 
-        } catch (UserInvalidValueException
-                | UserRoleNotFoundException
-                | UncategorizedSQLException
-                | DataIntegrityViolationException e) {
+        } catch (UserInvalidValueException | UserRoleNotFoundException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
     }
@@ -98,10 +93,7 @@ public class UserManagementApi {
 
             return ResponseEntity.noContent().build();
 
-        } catch (UserInvalidValueException
-                | UserRoleNotFoundException
-                | UncategorizedSQLException
-                | DataIntegrityViolationException e) {
+        } catch (UserInvalidValueException | UserRoleNotFoundException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
     }

--- a/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UserDuplicateValueException.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UserDuplicateValueException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.exception.auth;
+
+import com.axelixlabs.axelix.master.domain.UserEntity;
+import com.axelixlabs.axelix.master.service.state.UserService;
+
+/**
+ * Thrown if a {@link UserEntity} with the same username or email already exists.
+ *
+ * @see UserService
+ * @author Sergey Cherkasov
+ */
+public class UserDuplicateValueException extends RuntimeException {
+
+    public UserDuplicateValueException(Throwable cause) {
+        super("User with the same username or email already exists", cause);
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseUserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseUserService.java
@@ -27,7 +27,9 @@ import java.util.stream.Collectors;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
+import org.springframework.jdbc.UncategorizedSQLException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserOrigin;
+import com.axelixlabs.axelix.master.exception.auth.UserDuplicateValueException;
 import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 import com.axelixlabs.axelix.master.repository.UserRepository;
@@ -64,7 +67,7 @@ public class DatabaseUserService implements UserService {
 
     @Override
     public void createLocal(String username, @Nullable String email, String password, String role)
-            throws UserRoleNotFoundException, UserInvalidValueException {
+            throws UserRoleNotFoundException, UserInvalidValueException, UserDuplicateValueException {
 
         UserEntity userEntity = new UserEntity(
                 UUID.randomUUID().toString(),
@@ -75,11 +78,12 @@ public class DatabaseUserService implements UserService {
                 UserOrigin.LOCAL,
                 null);
 
-        jdbcAggregateTemplate.insert(userEntity);
+        insertNewUser(userEntity);
     }
 
     @Override
-    public void createFromOidc(String username, @Nullable String email, String role) {
+    public void createFromOidc(String username, @Nullable String email, String role)
+            throws UserRoleNotFoundException, UserInvalidValueException, UserDuplicateValueException {
 
         UserEntity userEntity = new UserEntity(
                 UUID.randomUUID().toString(),
@@ -90,7 +94,18 @@ public class DatabaseUserService implements UserService {
                 UserOrigin.OIDC,
                 Instant.now()); // the assumption is that the user is created during the initial login
 
-        jdbcAggregateTemplate.insert(userEntity);
+        insertNewUser(userEntity);
+    }
+
+    private void insertNewUser(UserEntity userEntity) throws UserDuplicateValueException {
+        try {
+            jdbcAggregateTemplate.insert(userEntity);
+        } catch (DuplicateKeyException | UncategorizedSQLException e) {
+            // TODO: develop a proper approach for handling SQLite errors so that only actual
+            //  unique constraint violations are mapped to UserDuplicateValueException, instead
+            //  of blindly treating every untranslated UncategorizedSQLException as a duplicate
+            throw new UserDuplicateValueException(e);
+        }
     }
 
     @Override
@@ -126,7 +141,7 @@ public class DatabaseUserService implements UserService {
             @Nullable String password,
             Set<String> roles,
             @Nullable Instant lastLoginAt)
-            throws UserRoleNotFoundException, UserInvalidValueException {
+            throws UserRoleNotFoundException, UserInvalidValueException, UserDuplicateValueException {
 
         if (roles.isEmpty()) {
             throw new UserInvalidValueException(null);
@@ -135,13 +150,20 @@ public class DatabaseUserService implements UserService {
         Set<String> validRoles =
                 roles.stream().map(this::validateAndNormalizeRole).collect(Collectors.toSet());
 
-        userRepository.updateUserPatch(
-                id,
-                requireNonBlankTrimmed(username),
-                email == null ? null : requireNonBlankTrimmed(email),
-                password == null ? null : passwordEncoder.encode(requireNonBlankTrimmed(password)),
-                new UserEntity.Roles(validRoles),
-                lastLoginAt);
+        try {
+            userRepository.updateUserPatch(
+                    id,
+                    requireNonBlankTrimmed(username),
+                    email == null ? null : requireNonBlankTrimmed(email),
+                    password == null ? null : passwordEncoder.encode(requireNonBlankTrimmed(password)),
+                    new UserEntity.Roles(validRoles),
+                    lastLoginAt);
+        } catch (DuplicateKeyException | UncategorizedSQLException e) {
+            // TODO: develop a proper approach for handling SQLite errors so that only actual
+            //  unique constraint violations are mapped to UserDuplicateValueException, instead
+            //  of blindly treating every untranslated UncategorizedSQLException as a duplicate
+            throw new UserDuplicateValueException(e);
+        }
     }
 
     private String requireNonBlankTrimmed(String value) throws UserInvalidValueException {

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/UserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/UserService.java
@@ -27,6 +27,7 @@ import org.jspecify.annotations.Nullable;
 
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserOrigin;
+import com.axelixlabs.axelix.master.exception.auth.UserDuplicateValueException;
 import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 
@@ -52,6 +53,7 @@ public interface UserService {
      *
      * @throws UserRoleNotFoundException if the provided role does not exist in the service.
      * @throws UserInvalidValueException if any of the provided string fields is blank.
+     * @throws UserDuplicateValueException if a user with the same username or email already exists.
      */
     void createLocal(String username, @Nullable String email, String password, String role);
 
@@ -64,6 +66,7 @@ public interface UserService {
      *
      * @throws UserRoleNotFoundException if the provided role does not exist in the service.
      * @throws UserInvalidValueException if any of the provided string fields is blank.
+     * @throws UserDuplicateValueException if a user with the same username or email already exists.
      */
     void createFromOidc(String username, @Nullable String email, String role);
 
@@ -123,10 +126,11 @@ public interface UserService {
      * @param roles    New set of role names. Replaces any roles previously assigned. Each role must not be blank or {@code null}.
      * @throws UserRoleNotFoundException if any of the provided role names does not exist in the service.
      * @throws UserInvalidValueException if any of the provided string fields is blank.
+     * @throws UserDuplicateValueException if another user with the same username or email already exists.
      */
     default void updateUserPatch(
             String id, String username, @Nullable String email, @Nullable String password, Set<String> roles)
-            throws UserRoleNotFoundException, UserInvalidValueException {
+            throws UserRoleNotFoundException, UserInvalidValueException, UserDuplicateValueException {
 
         updateUserPatch(id, username, email, password, roles, null);
     }
@@ -143,5 +147,5 @@ public interface UserService {
             @Nullable String password,
             Set<String> roles,
             @Nullable Instant lastLoginAt)
-            throws UserRoleNotFoundException, UserInvalidValueException;
+            throws UserRoleNotFoundException, UserInvalidValueException, UserDuplicateValueException;
 }

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
@@ -36,6 +36,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.TestPropertySource;
 
+import com.axelixlabs.axelix.master.api.error.handle.ApiErrorCodes;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.repository.UserRepository;
@@ -47,6 +48,7 @@ import static com.axelixlabs.axelix.common.auth.core.DefaultRole.SUPER_ADMIN;
 import static com.axelixlabs.axelix.common.domain.http.HttpMethod.DELETE;
 import static com.axelixlabs.axelix.common.domain.http.HttpMethod.POST;
 import static com.axelixlabs.axelix.common.domain.http.HttpMethod.PUT;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -337,6 +339,66 @@ public class UserManagementApiTest {
     }
 
     @Test
+    void shouldReturnBadRequest_WhenUpdateRequestUsernameIsDuplicate() {
+        // given.
+        insertUser("alice", "alice@example.com", "p", Set.of("VIEWER"), UserOrigin.LOCAL);
+        UserEntity bob = insertUser("bob", "bob@example.com", "p", Set.of("VIEWER"), UserOrigin.LOCAL);
+
+        // language=json
+        String request = """
+                {
+                  "id": "%s",
+                  "username": "alice",
+                  "email": "bob@example.com",
+                  "roles": ["VIEWER"],
+                  "password": null
+                }
+                """.formatted(bob.id());
+
+        // when.
+        ResponseEntity<String> response = restTemplate
+                .withRole(SUPER_ADMIN)
+                .exchange(USERS_UPDATE_PATH, HttpMethod.PUT, defaultEntity(request), String.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThatJson(response.getBody()).isEqualTo(duplicateValueError());
+
+        UserEntity untouched = userRepository.findById(bob.id()).orElseThrow();
+        assertThat(untouched.username()).isEqualTo("bob");
+    }
+
+    @Test
+    void shouldReturnBadRequest_WhenUpdateRequestEmailIsDuplicate() {
+        // given.
+        insertUser("alice", "alice@example.com", "p", Set.of("VIEWER"), UserOrigin.LOCAL);
+        UserEntity bob = insertUser("bob", "bob@example.com", "p", Set.of("VIEWER"), UserOrigin.LOCAL);
+
+        // language=json
+        String request = """
+                {
+                  "id": "%s",
+                  "username": "bob",
+                  "email": "alice@example.com",
+                  "roles": ["VIEWER"],
+                  "password": null
+                }
+                """.formatted(bob.id());
+
+        // when.
+        ResponseEntity<String> response = restTemplate
+                .withRole(SUPER_ADMIN)
+                .exchange(USERS_UPDATE_PATH, HttpMethod.PUT, defaultEntity(request), String.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThatJson(response.getBody()).isEqualTo(duplicateValueError());
+
+        UserEntity untouched = userRepository.findById(bob.id()).orElseThrow();
+        assertThat(untouched.email()).isEqualTo("bob@example.com");
+    }
+
+    @Test
     void shouldReturnBadRequest_WhenUpdateRolesContainSuperAdmin() {
         UserEntity user = insertUser("u", "u@example.com", "p", Set.of("VIEWER"), UserOrigin.LOCAL);
 
@@ -490,6 +552,15 @@ public class UserManagementApiTest {
                     }
                     """)
     void negativeAuthTestsOnUpdateUser() {}
+
+    private static String duplicateValueError() {
+        // language=json
+        return """
+                {
+                  "errorCode": "%s"
+                }
+                """.formatted(ApiErrorCodes.USER_DUPLICATE_VALUE.getErrorCode());
+    }
 
     private HttpEntity<String> defaultEntity(String body) {
         HttpHeaders headers = new HttpHeaders();

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
@@ -31,6 +31,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserOrigin;
+import com.axelixlabs.axelix.master.exception.auth.UserDuplicateValueException;
 import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 import com.axelixlabs.axelix.master.repository.UserRepository;
@@ -148,6 +149,54 @@ abstract class DatabaseUserServiceTest {
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void createLocal_shouldThrowWhenUsernameIsDuplicate() {
+        // given.
+        userService.createLocal("alice", "alice@example.com", "p", "VIEWER");
+
+        // when.
+        assertThatThrownBy(() -> userService.createLocal("alice", "other@example.com", "p", "VIEWER"))
+                // then.
+                .isInstanceOf(UserDuplicateValueException.class);
+        assertThat(userRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    void createLocal_shouldThrowWhenEmailIsDuplicate() {
+        // given.
+        userService.createLocal("alice", "alice@example.com", "p", "VIEWER");
+
+        // when.
+        assertThatThrownBy(() -> userService.createLocal("bob", "alice@example.com", "p", "VIEWER"))
+                // then.
+                .isInstanceOf(UserDuplicateValueException.class);
+        assertThat(userRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    void createFromOidc_shouldThrowWhenUsernameIsDuplicate() {
+        // given.
+        userService.createLocal("alice", "alice@example.com", "p", "VIEWER");
+
+        // when.
+        assertThatThrownBy(() -> userService.createFromOidc("alice", "other@example.com", "VIEWER"))
+                // then.
+                .isInstanceOf(UserDuplicateValueException.class);
+        assertThat(userRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    void createFromOidc_shouldThrowWhenEmailIsDuplicate() {
+        // given.
+        userService.createLocal("alice", "alice@example.com", "p", "VIEWER");
+
+        // when.
+        assertThatThrownBy(() -> userService.createFromOidc("bob", "alice@example.com", "VIEWER"))
+                // then.
+                .isInstanceOf(UserDuplicateValueException.class);
+        assertThat(userRepository.findAll()).hasSize(1);
     }
 
     @Test
@@ -372,6 +421,40 @@ abstract class DatabaseUserServiceTest {
 
         UserEntity untouched = userRepository.findById(existing.id()).orElseThrow();
         assertThat(untouched.roles().values()).containsExactly("VIEWER");
+    }
+
+    @Test
+    void updateUserPatch_shouldThrowWhenUsernameIsDuplicate() {
+        // given.
+        userService.createLocal("alice", "alice@example.com", "p", "VIEWER");
+        userService.createLocal("bob", "bob@example.com", "p", "VIEWER");
+        UserEntity bob = userRepository.findByUsername("bob").orElseThrow();
+
+        // when.
+        assertThatThrownBy(
+                        () -> userService.updateUserPatch(bob.id(), "alice", "bob@example.com", null, Set.of("VIEWER")))
+                // then.
+                .isInstanceOf(UserDuplicateValueException.class);
+
+        UserEntity untouched = userRepository.findById(bob.id()).orElseThrow();
+        assertThat(untouched.username()).isEqualTo("bob");
+    }
+
+    @Test
+    void updateUserPatch_shouldThrowWhenEmailIsDuplicate() {
+        // given.
+        userService.createLocal("alice", "alice@example.com", "p", "VIEWER");
+        userService.createLocal("bob", "bob@example.com", "p", "VIEWER");
+        UserEntity bob = userRepository.findByUsername("bob").orElseThrow();
+
+        // when.
+        assertThatThrownBy(
+                        () -> userService.updateUserPatch(bob.id(), "bob", "alice@example.com", null, Set.of("VIEWER")))
+                // then.
+                .isInstanceOf(UserDuplicateValueException.class);
+
+        UserEntity untouched = userRepository.findById(bob.id()).orElseThrow();
+        assertThat(untouched.email()).isEqualTo("bob@example.com");
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user creation and update validation to detect duplicate usernames or emails and return a clear `400 BAD_REQUEST` response instead of database-level errors. Duplicate update requests now also leave the existing user data unchanged.

* **Tests**
  * Added/extended integration and service-level tests covering duplicate username and duplicate email scenarios for both creation and patch/update flows, including response/error payload assertions and unchanged persisted state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->