### PR TITLE
test(sbs3): share one Spring context across env integration tests

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/AbstractEnvSharedContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/AbstractEnvSharedContextTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.env;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Base class for the {@code env} integration tests (the endpoint test is intentionally excluded). Every subclass
+ * inherits the same merged test configuration, so Spring's TestContext cache builds the context once and reuses it
+ * across all of them. The {@link TestPropertySource} below is the union of the properties each test needs; the keys
+ * do not collide and {@code args} is harmless to tests that do not read it.
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ */
+@SpringBootTest(args = "--fooBar=fromArgs")
+@TestPropertySource(
+        properties = {
+            // DefaultPropertyMetadataExtractorTest
+            "prop.test.server.port=test",
+            "prop.test.logging.level.root=test",
+            "custom.test.without.reason.property=test",
+            "custom.test.without.replacement.property=test",
+            // ValueInjectionTrackerBeanPostProcessorTest
+            "test.server.port=9090",
+            "test.spring.application.name=TimeoutTestApp",
+            "test.spring.profiles.active=production",
+            "test.app.timeout=3000",
+            "test.inner.timeout=1500",
+            "test.inner.constructor.timeout=2500",
+            "test.method.timeout=4200",
+            // DefaultEnvironmentServiceTest (explicit sanitization scenario)
+            "axelix.prop.test.tags.forSanitization=toBeSanitized",
+            "axelix.prop.test.tags.FOR_SANITIZATION=toBeSanitized"
+        })
+@EnableConfigurationProperties(EnvSharedTestConfig.AxelixConfigurationProperties.class)
+@Import(EnvSharedTestConfig.class)
+abstract class AbstractEnvSharedContextTest {}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/AbstractEnvSharedContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/AbstractEnvSharedContextTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.context.TestPropertySource;
  *
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
+ * @author Artemiy Degtyarev
  */
 @SpringBootTest(args = "--fooBar=fromArgs")
 @TestPropertySource(

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvPropertyEnricherTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvPropertyEnricherTest.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since 21.10.2025
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
+ * @author Artemiy Degtyarev
  */
 class DefaultEnvPropertyEnricherTest extends AbstractEnvSharedContextTest {
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvPropertyEnricherTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvPropertyEnricherTest.java
@@ -25,11 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.env.EnvironmentEndpoint;
 import org.springframework.boot.actuate.env.EnvironmentEndpoint.EnvironmentDescriptor;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.env.StandardEnvironment;
 
 import com.axelixlabs.axelix.common.api.env.EnvironmentFeed;
@@ -38,9 +33,6 @@ import com.axelixlabs.axelix.common.api.env.EnvironmentFeed.PropertySource;
 import com.axelixlabs.axelix.common.auth.core.DefaultSecurityContext;
 import com.axelixlabs.axelix.common.auth.core.SecurityContext;
 import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
-import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
-import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
-import com.axelixlabs.axelix.sbs.spring.core.env.DefaultEnvPropertyEnricherTest.CurrentTestConfig;
 
 import static com.axelixlabs.axelix.sbs.spring.core.utils.UserUtils.createUserWithAuthorities;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,9 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  */
-@SpringBootTest(args = "--fooBar=fromArgs")
-@Import({EnvironmentTestConfig.class, CurrentTestConfig.class})
-class DefaultEnvPropertyEnricherTest {
+class DefaultEnvPropertyEnricherTest extends AbstractEnvSharedContextTest {
 
     private final ThreadLocalSecurityContextExecutor securityContextExecutor = new ThreadLocalSecurityContextExecutor();
 
@@ -66,21 +56,6 @@ class DefaultEnvPropertyEnricherTest {
 
     @Autowired
     private EnvPropertyEnricher enricher;
-
-    @TestConfiguration
-    static class CurrentTestConfig {
-
-        @Bean
-        @ConfigurationProperties(prefix = "axelix.sbs.endpoints.config")
-        public EndpointsConfigurationProperties endpointsConfigurationProperties() {
-            return new EndpointsConfigurationProperties();
-        }
-
-        @Bean
-        SmartSanitizingFunction smartSanitizingFunction() {
-            return new SmartSanitizingFunction(List.of(), new DefaultPropertyNameNormalizer());
-        }
-    }
 
     @BeforeAll
     static void beforeAll() {

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvironmentServiceTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvironmentServiceTest.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for {@link DefaultEnvironmentService}
  *
  * @author Nikita Kirillov
+ * @author Artemiy Degtyarev
  */
 class DefaultEnvironmentServiceTest extends AbstractEnvSharedContextTest {
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvironmentServiceTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvironmentServiceTest.java
@@ -17,7 +17,6 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.env;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,12 +26,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 import com.axelixlabs.axelix.common.api.env.EnvironmentFeed;
 import com.axelixlabs.axelix.common.api.env.EnvironmentFeed.Property;
@@ -41,11 +35,6 @@ import com.axelixlabs.axelix.common.auth.core.DefaultSecurityContext;
 import com.axelixlabs.axelix.common.auth.core.SecurityContext;
 import com.axelixlabs.axelix.common.auth.core.User;
 import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
-import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
-import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
-import com.axelixlabs.axelix.sbs.spring.core.env.DefaultEnvironmentServiceTest.WithExplicitSanitizationProperties.AxelixConfigurationProperties;
-import com.axelixlabs.axelix.sbs.spring.core.env.DefaultEnvironmentServiceTest.WithExplicitSanitizationProperties.TestConfigWithExplicitSanitizationProperties;
-import com.axelixlabs.axelix.sbs.spring.core.env.DefaultEnvironmentServiceTest.WithoutExplicitSanitizationProperties.TestConfigWithAllPropertiesSanitized;
 
 import static com.axelixlabs.axelix.sbs.spring.core.utils.UserUtils.createUserWithAuthorities;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,16 +44,15 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Nikita Kirillov
  */
-class DefaultEnvironmentServiceTest {
+class DefaultEnvironmentServiceTest extends AbstractEnvSharedContextTest {
 
     private final ThreadLocalSecurityContextExecutor securityContextExecutor = new ThreadLocalSecurityContextExecutor();
 
-    @SpringBootTest
     @Nested
-    @Import(TestConfigWithAllPropertiesSanitized.class)
     class WithoutExplicitSanitizationProperties {
 
         @Autowired
+        @Qualifier("sanitizeAllEnvironmentService")
         private EnvironmentService environmentService;
 
         @Test
@@ -100,30 +88,13 @@ class DefaultEnvironmentServiceTest {
 
             assertThat(values).doesNotContain("******");
         }
-
-        @TestConfiguration
-        @Import(EnvironmentTestConfig.class)
-        static class TestConfigWithAllPropertiesSanitized {
-
-            @Bean
-            public SmartSanitizingFunction smartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
-                return new SmartSanitizingFunction(
-                        EndpointsConfigurationProperties.SANITIZE_ALL, propertyNameNormalizer);
-            }
-        }
     }
 
-    @SpringBootTest(
-            properties = {
-                "axelix.prop.test.tags.forSanitization=toBeSanitized",
-                "axelix.prop.test.tags.FOR_SANITIZATION=toBeSanitized"
-            })
     @Nested
-    @EnableConfigurationProperties(AxelixConfigurationProperties.class)
-    @Import(TestConfigWithExplicitSanitizationProperties.class)
     class WithExplicitSanitizationProperties {
 
         @Autowired
+        @Qualifier("explicitSanitizeEnvironmentService")
         private EnvironmentService environmentService;
 
         @Test
@@ -161,20 +132,5 @@ class DefaultEnvironmentServiceTest {
 
             assertThat(values).doesNotContain("******");
         }
-
-        @TestConfiguration
-        @Import(EnvironmentTestConfig.class)
-        static class TestConfigWithExplicitSanitizationProperties {
-
-            @Bean
-            public SmartSanitizingFunction smartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
-                return new SmartSanitizingFunction(
-                        List.of("axelix.prop.test.tags.forSanitization", "axelix.prop.test.tags.FOR_SANITIZATION"),
-                        propertyNameNormalizer);
-            }
-        }
-
-        @ConfigurationProperties(prefix = "axelix.prop.test")
-        public record AxelixConfigurationProperties(Map<String, String> tags) {}
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultPropertyMetadataExtractorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultPropertyMetadataExtractorTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration test for {@link DefaultPropertyMetadataExtractor}
  *
  * @author Nikita Kirillov
+ * @author Artemiy Degtyarev
  * @since 05.12.2025
  */
 class DefaultPropertyMetadataExtractorTest extends AbstractEnvSharedContextTest {

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultPropertyMetadataExtractorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultPropertyMetadataExtractorTest.java
@@ -21,12 +21,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,16 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Nikita Kirillov
  * @since 05.12.2025
  */
-@TestPropertySource(
-        properties = {
-            "prop.test.server.port=test",
-            "prop.test.logging.level.root=test",
-            "custom.test.without.reason.property=test",
-            "custom.test.without.replacement.property=test"
-        })
-@SpringBootTest
-@Import(DefaultPropertyMetadataExtractorTest.DefaultPropertyMetadataExtractorTestConfiguration.class)
-class DefaultPropertyMetadataExtractorTest {
+class DefaultPropertyMetadataExtractorTest extends AbstractEnvSharedContextTest {
 
     @Autowired
     private PropertyMetadataExtractor extractor;
@@ -101,20 +86,5 @@ class DefaultPropertyMetadataExtractorTest {
     void shouldNotExtractPropertyMetadataWithoutDeprecated() {
         PropertyMetadata nonExistentMetadata = extractor.getMetadata("non.existent.property");
         assertThat(nonExistentMetadata).isNull();
-    }
-
-    @TestConfiguration
-    static class DefaultPropertyMetadataExtractorTestConfiguration {
-
-        @Bean
-        public PropertyNameNormalizer propertyNameNormalizer() {
-            return new DefaultPropertyNameNormalizer();
-        }
-
-        @Bean
-        public PropertyMetadataExtractor propertyMetadataExtractor(
-                ConfigurableEnvironment configurableEnvironment, PropertyNameNormalizer propertyNameNormalizer) {
-            return new DefaultPropertyMetadataExtractor(configurableEnvironment, propertyNameNormalizer);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/EnvSharedTestConfig.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/EnvSharedTestConfig.java
@@ -55,6 +55,7 @@ import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction
  *
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
+ * @author Artemiy Degtyarev
  */
 @TestConfiguration
 public class EnvSharedTestConfig {

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/EnvSharedTestConfig.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/EnvSharedTestConfig.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.env;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+
+import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
+import com.axelixlabs.axelix.sbs.spring.core.auth.RequiredAuthorityCheckService;
+import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
+import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesConverter;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesFlattener;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesService;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesConverter;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesFlattener;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesService;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
+
+/**
+ * Shared test configuration backing a single, cached Spring context for all non-endpoint {@code env}
+ * integration tests. The two distinct sanitization behaviours required by these tests are exposed as two
+ * separately-named {@link SmartSanitizingFunction} beans (and two matching {@link EnvironmentService} beans),
+ * so a single context can satisfy every scenario.
+ *
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
+ */
+@TestConfiguration
+public class EnvSharedTestConfig {
+
+    @Bean
+    public ConfigurationPropertiesFlattener configurationPropertiesFlattener() {
+        return new DefaultConfigurationPropertiesFlattener();
+    }
+
+    @Bean
+    public ConfigurationPropertiesConverter configurationPropertiesConverter(
+            ConfigurationPropertiesFlattener configurationPropertiesFlattener) {
+        return new DefaultConfigurationPropertiesConverter(configurationPropertiesFlattener);
+    }
+
+    @Bean
+    public SecurityContextExecutor securityContextExecutor() {
+        return new ThreadLocalSecurityContextExecutor();
+    }
+
+    @Bean
+    public RequiredAuthorityCheckService requiredAuthorityCheckService(
+            SecurityContextExecutor securityContextExecutor) {
+        return new RequiredAuthorityCheckService(securityContextExecutor);
+    }
+
+    @Bean
+    public PropertyNameNormalizer propertyNameNormalizer() {
+        return new DefaultPropertyNameNormalizer();
+    }
+
+    @Bean
+    public PropertyMetadataExtractor propertyMetadataExtractor(
+            ConfigurableEnvironment environment, PropertyNameNormalizer propertyNameNormalizer) {
+        return new DefaultPropertyMetadataExtractor(environment, propertyNameNormalizer);
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "axelix.sbs.endpoints.config")
+    public EndpointsConfigurationProperties endpointsConfigurationProperties() {
+        return new EndpointsConfigurationProperties();
+    }
+
+    /**
+     * Declared {@code static} so the post-processor is registered early and analyzes every bean in the context
+     * (including the {@code @Value} sample beans below).
+     */
+    @Bean
+    public static ValueInjectionTrackerBeanPostProcessor valueInjectionTrackerBeanPostProcessor() {
+        return new ValueInjectionTrackerBeanPostProcessor(new DefaultPropertyNameNormalizer());
+    }
+
+    @Bean
+    public SmartSanitizingFunction sanitizeAllSmartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
+        return new SmartSanitizingFunction(EndpointsConfigurationProperties.SANITIZE_ALL, propertyNameNormalizer);
+    }
+
+    @Bean
+    public SmartSanitizingFunction explicitSmartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
+        return new SmartSanitizingFunction(
+                List.of("axelix.prop.test.tags.forSanitization", "axelix.prop.test.tags.FOR_SANITIZATION"),
+                propertyNameNormalizer);
+    }
+
+    @Bean
+    public ConfigurationPropertiesService configurationPropertiesService(
+            @Qualifier("explicitSmartSanitizingFunction") SmartSanitizingFunction smartSanitizingFunction,
+            ApplicationContext applicationContext,
+            ConfigurationPropertiesConverter configurationPropertiesConverter,
+            RequiredAuthorityCheckService requiredAuthorityCheckService) {
+        return new DefaultConfigurationPropertiesService(
+                smartSanitizingFunction,
+                applicationContext,
+                configurationPropertiesConverter,
+                requiredAuthorityCheckService);
+    }
+
+    @Bean
+    public EnvPropertyEnricher envPropertyEnricher(
+            Environment environment,
+            PropertyNameNormalizer propertyNameNormalizer,
+            ObjectProvider<ConfigurationPropertiesService> configurationPropertiesServiceProvider,
+            PropertyMetadataExtractor propertyMetadataExtractor,
+            ValueInjectionTrackerBeanPostProcessor valueInjectionTrackerBeanPostProcessor) {
+        return new DefaultEnvPropertyEnricher(
+                environment,
+                propertyNameNormalizer,
+                configurationPropertiesServiceProvider,
+                propertyMetadataExtractor,
+                valueInjectionTrackerBeanPostProcessor);
+    }
+
+    @Bean
+    public EnvironmentService sanitizeAllEnvironmentService(
+            Environment environment,
+            @Qualifier("sanitizeAllSmartSanitizingFunction") SmartSanitizingFunction smartSanitizingFunction,
+            EnvPropertyEnricher envPropertyEnricher,
+            RequiredAuthorityCheckService requiredAuthorityCheckService) {
+        return new DefaultEnvironmentService(
+                environment, smartSanitizingFunction, envPropertyEnricher, requiredAuthorityCheckService);
+    }
+
+    @Bean
+    public EnvironmentService explicitSanitizeEnvironmentService(
+            Environment environment,
+            @Qualifier("explicitSmartSanitizingFunction") SmartSanitizingFunction smartSanitizingFunction,
+            EnvPropertyEnricher envPropertyEnricher,
+            RequiredAuthorityCheckService requiredAuthorityCheckService) {
+        return new DefaultEnvironmentService(
+                environment, smartSanitizingFunction, envPropertyEnricher, requiredAuthorityCheckService);
+    }
+
+    @Bean
+    public TestBeanWithCustomAnnotations testBeanWithCustomAnnotations() {
+        return new TestBeanWithCustomAnnotations("appName", "connectionTimeout");
+    }
+
+    @Bean
+    public TestBeanWithSpEL testBeanWithSpEL() {
+        return new TestBeanWithSpEL();
+    }
+
+    @ConfigurationProperties(prefix = "axelix.prop.test")
+    public record AxelixConfigurationProperties(Map<String, String> tags) {}
+
+    @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Value("${test.app.timeout:5000}")
+    public @interface TimeoutValue {}
+
+    public static class TestBeanWithSpEL {
+
+        @Value("#{environment.getProperty('server.port')}")
+        private String envPort;
+
+        @Value("#{systemProperties['user.home']}")
+        private String systemHome;
+
+        @Value("#{environment.getProperty('app.timeout')}")
+        public Integer getTimeout() {
+            return 5000;
+        }
+    }
+
+    public static class TestBeanWithCustomAnnotations {
+
+        @Value("${test.server.port:8080}")
+        private String serverPort;
+
+        @TimeoutValue
+        private Integer timeout;
+
+        public TestBeanWithCustomAnnotations(
+                @Value("${test.spring.application.name:TestApp}") String appName,
+                @TimeoutValue String connectionTimeout) {}
+
+        private String profile;
+        private Integer maxTimeout;
+
+        @Autowired
+        public void setProfile(@Value("${test.spring.profiles.active}") String profile) {
+            this.profile = profile;
+        }
+
+        @Autowired
+        public void setMaxTimeout(@TimeoutValue Integer timeout) {
+            this.maxTimeout = timeout * 2;
+        }
+
+        @Value("${test.method.timeout}")
+        public void calculateRandomTimeout() {}
+
+        @TimeoutValue
+        public void getDefaultTimeout() {}
+
+        public String getServerPort() {
+            return serverPort;
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/ValueInjectionTrackerBeanPostProcessorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/ValueInjectionTrackerBeanPostProcessorTest.java
@@ -17,21 +17,11 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.env;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.stereotype.Component;
-import org.springframework.test.context.TestPropertySource;
 
 import com.axelixlabs.axelix.common.api.env.EnvironmentFeed.InjectionPoint;
 import com.axelixlabs.axelix.common.api.env.EnvironmentFeed.InjectionType;
@@ -39,38 +29,17 @@ import com.axelixlabs.axelix.common.api.env.EnvironmentFeed.InjectionType;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Integration test for {@link ValueInjectionTrackerBeanPostProcessor}
+ * Integration test for {@link ValueInjectionTrackerBeanPostProcessor}. The analyzed sample beans live in
+ * {@link EnvSharedTestConfig}, so the tracked injection points carry the bean name generated for those
+ * {@code @Bean} methods.
  *
  * @since 16.12.2025
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  */
-@SpringBootTest(
-        classes = {
-            ValueInjectionTrackerBeanPostProcessorTest.ValueInjectionTrackerBeanPostProcessorTestConfig.class,
-            ValueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations.class,
-            ValueInjectionTrackerBeanPostProcessorTest.TestBeanWithSpEL.class
-        })
-@TestPropertySource(
-        properties = {
-            "test.server.port=9090",
-            "test.spring.application.name=TimeoutTestApp",
-            "test.spring.profiles.active=production",
-            "test.app.timeout=3000",
-            "test.inner.timeout=1500",
-            "test.inner.constructor.timeout=2500",
-            "test.method.timeout=4200"
-        })
-class ValueInjectionTrackerBeanPostProcessorTest {
+class ValueInjectionTrackerBeanPostProcessorTest extends AbstractEnvSharedContextTest {
 
-    @TestConfiguration
-    static class ValueInjectionTrackerBeanPostProcessorTestConfig {
-
-        @Bean
-        public static ValueInjectionTrackerBeanPostProcessor valueInjectionTrackerBeanPostProcessor() {
-            return new ValueInjectionTrackerBeanPostProcessor(new DefaultPropertyNameNormalizer());
-        }
-    }
+    private static final String SAMPLE_BEAN_NAME = "testBeanWithCustomAnnotations";
 
     @Autowired
     private ValueInjectionTrackerBeanPostProcessor subject;
@@ -87,8 +56,7 @@ class ValueInjectionTrackerBeanPostProcessorTest {
 
         // then.
         assertThat(points).hasSize(1).first().satisfies(point -> {
-            assertThat(point.getBeanName())
-                    .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+            assertThat(point.getBeanName()).isEqualTo(SAMPLE_BEAN_NAME);
             assertThat(point.getInjectionType()).isEqualTo(InjectionType.FIELD);
             assertThat(point.getTargetName()).isEqualTo("serverPort");
             assertThat(point.getPropertyExpression()).isEqualTo("${" + propertyServerPort + ":8080}");
@@ -109,8 +77,7 @@ class ValueInjectionTrackerBeanPostProcessorTest {
                 .orElseThrow();
 
         // then.
-        assertThat(injectionPoint.getBeanName())
-                .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+        assertThat(injectionPoint.getBeanName()).isEqualTo(SAMPLE_BEAN_NAME);
         assertThat(injectionPoint.getPropertyExpression()).isEqualTo("${" + propertyTimeout + ":5000}");
     }
 
@@ -123,8 +90,7 @@ class ValueInjectionTrackerBeanPostProcessorTest {
         List<InjectionPoint> appNamePoints =
                 subject.getInjectionPointsForProperty(normalizer.normalize(propertyApplicationName));
         assertThat(appNamePoints).hasSize(1).first().satisfies(point -> {
-            assertThat(point.getBeanName())
-                    .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+            assertThat(point.getBeanName()).isEqualTo(SAMPLE_BEAN_NAME);
             assertThat(point.getInjectionType()).isEqualTo(InjectionType.CONSTRUCTOR_PARAMETER);
             assertThat(point.getTargetName()).isEqualTo("appName");
             assertThat(point.getPropertyExpression()).isEqualTo("${" + propertyApplicationName + ":TestApp}");
@@ -144,8 +110,7 @@ class ValueInjectionTrackerBeanPostProcessorTest {
                 .hasSize(1)
                 .first()
                 .satisfies(point -> {
-                    assertThat(point.getBeanName())
-                            .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+                    assertThat(point.getBeanName()).isEqualTo(SAMPLE_BEAN_NAME);
                     assertThat(point.getPropertyExpression()).isEqualTo("${test.app.timeout:5000}");
                 });
     }
@@ -159,8 +124,7 @@ class ValueInjectionTrackerBeanPostProcessorTest {
         List<InjectionPoint> profilePoints =
                 subject.getInjectionPointsForProperty(normalizer.normalize(propertyProfile));
         assertThat(profilePoints).hasSize(1).first().satisfies(point -> {
-            assertThat(point.getBeanName())
-                    .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+            assertThat(point.getBeanName()).isEqualTo(SAMPLE_BEAN_NAME);
             assertThat(point.getInjectionType()).isEqualTo(InjectionType.METHOD_PARAMETER);
             assertThat(point.getTargetName()).contains("setProfile");
             assertThat(point.getPropertyExpression()).isEqualTo("${" + propertyProfile + "}");
@@ -181,8 +145,7 @@ class ValueInjectionTrackerBeanPostProcessorTest {
                 .hasSize(1)
                 .first()
                 .satisfies(point -> {
-                    assertThat(point.getBeanName())
-                            .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+                    assertThat(point.getBeanName()).isEqualTo(SAMPLE_BEAN_NAME);
                     assertThat(point.getPropertyExpression()).isEqualTo("${" + propertyTimeout + ":5000}");
                 });
     }
@@ -201,8 +164,7 @@ class ValueInjectionTrackerBeanPostProcessorTest {
                 .hasSize(1)
                 .first()
                 .satisfies(point -> {
-                    assertThat(point.getBeanName())
-                            .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+                    assertThat(point.getBeanName()).isEqualTo(SAMPLE_BEAN_NAME);
                     assertThat(point.getPropertyExpression()).isEqualTo("${" + propertyMethodTimeout + "}");
                 });
     }
@@ -221,8 +183,7 @@ class ValueInjectionTrackerBeanPostProcessorTest {
                 .hasSize(1)
                 .first()
                 .satisfies(point -> {
-                    assertThat(point.getBeanName())
-                            .isEqualTo("valueInjectionTrackerBeanPostProcessorTest.TestBeanWithCustomAnnotations");
+                    assertThat(point.getBeanName()).isEqualTo(SAMPLE_BEAN_NAME);
                     assertThat(point.getPropertyExpression()).isEqualTo("${" + propertyAppTimeout + ":5000}");
                 });
     }
@@ -257,62 +218,5 @@ class ValueInjectionTrackerBeanPostProcessorTest {
                     assertThat(p.getInjectionType()).isEqualTo(InjectionType.FIELD);
                     assertThat(p.getPropertyExpression()).isEqualTo("#{systemProperties['user.home']}");
                 });
-    }
-
-    @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
-    @Retention(RetentionPolicy.RUNTIME)
-    @Value("${test.app.timeout:5000}")
-    public @interface TimeoutValue {}
-
-    @Component
-    public static class TestBeanWithSpEL {
-
-        @Value("#{environment.getProperty('server.port')}")
-        private String envPort;
-
-        @Value("#{systemProperties['user.home']}")
-        private String systemHome;
-
-        @Value("#{environment.getProperty('app.timeout')}")
-        public Integer getTimeout() {
-            return 5000;
-        }
-    }
-
-    @Component
-    public static class TestBeanWithCustomAnnotations {
-
-        @Value("${test.server.port:8080}")
-        private String serverPort;
-
-        @TimeoutValue
-        private Integer timeout;
-
-        public TestBeanWithCustomAnnotations(
-                @Value("${test.spring.application.name:TestApp}") String appName,
-                @TimeoutValue String connectionTimeout) {}
-
-        private String profile;
-        private Integer maxTimeout;
-
-        @Autowired
-        public void setProfile(@Value("${test.spring.profiles.active}") String profile) {
-            this.profile = profile;
-        }
-
-        @Autowired
-        public void setMaxTimeout(@TimeoutValue Integer timeout) {
-            this.maxTimeout = timeout * 2;
-        }
-
-        @Value("${test.method.timeout}")
-        public void calculateRandomTimeout() {}
-
-        @TimeoutValue
-        public void getDefaultTimeout() {}
-
-        public String getServerPort() {
-            return serverPort;
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/ValueInjectionTrackerBeanPostProcessorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/ValueInjectionTrackerBeanPostProcessorTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since 16.12.2025
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
+ * @author Artemiy Degtyarev
  */
 class ValueInjectionTrackerBeanPostProcessorTest extends AbstractEnvSharedContextTest {
 


### PR DESCRIPTION
## What & why

Each non-endpoint test under `sbs/axelix-spring-boot-3-starter/.../core/env/` declared its own `@SpringBootTest` configuration, so every class — and each `@Nested` scenario — built a separate `ApplicationContext`. This consolidates them onto a single shared, cached context.

## How

- **`AbstractEnvSharedContextTest`** (new abstract base): one `@SpringBootTest(args=…)` + the union of the tests' `@TestPropertySource` properties + `@EnableConfigurationProperties` + `@Import(EnvSharedTestConfig)`. The four non-endpoint env tests now extend it, so Spring caches the context once and reuses it.
- **`EnvSharedTestConfig`** (new shared `@TestConfiguration`): the union of beans needed. The differing sanitization behaviour is exposed as **two separately-named** `SmartSanitizingFunction` beans (`sanitizeAllSmartSanitizingFunction` / `explicitSmartSanitizingFunction`), each backing a named `EnvironmentService`, so a single context satisfies every scenario without ambiguous autowiring. The `@Value` sample beans and the `AxelixConfigurationProperties` record were relocated here.
- The Actuator endpoint test (`AxelixEnvironmentEndpointTest`) is intentionally **left on its own context**.

## Result (spring-test-profiler, env package)

| Metric | Before | After |
|---|---|---|
| Cache Size (contexts) | 6 | **2** |
| Cache Misses | 6 | **2** |
| Cache Hit Rate | 87.5% | **96.2%** |

The shared context holds exactly the 6 env units (`DefaultEnvPropertyEnricherTest`, `DefaultEnvironmentServiceTest` + its 2 `@Nested` scenarios, `DefaultPropertyMetadataExtractorTest`, `ValueInjectionTrackerBeanPostProcessorTest`); `AxelixEnvironmentEndpointTest` stands alone.

## Verification

- Env tests green; module `spotlessCheck` / `pmdMain` / `pmdTest` / Error-Prone+NullAway compile green.
- Behaviour preserved; assertions unchanged except the value-injection tracker's expected bean name (sample beans now registered via `@Bean` in the shared config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored integration test infrastructure to consolidate shared configuration and reduce duplication across test classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->