### PR TITLE
test(sbs3): share one Spring context across master integration tests

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/AbstractMasterContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/AbstractMasterContextTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.master;
+
+import java.lang.management.ManagementFactory;
+
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import com.axelixlabs.axelix.common.api.registration.BasicDiscoveryMetadata;
+import com.axelixlabs.axelix.common.domain.version.AxelixVersionDiscoverer;
+
+/**
+ * Shared base for the {@code master} integration tests that do not require a running web server. By defining a single,
+ * unioned context here and having every subclass inherit it unchanged, the Spring TestContext framework resolves the
+ * same context cache key for all of them, so they share one cached {@link org.springframework.context.ApplicationContext}.
+ *
+ * <p>{@link AxelixMetadataEndpointTest} intentionally does not extend this class: it starts a real web server and its
+ * own JWT stack, so it keeps a separate context.
+ */
+@SpringBootTest
+@Import({
+    CommitIdPluginGitInformationProvider.class,
+    CommitIdPluginShortBuildInfoProvider.class,
+    ProjectInfoAutoConfiguration.class,
+    DefaultServiceMetadataAssembler.class,
+    AbstractMasterContextTest.SharedConfig.class
+})
+abstract class AbstractMasterContextTest {
+
+    @MockBean
+    private HealthEndpoint healthEndpoint;
+
+    @TestConfiguration
+    static class SharedConfig {
+
+        @Bean
+        VMFeaturesProvider vmFeaturesProvider() {
+            return new OptionsParsingVMFeaturesProvider(
+                    ManagementFactory.getRuntimeMXBean().getInputArguments());
+        }
+
+        @Bean
+        HealthDetectionFunction healthDetectionFunction() {
+            return () -> BasicDiscoveryMetadata.HealthStatus.UP;
+        }
+
+        @Bean
+        AxelixVersionDiscoverer axelixVersionDiscoverer() {
+            return () -> "1.1.3";
+        }
+
+        @Bean
+        public LibraryInformationProvider libraryInformationProvider() {
+            return new DefaultLibraryInformationProvider();
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/AbstractMasterContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/AbstractMasterContextTest.java
@@ -37,6 +37,9 @@ import com.axelixlabs.axelix.common.domain.version.AxelixVersionDiscoverer;
  *
  * <p>{@link AxelixMetadataEndpointTest} intentionally does not extend this class: it starts a real web server and its
  * own JWT stack, so it keeps a separate context.
+ *
+ * @author Mikhail Polivakha
+ * @author Artemiy Degtyarev
  */
 @SpringBootTest
 @Import({

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/AbstractMasterSharedContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/AbstractMasterSharedContextTest.java
@@ -35,8 +35,6 @@ import com.axelixlabs.axelix.common.domain.version.AxelixVersionDiscoverer;
  * unioned context here and having every subclass inherit it unchanged, the Spring TestContext framework resolves the
  * same context cache key for all of them, so they share one cached {@link org.springframework.context.ApplicationContext}.
  *
- * <p>{@link AxelixMetadataEndpointTest} intentionally does not extend this class: it starts a real web server and its
- * own JWT stack, so it keeps a separate context.
  *
  * @author Mikhail Polivakha
  * @author Artemiy Degtyarev
@@ -47,9 +45,9 @@ import com.axelixlabs.axelix.common.domain.version.AxelixVersionDiscoverer;
     CommitIdPluginShortBuildInfoProvider.class,
     ProjectInfoAutoConfiguration.class,
     DefaultServiceMetadataAssembler.class,
-    AbstractMasterContextTest.SharedConfig.class
+    AbstractMasterSharedContextTest.SharedConfig.class
 })
-abstract class AbstractMasterContextTest {
+abstract class AbstractMasterSharedContextTest {
 
     @MockBean
     private HealthEndpoint healthEndpoint;

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginGitInformationProviderTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginGitInformationProviderTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mikhail Polivakha
  * @author Artemiy Degtyarev
  */
-class CommitIdPluginGitInformationProviderTest extends AbstractMasterContextTest {
+class CommitIdPluginGitInformationProviderTest extends AbstractMasterSharedContextTest {
 
     @Autowired
     private CommitIdPluginGitInformationProvider subject;

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginGitInformationProviderTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginGitInformationProviderTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration test for {@link CommitIdPluginGitInformationProvider}.
  *
  * @author Mikhail Polivakha
+ * @author Artemiy Degtyarev
  */
 class CommitIdPluginGitInformationProviderTest extends AbstractMasterContextTest {
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginGitInformationProviderTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginGitInformationProviderTest.java
@@ -20,9 +20,6 @@ package com.axelixlabs.axelix.sbs.spring.core.master;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 
 import com.axelixlabs.axelix.common.api.registration.GitInfo;
 
@@ -33,9 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Mikhail Polivakha
  */
-@SpringBootTest
-@Import({CommitIdPluginGitInformationProvider.class, ProjectInfoAutoConfiguration.class})
-class CommitIdPluginGitInformationProviderTest {
+class CommitIdPluginGitInformationProviderTest extends AbstractMasterContextTest {
 
     @Autowired
     private CommitIdPluginGitInformationProvider subject;

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginShortBuildInfoProviderTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginShortBuildInfoProviderTest.java
@@ -20,9 +20,6 @@ package com.axelixlabs.axelix.sbs.spring.core.master;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 
 import com.axelixlabs.axelix.common.api.registration.ShortBuildInfo;
 
@@ -33,9 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Mikhail Polivakha
  */
-@SpringBootTest
-@Import({CommitIdPluginShortBuildInfoProvider.class, ProjectInfoAutoConfiguration.class})
-class CommitIdPluginShortBuildInfoProviderTest {
+class CommitIdPluginShortBuildInfoProviderTest extends AbstractMasterContextTest {
 
     @Autowired
     private CommitIdPluginShortBuildInfoProvider subject;

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginShortBuildInfoProviderTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginShortBuildInfoProviderTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration test for {@link CommitIdPluginShortBuildInfoProvider}.
  *
  * @author Mikhail Polivakha
+ * @author Artemiy Degtyarev
  */
 class CommitIdPluginShortBuildInfoProviderTest extends AbstractMasterContextTest {
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginShortBuildInfoProviderTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/CommitIdPluginShortBuildInfoProviderTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mikhail Polivakha
  * @author Artemiy Degtyarev
  */
-class CommitIdPluginShortBuildInfoProviderTest extends AbstractMasterContextTest {
+class CommitIdPluginShortBuildInfoProviderTest extends AbstractMasterSharedContextTest {
 
     @Autowired
     private CommitIdPluginShortBuildInfoProvider subject;

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultServiceMetadataAssemblerTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultServiceMetadataAssemblerTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mikhail Polivakha
  * @author Artemiy Degtyarev
  */
-class DefaultServiceMetadataAssemblerTest extends AbstractMasterContextTest {
+class DefaultServiceMetadataAssemblerTest extends AbstractMasterSharedContextTest {
 
     @Autowired
     private DefaultServiceMetadataAssembler subject;

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultServiceMetadataAssemblerTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultServiceMetadataAssemblerTest.java
@@ -17,21 +17,12 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.master;
 
-import java.lang.management.ManagementFactory;
-
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootVersion;
-import org.springframework.boot.actuate.health.HealthEndpoint;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 
 import com.axelixlabs.axelix.common.api.registration.BasicDiscoveryMetadata;
-import com.axelixlabs.axelix.common.domain.version.AxelixVersionDiscoverer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,45 +31,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Mikhail Polivakha
  */
-@SpringBootTest
-@Import({
-    CommitIdPluginGitInformationProvider.class,
-    CommitIdPluginShortBuildInfoProvider.class,
-    DefaultServiceMetadataAssembler.class,
-    DefaultServiceMetadataAssemblerTest.CurrentConfig.class
-})
-class DefaultServiceMetadataAssemblerTest {
+class DefaultServiceMetadataAssemblerTest extends AbstractMasterContextTest {
 
     @Autowired
     private DefaultServiceMetadataAssembler subject;
-
-    @MockBean
-    private HealthEndpoint healthEndpoint;
-
-    @TestConfiguration
-    static class CurrentConfig {
-
-        @Bean
-        VMFeaturesProvider vmFeaturesProvider() {
-            return new OptionsParsingVMFeaturesProvider(
-                    ManagementFactory.getRuntimeMXBean().getInputArguments());
-        }
-
-        @Bean
-        HealthDetectionFunction healthDetectionFunction() {
-            return () -> BasicDiscoveryMetadata.HealthStatus.UP;
-        }
-
-        @Bean
-        AxelixVersionDiscoverer axelixVersionDiscoverer() {
-            return () -> "1.1.3";
-        }
-
-        @Bean
-        public LibraryInformationProvider libraryInformationProvider() {
-            return new DefaultLibraryInformationProvider();
-        }
-    }
 
     @Test
     void shouldAssembleTheMetadataAboutGivenService() {

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultServiceMetadataAssemblerTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultServiceMetadataAssemblerTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration test for {@link DefaultServiceMetadataAssembler}.
  *
  * @author Mikhail Polivakha
+ * @author Artemiy Degtyarev
  */
 class DefaultServiceMetadataAssemblerTest extends AbstractMasterContextTest {
 


### PR DESCRIPTION
## What

The four tests under `sbs/axelix-spring-boot-3-starter/.../core/master/` each spun up a separate Spring `ApplicationContext`. This introduces `AbstractMasterContextTest`, an abstract base defining a single, unioned `@SpringBootTest` context, and refactors the three non-endpoint master tests to extend it.

Because the resolved context cache key is now identical across them, the Spring TestContext framework caches and shares **one** `ApplicationContext` instead of building three.

- `CommitIdPluginGitInformationProviderTest`
- `CommitIdPluginShortBuildInfoProviderTest`
- `DefaultServiceMetadataAssemblerTest`

`AxelixMetadataEndpointTest` is intentionally left untouched — its `RANDOM_PORT` web server and JWT stack keep it in its own context.

## Why

Fewer context loads = faster test execution and lower memory churn for tests whose configuration only differed incidentally (import sets, a nested `@TestConfiguration`, and a `@MockBean` customizer).

## Verification

- `./gradlew :sbs:axelix-spring-boot-3-starter:test` — green
- `./gradlew :sbs:axelix-spring-boot-3-starter:spotlessCheck` — green
- spring-test-profiler report confirms the three tests share **context-8**, while `AxelixMetadataEndpointTest` stays isolated in its own context.

> Note: `@MockBean` (not `@MockitoBean`) is used on the shared base because this module resolves to spring-test 6.0.14, which predates the `@MockitoBean` bean-override API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored test infrastructure to improve maintainability by consolidating shared Spring Boot test configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->