### PR TITLE
test(sbs3): share one Spring context across transaction integration tests

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/AbstractTransactionMonitoringIntegrationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/AbstractTransactionMonitoringIntegrationTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+
+/**
+ * Base class for the transaction-monitoring integration tests that exercise the
+ * {@link TransactionMonitoringBeanPostProcessor} / {@link ProxyingDataSourceBeanPostProcessor}
+ * machinery. It owns the {@link SpringBootTest} declaration and the shared {@link TestConfiguration},
+ * so that all subclasses resolve to an identical merged context configuration and therefore share a
+ * single cached {@link org.springframework.context.ApplicationContext}.
+ *
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest
+@Import(AbstractTransactionMonitoringIntegrationTest.SharedTransactionTestConfiguration.class)
+abstract class AbstractTransactionMonitoringIntegrationTest {
+
+    @TestConfiguration
+    @EnableJpaRepositories(basePackageClasses = OwnerRepository.class, considerNestedRepositories = true)
+    @EntityScan(basePackageClasses = Owner.class)
+    static class SharedTransactionTestConfiguration {
+
+        @Bean
+        public TransactionStatsCollector transactionStatsCollector() {
+            return new DefaultTransactionStatsCollector(30);
+        }
+
+        @Bean
+        public TransactionMonitoringBeanPostProcessor transactionMonitoringBeanPostProcessor(
+                TransactionStatsCollector transactionStatsCollector,
+                QueriesRecorder queriesCollector,
+                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
+            return new TransactionMonitoringBeanPostProcessor(
+                    transactionStatsCollector, queriesCollector, axelixMetricsPublisherObjectProvider);
+        }
+
+        @Bean
+        public QueriesRecorder queriesStatsCollector() {
+            return new DefaultQueriesRecorder();
+        }
+
+        @Bean
+        public ProxyingDataSourceBeanPostProcessor transactionMonitoringDataSourceBeanPostProcessor(
+                QueriesRecorder queriesCollector) {
+            return new ProxyingDataSourceBeanPostProcessor(queriesCollector);
+        }
+
+        @Bean
+        public PropagationTestHelper propagationTestHelper(
+                OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
+            return new PropagationTestHelper(ownerRepository, self);
+        }
+
+        @Bean
+        public PropagationTestService propagationTestService(
+                OwnerRepository ownerRepository, PropagationTestHelper helper) {
+            return new PropagationTestService(ownerRepository, helper);
+        }
+
+        @Bean
+        public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
+            return new DefaultAxelixMetricsPublisher(meterRegistry);
+        }
+    }
+
+    @Entity
+    static class Owner {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+
+        private String lastName;
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+    }
+
+    interface OwnerRepository extends JpaRepository<Owner, Long> {
+
+        @Transactional
+        default Owner findByLastName(String lastName) {
+            return new Owner();
+        }
+
+        @Transactional(propagation = Propagation.SUPPORTS)
+        default List<Owner> findAll() {
+            return List.of(new Owner());
+        }
+    }
+
+    static class PropagationTestHelper {
+
+        private final OwnerRepository ownerRepository;
+        private final PropagationTestHelper self;
+
+        public PropagationTestHelper(OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
+            this.ownerRepository = ownerRepository;
+            this.self = self;
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void testRequiresNew(String lastName) {
+            ownerRepository.findByLastName(lastName);
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void testNestedRequiresNew() {
+            ownerRepository.findByLastName("Franklin");
+        }
+
+        @Transactional(propagation = Propagation.MANDATORY)
+        public void testMandatory(String lastName) {
+            ownerRepository.findByLastName(lastName);
+        }
+    }
+
+    static class PropagationTestService {
+
+        private final OwnerRepository ownerRepository;
+        private final PropagationTestHelper helperService;
+
+        public PropagationTestService(OwnerRepository ownerRepository, PropagationTestHelper helperService) {
+            this.ownerRepository = ownerRepository;
+            this.helperService = helperService;
+        }
+
+        @Transactional(propagation = Propagation.REQUIRED)
+        void testRequired(String lastName) {
+            ownerRepository.findByLastName(lastName);
+            helperService.testNestedRequiresNew();
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/AbstractTransactionMonitoringIntegrationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/AbstractTransactionMonitoringIntegrationTest.java
@@ -49,6 +49,8 @@ import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublish
  * single cached {@link org.springframework.context.ApplicationContext}.
  *
  * @author Sergey Cherkasov
+ * @author Nikita Kirillov
+ * @author Artemiy Degtyarev
  */
 @SpringBootTest
 @Import(AbstractTransactionMonitoringIntegrationTest.SharedTransactionTestConfiguration.class)

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ProxyingDataSourceBeanPostProcessorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ProxyingDataSourceBeanPostProcessorTest.java
@@ -22,10 +22,6 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,9 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Sergey Cherkasov
  */
-@SpringBootTest
-@Import(ProxyingDataSourceBeanPostProcessorTest.ProxyingDataSourceBeanPostProcessorTestConfiguration.class)
-class ProxyingDataSourceBeanPostProcessorTest {
+class ProxyingDataSourceBeanPostProcessorTest extends AbstractTransactionMonitoringIntegrationTest {
 
     @Autowired
     private DataSource dataSource;
@@ -64,20 +58,5 @@ class ProxyingDataSourceBeanPostProcessorTest {
         Object result = subject.postProcessAfterInitialization(alreadyProxied, "dataSource");
 
         assertThat(result).isSameAs(alreadyProxied);
-    }
-
-    @TestConfiguration
-    static class ProxyingDataSourceBeanPostProcessorTestConfiguration {
-
-        @Bean
-        public QueriesRecorder queriesRecorder() {
-            return new DefaultQueriesRecorder();
-        }
-
-        @Bean
-        public ProxyingDataSourceBeanPostProcessor proxyingDataSourceBeanPostProcessor(
-                QueriesRecorder queriesRecorder) {
-            return new ProxyingDataSourceBeanPostProcessor(queriesRecorder);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ProxyingDataSourceBeanPostProcessorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ProxyingDataSourceBeanPostProcessorTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration test for {@link ProxyingDataSourceBeanPostProcessor}.
  *
  * @author Sergey Cherkasov
+ * @author Artemiy Degtyarev
  */
 class ProxyingDataSourceBeanPostProcessorTest extends AbstractTransactionMonitoringIntegrationTest {
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessorTest.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since 22.01.2026
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
+ * @author Artemiy Degtyarev
  */
 class TransactionMonitoringBeanPostProcessorTest extends AbstractTransactionMonitoringIntegrationTest {
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringBeanPostProcessorTest.java
@@ -22,34 +22,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-
-import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -60,9 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
  */
-@SpringBootTest
-@Import(TransactionMonitoringBeanPostProcessorTest.TransactionMonitoringBeanPostProcessorTestConfiguration.class)
-class TransactionMonitoringBeanPostProcessorTest {
+class TransactionMonitoringBeanPostProcessorTest extends AbstractTransactionMonitoringIntegrationTest {
 
     @Autowired
     private OwnerRepository ownerRepository;
@@ -123,127 +102,5 @@ class TransactionMonitoringBeanPostProcessorTest {
         key = new MethodClassKey(testFromNonTransactional, PropagationTestHelper.class);
 
         assertThat(propagationCache).containsKey(key);
-    }
-
-    @TestConfiguration
-    @EnableJpaRepositories(basePackageClasses = OwnerRepository.class, considerNestedRepositories = true)
-    @EntityScan(basePackageClasses = Owner.class)
-    static class TransactionMonitoringBeanPostProcessorTestConfiguration {
-
-        @Bean
-        public TransactionStatsCollector transactionStatsCollector() {
-            return new DefaultTransactionStatsCollector(30);
-        }
-
-        @Bean
-        public TransactionMonitoringBeanPostProcessor transactionMonitoringBeanPostProcessor(
-                TransactionStatsCollector transactionStatsCollector,
-                QueriesRecorder queriesCollector,
-                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
-            return new TransactionMonitoringBeanPostProcessor(
-                    transactionStatsCollector, queriesCollector, axelixMetricsPublisherObjectProvider);
-        }
-
-        @Bean
-        public QueriesRecorder queriesStatsCollector() {
-            return new DefaultQueriesRecorder();
-        }
-
-        @Bean
-        public ProxyingDataSourceBeanPostProcessor transactionMonitoringDataSourceBeanPostProcessor(
-                QueriesRecorder queriesCollector) {
-            return new ProxyingDataSourceBeanPostProcessor(queriesCollector);
-        }
-
-        @Bean
-        public PropagationTestHelper propagationTestHelper(
-                OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
-            return new PropagationTestHelper(ownerRepository, self);
-        }
-
-        @Bean
-        public PropagationTestService propagationTestService(
-                OwnerRepository ownerRepository, PropagationTestHelper helper) {
-            return new PropagationTestService(ownerRepository, helper);
-        }
-
-        @Bean
-        public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
-            return new DefaultAxelixMetricsPublisher(meterRegistry);
-        }
-    }
-
-    @Entity
-    static class Owner {
-
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        private Long id;
-
-        private String lastName;
-
-        public Long getId() {
-            return id;
-        }
-
-        public String getLastName() {
-            return lastName;
-        }
-    }
-
-    interface OwnerRepository extends JpaRepository<Owner, Long> {
-
-        @Transactional
-        default Owner findByLastName(String lastName) {
-            return new Owner();
-        }
-
-        @Transactional(propagation = Propagation.SUPPORTS)
-        default List<Owner> findAll() {
-            return List.of(new Owner());
-        }
-    }
-
-    static class PropagationTestHelper {
-
-        private final OwnerRepository ownerRepository;
-        private final PropagationTestHelper self;
-
-        public PropagationTestHelper(OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
-            this.ownerRepository = ownerRepository;
-            this.self = self;
-        }
-
-        @Transactional(propagation = Propagation.REQUIRES_NEW)
-        public void testRequiresNew(String lastName) {
-            ownerRepository.findByLastName(lastName);
-        }
-
-        @Transactional(propagation = Propagation.REQUIRES_NEW)
-        public void testNestedRequiresNew() {
-            ownerRepository.findByLastName("Franklin");
-        }
-
-        @Transactional(propagation = Propagation.MANDATORY)
-        public void testMandatory(String lastName) {
-            ownerRepository.findByLastName(lastName);
-        }
-    }
-
-    static class PropagationTestService {
-
-        private final OwnerRepository ownerRepository;
-        private final PropagationTestHelper helperService;
-
-        public PropagationTestService(OwnerRepository ownerRepository, PropagationTestHelper helperService) {
-            this.ownerRepository = ownerRepository;
-            this.helperService = helperService;
-        }
-
-        @Transactional(propagation = Propagation.REQUIRED)
-        void testRequired(String lastName) {
-            ownerRepository.findByLastName(lastName);
-            helperService.testNestedRequiresNew();
-        }
     }
 }


### PR DESCRIPTION
## What

The two `@SpringBootTest` transaction-monitoring integration tests in `sbs/axelix-spring-boot-3-starter` each spun up their own cached Spring `ApplicationContext`. This extracts a shared abstract base test (`AbstractTransactionMonitoringIntegrationTest`) that owns `@SpringBootTest`, the `@Import` of one `@TestConfiguration`, and the shared domain/helper classes.

`TransactionMonitoringBeanPostProcessorTest` and `ProxyingDataSourceBeanPostProcessorTest` now extend it, so both resolve to an identical `MergedContextConfiguration` and **share a single cached context** (2 contexts → 1).

`TransactionMonitoringEndpointTest` is intentionally left untouched — it uses `RANDOM_PORT` + `@TestPropertySource` + JWT auth, a deliberately different cache key, and keeps its own context.

## Verification

- `./gradlew :sbs:axelix-spring-boot-3-starter:test` → BUILD SUCCESSFUL (incl. spotless + pmd).
- All transaction tests green: BeanPostProcessor 3, Proxying 3, Endpoint 10, AutoConfiguration 4 — 0 failures/errors.
- `spring-test-profiler` report confirms one context shared by `TransactionMonitoringBeanPostProcessorTest` + `ProxyingDataSourceBeanPostProcessorTest`, with `TransactionMonitoringEndpointTest` in a separate context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)