### PR TITLE
test(sbs3): share one Spring context across beans integration tests

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AbstractSharedBeansContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AbstractSharedBeansContextTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.beans;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import com.axelixlabs.axelix.sbs.spring.core.Main;
+
+/**
+ * Shared base test that defines a single Spring {@link org.springframework.context.ApplicationContext}
+ * reused by the non-endpoint "beans" tests so they hit the Spring TestContext cache instead of each
+ * building its own context.
+ *
+ * <p>{@link Main} is pinned via the {@code classes} attribute (rather than left to Spring Boot's
+ * auto-detection) so both subclasses resolve an identical, deterministic configuration — this is
+ * what makes the cached context shareable, and it also keeps auto-configuration (e.g. the embedded
+ * {@code DataSource}) active. The imported configurations are the union of the fixtures required by
+ * {@link DefaultBeanMetaInfoExtractorTest} and {@link QualifiersPersistencePostProcessorTest}.
+ *
+ * <p>{@code QualifiersPersistencePostProcessor} is intentionally not listed here — it is already
+ * provided by {@link DefaultBeanMetaInfoExtractorTest.DefaultBeanAnalyzerTestConfig} as a static
+ * {@code @Bean}.
+ */
+@SpringBootTest(classes = Main.class)
+@Import({
+    DefaultBeanMetaInfoExtractorTest.DefaultBeanAnalyzerTestConfig.class,
+    QualifiersPersistencePostProcessorTest.BeanMethodDeclarations.class,
+    QualifiersPersistencePostProcessorTest.ComponentMethodDeclarations.class,
+    QualifiersPersistencePostProcessorTest.ConfigurationClassesDeclarations.class
+})
+abstract class AbstractSharedBeansContextTest {}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeanMetaInfoExtractorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeanMetaInfoExtractorTest.java
@@ -43,7 +43,6 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProce
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -78,8 +77,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  */
-@SpringBootTest(classes = DefaultBeanMetaInfoExtractorTest.DefaultBeanAnalyzerTestConfig.class)
-class DefaultBeanMetaInfoExtractorTest {
+class DefaultBeanMetaInfoExtractorTest extends AbstractSharedBeansContextTest {
 
     @Autowired
     private BeanMetaInfoExtractor metaInfoExtractor;

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/QualifiersPersistencePostProcessorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/QualifiersPersistencePostProcessorTest.java
@@ -27,11 +27,9 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
@@ -40,14 +38,7 @@ import org.springframework.stereotype.Service;
  *
  * @author Mikhail Polivakha
  */
-@SpringBootTest
-@Import({
-    QualifiersPersistencePostProcessorTest.BeanMethodDeclarations.class,
-    QualifiersPersistencePostProcessorTest.ComponentMethodDeclarations.class,
-    QualifiersPersistencePostProcessorTest.ConfigurationClassesDeclarations.class,
-    QualifiersPersistencePostProcessor.class
-})
-class QualifiersPersistencePostProcessorTest {
+class QualifiersPersistencePostProcessorTest extends AbstractSharedBeansContextTest {
 
     @Test
     void shouldDetectAnnotationQualifiers() {


### PR DESCRIPTION
## What

The `...core.beans` tests in `sbs/axelix-spring-boot-3-starter` each built their own Spring `TestContext`. This makes the two **non-endpoint** beans tests share a single cached context:

- `DefaultBeanMetaInfoExtractorTest`
- `QualifiersPersistencePostProcessorTest`

They now extend a new abstract `AbstractSharedBeansContextTest`. The base pins `Main` via `@SpringBootTest(classes = Main.class)` and contributes the union of both tests' fixtures via `@Import`, so Spring reuses one `ApplicationContext` for both.

`AxelixBeansEndpointTest` (the endpoint test) is intentionally left on its own context.

## Why `Main` is pinned in `classes`

Leaving the configuration to Spring Boot's auto-detection produced divergent, non-shareable merged configurations across the two subclasses (and, in one attempt, dropped the auto-detected `Main` so the embedded `DataSource` was missing). Pinning `Main` explicitly via the `classes` attribute makes both subclasses resolve an identical, deterministic context — which is what lets them share the cache — while keeping auto-configuration (e.g. the embedded `DataSource`) active. `QualifiersPersistencePostProcessor` is not imported separately; it is already provided by `DefaultBeanAnalyzerTestConfig` as a static `@Bean`.

## Verification

- `./gradlew :sbs:axelix-spring-boot-3-starter:build` — green (tests + Spotless + PMD).
- spring-test-profiler report confirms **one shared context** for `DefaultBeanMetaInfoExtractorTest` + `QualifiersPersistencePostProcessorTest` (16 test methods, one context), and a **separate** context for `AxelixBeansEndpointTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)