### PR TITLE
GH-1139 Fix flaky transaction monitoring timestamp nesting invariant

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringInterceptor.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringInterceptor.java
@@ -63,18 +63,17 @@ public class TransactionMonitoringInterceptor implements MethodInterceptor {
 
         if (propagation != null && shouldCreateNewTransaction(propagation)) {
             long startTimestampMs = System.currentTimeMillis();
-            long txStartTime = System.nanoTime();
 
             queriesCollector.startNewContext();
 
             try {
                 return invocation.proceed();
             } finally {
-                long duration = System.nanoTime() - txStartTime;
+                long endTimestampMs = System.currentTimeMillis();
+
                 List<SqlQueryRecord> queries = queriesCollector.popAllRecords();
 
-                statsCollector.recordTransaction(
-                        key, new TransactionRecord(duration / 1_000_000, startTimestampMs, queries));
+                statsCollector.recordTransaction(key, new TransactionRecord(endTimestampMs, startTimestampMs, queries));
             }
         }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringInterceptor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringInterceptor.java
@@ -68,7 +68,6 @@ public class TransactionMonitoringInterceptor implements MethodInterceptor {
 
         if (propagation != null && shouldCreateNewTransaction(propagation)) {
             long startTimestampMs = System.currentTimeMillis();
-            long txStartTime = System.nanoTime();
 
             queriesCollector.startNewContext();
 
@@ -85,11 +84,13 @@ public class TransactionMonitoringInterceptor implements MethodInterceptor {
                 throw e;
             } finally {
 
-                long durationNano = System.nanoTime() - txStartTime;
-                long durationMillis = durationNano / 1_000_000;
+                long endTimestampMs = System.currentTimeMillis();
+
                 List<SqlQueryRecord> queries = queriesCollector.popAllRecords();
 
-                statsCollector.recordTransaction(key, new TransactionRecord(durationMillis, startTimestampMs, queries));
+                TransactionRecord transactionRecord = new TransactionRecord(endTimestampMs, startTimestampMs, queries);
+
+                statsCollector.recordTransaction(key, transactionRecord);
 
                 // METRICS. Publish metrics in MeterRegistry
                 try {
@@ -97,7 +98,7 @@ public class TransactionMonitoringInterceptor implements MethodInterceptor {
                         metricsPublisher.publishTransactionMetrics(
                                 declaringClass.getSimpleName(),
                                 method.getName(),
-                                durationMillis,
+                                transactionRecord.getDurationMs(),
                                 transactionStatus,
                                 queries.size());
                     }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultTransactionMonitoringService.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultTransactionMonitoringService.java
@@ -107,16 +107,9 @@ public class DefaultTransactionMonitoringService implements TransactionMonitorin
     private TransactionExecution convertToTransactionExecution(TransactionRecord record) {
         List<Query> queries = convertToQueries(record.getQueries());
         long startTimestamp = record.getStartTimestampMs();
-        long endTimestamp = startTimestamp + record.getDurationMs();
+        long endTimestamp = record.getEndTimestampMs();
 
-        // The execution end and each query end are synthesized from currentTimeMillis() plus a
-        // nanoTime-based duration truncated to whole milliseconds. A query is always nested inside
-        // the execution in real time, so make the reported execution end cover the latest query end
-        // to keep that invariant after millisecond rounding.
-        long maxQueryEndTimestamp =
-                queries.stream().mapToLong(Query::getEndTimestampMs).max().orElse(endTimestamp);
-
-        return new TransactionExecution(startTimestamp, Math.max(endTimestamp, maxQueryEndTimestamp), queries);
+        return new TransactionExecution(startTimestamp, endTimestamp, queries);
     }
 
     private List<Query> convertToQueries(List<SqlQueryRecord> queriesRecords) {

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultTransactionMonitoringService.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/DefaultTransactionMonitoringService.java
@@ -108,7 +108,15 @@ public class DefaultTransactionMonitoringService implements TransactionMonitorin
         List<Query> queries = convertToQueries(record.getQueries());
         long startTimestamp = record.getStartTimestampMs();
         long endTimestamp = startTimestamp + record.getDurationMs();
-        return new TransactionExecution(startTimestamp, endTimestamp, queries);
+
+        // The execution end and each query end are synthesized from currentTimeMillis() plus a
+        // nanoTime-based duration truncated to whole milliseconds. A query is always nested inside
+        // the execution in real time, so make the reported execution end cover the latest query end
+        // to keep that invariant after millisecond rounding.
+        long maxQueryEndTimestamp =
+                queries.stream().mapToLong(Query::getEndTimestampMs).max().orElse(endTimestamp);
+
+        return new TransactionExecution(startTimestamp, Math.max(endTimestamp, maxQueryEndTimestamp), queries);
     }
 
     private List<Query> convertToQueries(List<SqlQueryRecord> queriesRecords) {

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/QueriesRecorder.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/QueriesRecorder.java
@@ -45,7 +45,11 @@ public interface QueriesRecorder {
 
     /**
      * Pops all query statistics collected within the particular transaction
-     * (i.e. the history of queries is removed from {@link QueriesRecorder})
+     * (i.e. the history of queries is removed from {@link QueriesRecorder}).
+     * <p>
+     * The implementation <strong>must guarantee</strong> that the returned {@link List}
+     * of recorded queries is chronologically sorted, i.e. the transaction on the X element
+     * of the {@link List} is guaranteed to happen BEFORE transaction under X + 1 element.
      *
      * @return list of query statistics
      */

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/SqlQueryRecord.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/SqlQueryRecord.java
@@ -51,4 +51,8 @@ public class SqlQueryRecord {
     public long getStartTimestampMs() {
         return startTimestampMs;
     }
+
+    public long getEndTimestampMs() {
+        return startTimestampMs + durationMs;
+    }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionRecord.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionRecord.java
@@ -24,26 +24,31 @@ import java.util.List;
  *
  * @author Sergey Cherkasov
  * @author Nikita Kirillov
+ * @author Mikhail Polivakha
  */
 public class TransactionRecord {
 
-    private final long durationMs;
+    private final long endTimestampMs;
     private final long startTimestampMs;
     private final List<SqlQueryRecord> queries;
 
     /**
-     * @param durationMs       transaction execution duration in milliseconds
-     * @param startTimestampMs transaction start timestamp in milliseconds since epoch
+     * @param endTimestampMs   transaction end timestamp in milliseconds since epoch.
+     * @param startTimestampMs transaction start timestamp in milliseconds since epoch.
      * @param queries          the list of queries executed during a particular transaction.
      */
-    public TransactionRecord(long durationMs, long startTimestampMs, List<SqlQueryRecord> queries) {
+    public TransactionRecord(long endTimestampMs, long startTimestampMs, List<SqlQueryRecord> queries) {
         this.queries = queries;
-        this.durationMs = durationMs;
+        this.endTimestampMs = TransactionUtils.calculateTransactionEndTimestamp(endTimestampMs, queries);
         this.startTimestampMs = startTimestampMs;
     }
 
+    public long getEndTimestampMs() {
+        return endTimestampMs;
+    }
+
     public long getDurationMs() {
-        return durationMs;
+        return endTimestampMs - startTimestampMs;
     }
 
     public long getStartTimestampMs() {

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionUtils.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Utility class for transactional operations interception.
+ *
+ * @author Sergey Cherkasov
+ * @author Mikhail Polivakha
+ */
+@NullMarked
+public class TransactionUtils {
+
+    /**
+     * <p>Why do we need this method:</p>
+     *
+     * In case the transaction is very short-lived (e.g. it is executed within milliseconds), then this might be possible, that
+     * any particular query executed in the transaction, i.e. last {@link SqlQueryRecord}, will have the timestamp that is slightly
+     * ahead of the transaction end time as we calculate it.
+     * <p>
+     * Why? Because of the rounding errors and non-deterministic granularity of {@link System#currentTimeMillis()}.
+     * So we have to assume, that if for some reason any sql query got larger end timestamp than that of a transaction -
+     * we just take this end timestamp of this query as the transaction end timestamp and that is it.
+     */
+    public static long calculateTransactionEndTimestamp(long transactionEndTimestamp, List<SqlQueryRecord> queries) {
+        if (queries.isEmpty()) {
+            return transactionEndTimestamp;
+        }
+
+        return Math.max(transactionEndTimestamp, maxQueriesTimestamp(queries));
+    }
+
+    @SuppressWarnings("NullAway")
+    private static Long maxQueriesTimestamp(List<SqlQueryRecord> queries) {
+        return queries.stream()
+                .max(Comparator.comparing(SqlQueryRecord::getEndTimestampMs))
+                .map(SqlQueryRecord::getEndTimestampMs)
+                .orElse(null);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction execution timing so the transaction end time and published metrics reflect the latest completion time of any nested SQL query within the transaction.
* **New Features**
  * Enhanced transaction timing data by adding an end-timestamp accessor on transaction records (with duration derived from start/end).
* **Documentation**
  * Clarified that returned query history is chronologically ordered to better reflect the sequence of transaction activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->