### PR TITLE
GH-1222: Add axelix-maven-plugin for spring-test-profiler wiring

### DIFF
--- a/plugins/axelix-maven-plugin/README.md
+++ b/plugins/axelix-maven-plugin/README.md
@@ -1,0 +1,57 @@
+# axelix-maven-plugin
+
+Wires the Axelix [spring-test-profiler](https://central.sonatype.com/artifact/digital.pragmatech.testing/spring-test-profiler)
+diagnostics into a Maven-based Spring Boot project's **test** build. It is the Maven counterpart of
+the Axelix Gradle plugin and supports Spring Boot 2 through Spring Boot 4.
+
+For every reactor project that declares it, the plugin:
+
+1. Adds `digital.pragmatech.testing:spring-test-profiler` (scope `test`) when it is absent. The
+   version defaults to `0.1.2` and can be overridden with the `axelix.spring-test-profiler.version`
+   property.
+2. Ensures `META-INF/spring.factories` on the test classpath registers the Axelix
+   `TestExecutionListener` and `ApplicationContextInitializer`. An existing test `spring.factories` is
+   **merged** (the Axelix values are appended to those keys), not overwritten.
+3. Ensures `org.thymeleaf:thymeleaf` is at least `3.1.5.RELEASE` on the test classpath (required by
+   the profiler's HTML report renderer): it is added at the floor when absent, or its version is
+   raised in place — preserving the existing scope — when it is declared below the floor.
+
+## Usage
+
+`<extensions>true</extensions>` is **required** — it activates the lifecycle participant that injects
+the test dependencies before Maven resolves the test classpath. Without it only the `spring.factories`
+file is written.
+
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>com.axelixlabs</groupId>
+      <artifactId>axelix-maven-plugin</artifactId>
+      <version>1.0.0-M2</version>
+      <extensions>true</extensions>
+      <executions>
+        <execution>
+          <id>axelix-test-profiler</id>
+          <goals>
+            <goal>prepare-test-profiler</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+```
+
+The `prepare-test-profiler` goal binds to the `process-test-resources` phase by default.
+
+## Tests
+
+- Unit tests (`./gradlew :plugins:axelix-maven-plugin:test`) cover the `spring.factories` merge logic
+  and the Thymeleaf version policy.
+- Integration tests (`./gradlew :plugins:axelix-maven-plugin:integrationTest`) drive a real Maven
+  build against the bundled Spring Boot 2 and Spring Boot 4 sample projects under
+  `src/integrationTest/resources/it`, asserting the injected test classpath and the generated
+  `spring.factories`. They publish the plugin to the local Maven repository first, require a Maven
+  installation (discovered from `MAVEN_HOME`/`M2_HOME`, or SDKMAN), and are skipped when none is
+  found. They are opt-in and not part of `check`.

--- a/plugins/axelix-maven-plugin/build.gradle.kts
+++ b/plugins/axelix-maven-plugin/build.gradle.kts
@@ -1,0 +1,87 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
+plugins {
+    `java`
+    `maven-publish`
+}
+
+description = "Axelix Maven plugin: wires spring-test-profiler diagnostics into Spring Boot test builds"
+
+val mavenApiVersion = "3.6.3"
+val mavenAnnotationsVersion = "3.13.1"
+
+dependencies {
+    // Maven runtime supplies these; they must not be bundled into the plugin jar.
+    compileOnly("org.apache.maven:maven-plugin-api:$mavenApiVersion")
+    compileOnly("org.apache.maven:maven-core:$mavenApiVersion")
+    compileOnly("org.apache.maven:maven-model:$mavenApiVersion")
+    compileOnly("org.apache.maven:maven-artifact:$mavenApiVersion")
+    compileOnly("org.apache.maven.plugin-tools:maven-plugin-annotations:$mavenAnnotationsVersion")
+
+    // maven-artifact provides ComparableVersion, exercised directly by the version policy tests.
+    testImplementation("org.apache.maven:maven-artifact:$mavenApiVersion")
+    testImplementation("org.assertj:assertj-core:3.25.3")
+}
+
+// Java 8 bytecode floor so the plugin loads inside Maven on the JDKs that Spring Boot 2
+// (possibly JDK 8/11) through Spring Boot 4 (JDK 17+) consumers build with.
+tasks.named<JavaCompile>("compileJava") {
+    options.release.set(8)
+}
+
+// Keep the hand-written Maven plugin descriptor version in sync with the project version.
+// Only the @axelixVersion@ token is replaced; Maven's own ${...} expressions are left intact.
+tasks.processResources {
+    val pluginVersion = version.toString()
+    inputs.property("pluginVersion", pluginVersion)
+    filesMatching("META-INF/maven/plugin.xml") {
+        filter<ReplaceTokens>("tokens" to mapOf("axelixVersion" to pluginVersion))
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            pom {
+                packaging = "maven-plugin"
+            }
+        }
+    }
+}
+
+// Integration tests drive a real Maven against sample Spring Boot projects (see
+// src/integrationTest/resources/it). They are opt-in (not wired into `check`): run with
+// ./gradlew :plugins:axelix-maven-plugin:integrationTest. Each test aborts (is skipped) when a
+// Maven installation cannot be located, so they never break builds in Maven-less environments.
+val integrationTestProjectsDir = layout.projectDirectory.dir("src/integrationTest/resources/it")
+
+testing {
+    suites {
+        val integrationTest by registering(JvmTestSuite::class) {
+            dependencies {
+                implementation("org.apache.maven.shared:maven-invoker:3.2.0")
+                implementation("org.assertj:assertj-core:3.25.3")
+            }
+            targets {
+                all {
+                    testTask.configure {
+                        // The sample builds resolve the plugin from the local Maven repository.
+                        dependsOn(tasks.named("publishToMavenLocal"))
+                        shouldRunAfter(tasks.named("test"))
+
+                        val mavenHome = System.getenv("MAVEN_HOME")
+                                ?: System.getenv("M2_HOME")
+                                ?: file("${System.getProperty("user.home")}/.sdkman/candidates/maven/current")
+                                        .takeIf { it.exists() }
+                                        ?.absolutePath
+                                ?: ""
+                        systemProperty("axelix.it.maven.home", mavenHome)
+                        systemProperty("axelix.it.plugin.version", project.version.toString())
+                        systemProperty("axelix.it.projects.dir", integrationTestProjectsDir.asFile.absolutePath)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugins/axelix-maven-plugin/src/integrationTest/java/com/axelixlabs/maven/plugin/AxelixMavenPluginIntegrationTest.java
+++ b/plugins/axelix-maven-plugin/src/integrationTest/java/com/axelixlabs/maven/plugin/AxelixMavenPluginIntegrationTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Stream;
+
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Drives a real Maven build against bundled sample Spring Boot 2 and Spring Boot 4 projects and
+ * asserts that the plugin injects the spring-test-profiler dependency, raises Thymeleaf to the floor
+ * and writes the merged {@code META-INF/spring.factories} onto the test classpath.
+ *
+ * <p>The samples are built only up to {@code process-test-resources} plus {@code build-classpath}, so
+ * the assertions cover dependency resolution and resource generation without needing to run the
+ * Spring context (and therefore without a specific JDK requirement). Each test is skipped when no
+ * Maven installation can be located.
+ */
+class AxelixMavenPluginIntegrationTest {
+
+    private static final String MAVEN_HOME = System.getProperty("axelix.it.maven.home", "");
+    private static final String PLUGIN_VERSION = System.getProperty("axelix.it.plugin.version", "");
+    private static final String PROJECTS_DIR = System.getProperty("axelix.it.projects.dir", "");
+
+    @BeforeEach
+    void mavenInstallationMustBeAvailable() {
+        assumeTrue(
+                !MAVEN_HOME.isEmpty() && new File(MAVEN_HOME).isDirectory(), "No Maven installation found; skipping.");
+        assumeTrue(
+                !PROJECTS_DIR.isEmpty() && new File(PROJECTS_DIR).isDirectory(), "Sample projects missing; skipping.");
+    }
+
+    @Test
+    void springBoot2SampleMergesFactoriesAndBumpsThymeleaf(@TempDir Path workspace) throws Exception {
+        // given
+        Path project = copyProject("spring-boot-2-sample", workspace);
+
+        // when
+        build(project);
+
+        // then
+        String factories = read(project.resolve("target/test-classes/META-INF/spring.factories"));
+        assertThat(factories)
+                .contains("com.example.sb2.NoOpTestExecutionListener,"
+                        + "digital.pragmatech.testing.SpringTestProfilerListener")
+                .contains("org.springframework.context.ApplicationContextInitializer="
+                        + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer");
+
+        String classpath = read(project.resolve("cp.txt"));
+        assertThat(classpath)
+                .contains("spring-test-profiler")
+                .contains("0.1.2")
+                .contains("thymeleaf")
+                .contains("3.1.5.RELEASE");
+    }
+
+    @Test
+    void springBoot4SampleCreatesFactoriesAndAddsThymeleaf(@TempDir Path workspace) throws Exception {
+        // given
+        Path project = copyProject("spring-boot-4-sample", workspace);
+
+        // when
+        build(project);
+
+        // then
+        String factories = read(project.resolve("target/test-classes/META-INF/spring.factories"));
+        assertThat(factories)
+                .contains("org.springframework.test.context.TestExecutionListener="
+                        + "digital.pragmatech.testing.SpringTestProfilerListener")
+                .contains("org.springframework.context.ApplicationContextInitializer="
+                        + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer");
+
+        String classpath = read(project.resolve("cp.txt"));
+        assertThat(classpath)
+                .contains("spring-test-profiler")
+                .contains("0.1.2")
+                .contains("thymeleaf")
+                .contains("3.1.5.RELEASE");
+    }
+
+    private static void build(Path project) throws MavenInvocationException {
+        List<String> log = new ArrayList<>();
+
+        InvocationRequest request = new DefaultInvocationRequest();
+        request.setPomFile(project.resolve("pom.xml").toFile());
+        request.setGoals(Arrays.asList("process-test-resources", "dependency:build-classpath"));
+        request.setBatchMode(true);
+        request.setShowErrors(true);
+        request.setJavaHome(new File(System.getProperty("java.home")));
+        request.setProperties(buildProperties());
+        request.setOutputHandler(log::add);
+        request.setErrorHandler(log::add);
+
+        Invoker invoker = new DefaultInvoker();
+        invoker.setMavenHome(new File(MAVEN_HOME));
+
+        InvocationResult result = invoker.execute(request);
+        assertThat(result.getExitCode())
+                .as("Maven build failed:%n%s", String.join("\n", log))
+                .isZero();
+    }
+
+    private static Properties buildProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("axelix.plugin.version", PLUGIN_VERSION);
+        properties.setProperty("mdep.includeScope", "test");
+        properties.setProperty("mdep.outputFile", "cp.txt");
+        return properties;
+    }
+
+    private static Path copyProject(String name, Path workspace) throws IOException {
+        Path source = Paths.get(PROJECTS_DIR, name);
+        Path destination = workspace.resolve(name);
+        try (Stream<Path> paths = Files.walk(source)) {
+            for (Path path : (Iterable<Path>) paths::iterator) {
+                Path target = destination.resolve(source.relativize(path).toString());
+                if (Files.isDirectory(path)) {
+                    Files.createDirectories(target);
+                } else {
+                    Files.createDirectories(target.getParent());
+                    Files.copy(path, target);
+                }
+            }
+        }
+        return destination;
+    }
+
+    private static String read(Path path) throws IOException {
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+}

--- a/plugins/axelix-maven-plugin/src/integrationTest/resources/it/spring-boot-2-sample/pom.xml
+++ b/plugins/axelix-maven-plugin/src/integrationTest/resources/it/spring-boot-2-sample/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.7.18</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>com.example</groupId>
+  <artifactId>sb2-sample</artifactId>
+  <version>1.0.0</version>
+
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+
+    <!-- Direct thymeleaf below the 3.1.5.RELEASE floor: exercises the bump-in-place path. -->
+    <dependency>
+      <groupId>org.thymeleaf</groupId>
+      <artifactId>thymeleaf</artifactId>
+      <version>3.0.15.RELEASE</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.axelixlabs</groupId>
+        <artifactId>axelix-maven-plugin</artifactId>
+        <version>${axelix.plugin.version}</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>axelix-test-profiler</id>
+            <goals>
+              <goal>prepare-test-profiler</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugins/axelix-maven-plugin/src/integrationTest/resources/it/spring-boot-2-sample/src/test/resources/META-INF/spring.factories
+++ b/plugins/axelix-maven-plugin/src/integrationTest/resources/it/spring-boot-2-sample/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.test.context.TestExecutionListener=com.example.sb2.NoOpTestExecutionListener

--- a/plugins/axelix-maven-plugin/src/integrationTest/resources/it/spring-boot-4-sample/pom.xml
+++ b/plugins/axelix-maven-plugin/src/integrationTest/resources/it/spring-boot-4-sample/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>4.0.0</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>com.example</groupId>
+  <artifactId>sb4-sample</artifactId>
+  <version>1.0.0</version>
+
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.axelixlabs</groupId>
+        <artifactId>axelix-maven-plugin</artifactId>
+        <version>${axelix.plugin.version}</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>axelix-test-profiler</id>
+            <goals>
+              <goal>prepare-test-profiler</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/PrepareTestProfilerMojo.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/PrepareTestProfilerMojo.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Ensures the Axelix spring-test-profiler entries are present in {@code META-INF/spring.factories}
+ * on the test classpath. Any {@code spring.factories} already copied into the test output directory
+ * is merged with the Axelix entries rather than overwritten.
+ */
+@Mojo(
+        name = "prepare-test-profiler",
+        defaultPhase = LifecyclePhase.PROCESS_TEST_RESOURCES,
+        requiresDependencyResolution = ResolutionScope.TEST,
+        threadSafe = true)
+public class PrepareTestProfilerMojo extends AbstractMojo {
+
+    private static final String SPRING_FACTORIES_PATH = "META-INF/spring.factories";
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        if (project.getBuild() == null) {
+            return;
+        }
+        Path testOutput = Paths.get(project.getBuild().getTestOutputDirectory());
+        Path target = testOutput.resolve(SPRING_FACTORIES_PATH);
+
+        Map<String, String> existing = read(target);
+        Map<String, String> merged = SpringFactoriesMerger.merge(existing);
+        write(target, SpringFactoriesMerger.render(merged));
+        getLog().info("Axelix: wrote spring-test-profiler entries to " + target);
+    }
+
+    private Map<String, String> read(Path target) throws MojoExecutionException {
+        if (!Files.exists(target)) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            String content = new String(Files.readAllBytes(target), StandardCharsets.UTF_8);
+            return SpringFactoriesMerger.parse(content);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to read " + target, e);
+        }
+    }
+
+    private void write(Path target, String content) throws MojoExecutionException {
+        try {
+            Files.createDirectories(target.getParent());
+            Files.write(target, content.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to write " + target, e);
+        }
+    }
+}

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/SpringFactoriesMerger.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/SpringFactoriesMerger.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Pure (Maven-free) logic for reading, merging and rendering a {@code META-INF/spring.factories}
+ * file. The Axelix {@code TestExecutionListener} and {@code ApplicationContextInitializer} entries
+ * are appended to any existing values for their keys without duplication, so a consumer-provided
+ * {@code spring.factories} is preserved rather than overwritten.
+ */
+final class SpringFactoriesMerger {
+
+    static final String TEST_EXECUTION_LISTENER_KEY = "org.springframework.test.context.TestExecutionListener";
+    static final String TEST_EXECUTION_LISTENER_VALUE = "digital.pragmatech.testing.SpringTestProfilerListener";
+    static final String APPLICATION_CONTEXT_INITIALIZER_KEY =
+            "org.springframework.context.ApplicationContextInitializer";
+    static final String APPLICATION_CONTEXT_INITIALIZER_VALUE =
+            "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer";
+
+    private SpringFactoriesMerger() {}
+
+    /**
+     * Parses {@code spring.factories} content into an ordered key to value map, joining backslash
+     * line continuations and skipping blank lines and comments.
+     */
+    static Map<String, String> parse(String content) {
+        Map<String, String> result = new LinkedHashMap<>();
+        String joined = content.replace("\\\r\n", "").replace("\\\n", "");
+        for (String rawLine : joined.split("\\R")) {
+            String line = rawLine.trim();
+            if (line.isEmpty() || line.startsWith("#")) {
+                continue;
+            }
+            int separator = line.indexOf('=');
+            if (separator < 0) {
+                continue;
+            }
+            String key = line.substring(0, separator).trim();
+            String value = line.substring(separator + 1).trim();
+            result.put(key, value);
+        }
+        return result;
+    }
+
+    /** Appends the Axelix entries to the given map, returning the same instance for convenience. */
+    static Map<String, String> merge(Map<String, String> factories) {
+        appendValue(factories, TEST_EXECUTION_LISTENER_KEY, TEST_EXECUTION_LISTENER_VALUE);
+        appendValue(factories, APPLICATION_CONTEXT_INITIALIZER_KEY, APPLICATION_CONTEXT_INITIALIZER_VALUE);
+        return factories;
+    }
+
+    /** Renders the map back into {@code spring.factories} format, one {@code key=value} per line. */
+    static String render(Map<String, String> factories) {
+        StringBuilder builder = new StringBuilder();
+        for (Map.Entry<String, String> entry : factories.entrySet()) {
+            builder.append(entry.getKey()).append('=').append(entry.getValue()).append('\n');
+        }
+        return builder.toString();
+    }
+
+    private static void appendValue(Map<String, String> factories, String key, String value) {
+        String current = factories.get(key);
+        if (current == null || current.trim().isEmpty()) {
+            factories.put(key, value);
+            return;
+        }
+        List<String> values = new ArrayList<>();
+        for (String existing : current.split(",")) {
+            String trimmed = existing.trim();
+            if (!trimmed.isEmpty()) {
+                values.add(trimmed);
+            }
+        }
+        if (!values.contains(value)) {
+            values.add(value);
+        }
+        factories.put(key, String.join(",", values));
+    }
+}

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/TestProfilerDependencyInjector.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/TestProfilerDependencyInjector.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import org.apache.maven.AbstractMavenLifecycleParticipant;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Injects the test-scoped dependencies the spring-test-profiler diagnostics rely on into every
+ * reactor project that declares the Axelix Maven plugin.
+ *
+ * <p>This runs as a Maven lifecycle participant (registered via {@code META-INF/plexus/components.xml})
+ * so it executes in {@link #afterProjectsRead(MavenSession)}, before dependency resolution. Mutating
+ * dependencies here is what reliably gets them onto the Surefire test classpath; doing the same from
+ * a phase-bound Mojo would be too late. It is only active when the plugin is declared with
+ * {@code <extensions>true</extensions>}.
+ */
+public class TestProfilerDependencyInjector extends AbstractMavenLifecycleParticipant {
+
+    private static final String PLUGIN_GROUP_ID = "com.axelixlabs";
+    private static final String PLUGIN_ARTIFACT_ID = "axelix-maven-plugin";
+
+    private static final String PROFILER_GROUP_ID = "digital.pragmatech.testing";
+    private static final String PROFILER_ARTIFACT_ID = "spring-test-profiler";
+    private static final String PROFILER_VERSION_PROPERTY = "axelix.spring-test-profiler.version";
+    private static final String PROFILER_DEFAULT_VERSION = "0.1.2";
+
+    private static final String THYMELEAF_GROUP_ID = "org.thymeleaf";
+    private static final String THYMELEAF_ARTIFACT_ID = "thymeleaf";
+
+    private static final String TEST_SCOPE = "test";
+
+    @Override
+    public void afterProjectsRead(MavenSession session) {
+        for (MavenProject project : session.getAllProjects()) {
+            if (declaresAxelixPlugin(project)) {
+                ensureProfilerDependency(project);
+                ensureThymeleafFloor(project);
+            }
+        }
+    }
+
+    private boolean declaresAxelixPlugin(MavenProject project) {
+        return project.getBuildPlugins().stream()
+                .anyMatch(plugin -> PLUGIN_GROUP_ID.equals(plugin.getGroupId())
+                        && PLUGIN_ARTIFACT_ID.equals(plugin.getArtifactId()));
+    }
+
+    private void ensureProfilerDependency(MavenProject project) {
+        if (findDependency(project, PROFILER_GROUP_ID, PROFILER_ARTIFACT_ID) != null) {
+            return;
+        }
+        String version = project.getProperties().getProperty(PROFILER_VERSION_PROPERTY, PROFILER_DEFAULT_VERSION);
+        project.getDependencies().add(dependency(PROFILER_GROUP_ID, PROFILER_ARTIFACT_ID, version, TEST_SCOPE));
+    }
+
+    /**
+     * Ensures Thymeleaf is at least {@link ThymeleafVersionPolicy#FLOOR} on the test classpath. When
+     * Thymeleaf is absent a test-scoped dependency at the floor is added; when it is present at a lower
+     * version its version is raised in place while keeping the existing scope, so a runtime usage of
+     * Thymeleaf in the consumer application is not disturbed.
+     */
+    private void ensureThymeleafFloor(MavenProject project) {
+        Dependency existing = findDependency(project, THYMELEAF_GROUP_ID, THYMELEAF_ARTIFACT_ID);
+        if (existing == null) {
+            project.getDependencies()
+                    .add(dependency(
+                            THYMELEAF_GROUP_ID, THYMELEAF_ARTIFACT_ID, ThymeleafVersionPolicy.FLOOR, TEST_SCOPE));
+            return;
+        }
+        String version = existing.getVersion();
+        if (version == null) {
+            version = managedVersion(project, THYMELEAF_GROUP_ID, THYMELEAF_ARTIFACT_ID);
+        }
+        if (ThymeleafVersionPolicy.isBelowFloor(version)) {
+            existing.setVersion(ThymeleafVersionPolicy.FLOOR);
+        }
+    }
+
+    private Dependency findDependency(MavenProject project, String groupId, String artifactId) {
+        return project.getDependencies().stream()
+                .filter(dependency ->
+                        groupId.equals(dependency.getGroupId()) && artifactId.equals(dependency.getArtifactId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String managedVersion(MavenProject project, String groupId, String artifactId) {
+        DependencyManagement management = project.getDependencyManagement();
+        if (management == null) {
+            return null;
+        }
+        return management.getDependencies().stream()
+                .filter(dependency ->
+                        groupId.equals(dependency.getGroupId()) && artifactId.equals(dependency.getArtifactId()))
+                .map(Dependency::getVersion)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private Dependency dependency(String groupId, String artifactId, String version, String scope) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion(version);
+        dependency.setScope(scope);
+        return dependency;
+    }
+}

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/ThymeleafVersionPolicy.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/ThymeleafVersionPolicy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import org.apache.maven.artifact.versioning.ComparableVersion;
+
+/**
+ * Decides whether a project's Thymeleaf version is below the floor required by the
+ * spring-test-profiler diagnostic report renderer.
+ */
+final class ThymeleafVersionPolicy {
+
+    static final String FLOOR = "3.1.5.RELEASE";
+
+    private static final ComparableVersion FLOOR_VERSION = new ComparableVersion(FLOOR);
+
+    private ThymeleafVersionPolicy() {}
+
+    /**
+     * Returns {@code true} when the given version is unknown (null or blank) or strictly lower than
+     * {@value #FLOOR}, meaning the test classpath needs Thymeleaf to be raised to the floor.
+     */
+    static boolean isBelowFloor(String version) {
+        if (version == null || version.trim().isEmpty()) {
+            return true;
+        }
+        return new ComparableVersion(version.trim()).compareTo(FLOOR_VERSION) < 0;
+    }
+}

--- a/plugins/axelix-maven-plugin/src/main/resources/META-INF/maven/plugin.xml
+++ b/plugins/axelix-maven-plugin/src/main/resources/META-INF/maven/plugin.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Hand-written Maven plugin descriptor. The @axelixVersion@ token is replaced at build time by the
+  Gradle processResources task; Maven's own ${...} expressions are intentionally left untouched.
+-->
+<plugin>
+  <name>Axelix Maven Plugin</name>
+  <description>Wires the Axelix spring-test-profiler diagnostics into Spring Boot test builds.</description>
+  <groupId>com.axelixlabs</groupId>
+  <artifactId>axelix-maven-plugin</artifactId>
+  <version>@axelixVersion@</version>
+  <goalPrefix>axelix</goalPrefix>
+  <isolatedRealm>false</isolatedRealm>
+  <inheritedByDefault>true</inheritedByDefault>
+  <mojos>
+    <mojo>
+      <goal>prepare-test-profiler</goal>
+      <description>Merges the Axelix spring.factories entries into the test output directory.</description>
+      <requiresDependencyResolution>test</requiresDependencyResolution>
+      <requiresProject>true</requiresProject>
+      <threadSafe>true</threadSafe>
+      <phase>process-test-resources</phase>
+      <implementation>com.axelixlabs.maven.plugin.PrepareTestProfilerMojo</implementation>
+      <language>java</language>
+      <instantiationStrategy>per-lookup</instantiationStrategy>
+      <executionStrategy>once-per-session</executionStrategy>
+      <parameters>
+        <parameter>
+          <name>project</name>
+          <type>org.apache.maven.project.MavenProject</type>
+          <required>true</required>
+          <editable>false</editable>
+          <description>The Maven project being built.</description>
+        </parameter>
+      </parameters>
+      <configuration>
+        <project implementation="org.apache.maven.project.MavenProject" default-value="${project}"/>
+      </configuration>
+    </mojo>
+  </mojos>
+</plugin>

--- a/plugins/axelix-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/plugins/axelix-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Registers the Axelix lifecycle participant. When the plugin is declared with
+  <extensions>true</extensions>, Maven exposes this component to the build and invokes
+  afterProjectsRead(...) before dependency resolution.
+-->
+<component-set>
+  <components>
+    <component>
+      <role>org.apache.maven.AbstractMavenLifecycleParticipant</role>
+      <role-hint>com.axelixlabs.maven.plugin.TestProfilerDependencyInjector</role-hint>
+      <implementation>com.axelixlabs.maven.plugin.TestProfilerDependencyInjector</implementation>
+    </component>
+  </components>
+</component-set>

--- a/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/SpringFactoriesMergerTest.java
+++ b/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/SpringFactoriesMergerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpringFactoriesMergerTest {
+
+    @Nested
+    class WhenNoExistingFactories {
+
+        @Test
+        void addsBothAxelixEntries() {
+            // given
+            Map<String, String> empty = new LinkedHashMap<>();
+
+            // when
+            Map<String, String> merged = SpringFactoriesMerger.merge(empty);
+
+            // then
+            assertThat(merged)
+                    .containsEntry(
+                            SpringFactoriesMerger.TEST_EXECUTION_LISTENER_KEY,
+                            SpringFactoriesMerger.TEST_EXECUTION_LISTENER_VALUE)
+                    .containsEntry(
+                            SpringFactoriesMerger.APPLICATION_CONTEXT_INITIALIZER_KEY,
+                            SpringFactoriesMerger.APPLICATION_CONTEXT_INITIALIZER_VALUE);
+        }
+    }
+
+    @Nested
+    class WhenConsumerAlreadyHasEntries {
+
+        @Test
+        void appendsToExistingKeyWithoutOverwriting() {
+            // given
+            Map<String, String> existing = new LinkedHashMap<>();
+            existing.put(SpringFactoriesMerger.TEST_EXECUTION_LISTENER_KEY, "com.example.OtherListener");
+
+            // when
+            Map<String, String> merged = SpringFactoriesMerger.merge(existing);
+
+            // then
+            assertThat(merged.get(SpringFactoriesMerger.TEST_EXECUTION_LISTENER_KEY))
+                    .isEqualTo("com.example.OtherListener," + SpringFactoriesMerger.TEST_EXECUTION_LISTENER_VALUE);
+        }
+
+        @Test
+        void preservesUnrelatedKeys() {
+            // given
+            Map<String, String> existing = new LinkedHashMap<>();
+            existing.put("com.example.SomeFactory", "com.example.SomeImpl");
+
+            // when
+            Map<String, String> merged = SpringFactoriesMerger.merge(existing);
+
+            // then
+            assertThat(merged).containsEntry("com.example.SomeFactory", "com.example.SomeImpl");
+        }
+    }
+
+    @Nested
+    class Idempotency {
+
+        @Test
+        void runningTwiceDoesNotDuplicateValues() {
+            // given
+            Map<String, String> factories = SpringFactoriesMerger.merge(new LinkedHashMap<>());
+
+            // when
+            Map<String, String> mergedAgain = SpringFactoriesMerger.merge(factories);
+
+            // then
+            assertThat(mergedAgain.get(SpringFactoriesMerger.TEST_EXECUTION_LISTENER_KEY))
+                    .isEqualTo(SpringFactoriesMerger.TEST_EXECUTION_LISTENER_VALUE);
+            assertThat(mergedAgain.get(SpringFactoriesMerger.APPLICATION_CONTEXT_INITIALIZER_KEY))
+                    .isEqualTo(SpringFactoriesMerger.APPLICATION_CONTEXT_INITIALIZER_VALUE);
+        }
+    }
+
+    @Nested
+    class ParsingAndRendering {
+
+        @Test
+        void parsesBackslashLineContinuations() {
+            // given
+            String content = "org.springframework.test.context.TestExecutionListener=\\\n"
+                    + "digital.pragmatech.testing.SpringTestProfilerListener\n";
+
+            // when
+            Map<String, String> parsed = SpringFactoriesMerger.parse(content);
+
+            // then
+            assertThat(parsed)
+                    .containsEntry(
+                            SpringFactoriesMerger.TEST_EXECUTION_LISTENER_KEY,
+                            SpringFactoriesMerger.TEST_EXECUTION_LISTENER_VALUE);
+        }
+
+        @Test
+        void skipsCommentsAndBlankLines() {
+            // given
+            String content = "# a comment\n\ncom.example.Key=com.example.Value\n";
+
+            // when
+            Map<String, String> parsed = SpringFactoriesMerger.parse(content);
+
+            // then
+            assertThat(parsed).hasSize(1).containsEntry("com.example.Key", "com.example.Value");
+        }
+
+        @Test
+        void parseThenMergeThenRenderRoundTripsConsumerValue() {
+            // given
+            String content = SpringFactoriesMerger.TEST_EXECUTION_LISTENER_KEY + "=com.example.OtherListener\n";
+
+            // when
+            Map<String, String> merged = SpringFactoriesMerger.merge(SpringFactoriesMerger.parse(content));
+            String rendered = SpringFactoriesMerger.render(merged);
+
+            // then
+            assertThat(rendered)
+                    .contains("com.example.OtherListener," + SpringFactoriesMerger.TEST_EXECUTION_LISTENER_VALUE)
+                    .contains(SpringFactoriesMerger.APPLICATION_CONTEXT_INITIALIZER_VALUE);
+        }
+    }
+}

--- a/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/ThymeleafVersionPolicyTest.java
+++ b/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/ThymeleafVersionPolicyTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThymeleafVersionPolicyTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"3.0.15.RELEASE", "3.1.4.RELEASE", "3.1.5-SNAPSHOT", "2.5.8", "3.1.0.RELEASE"})
+    void treatsLowerOrPreReleaseVersionsAsBelowFloor(String version) {
+        // given / when / then
+        assertThat(ThymeleafVersionPolicy.isBelowFloor(version)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"3.1.5", "3.1.5.RELEASE", "3.1.6.RELEASE", "3.2.0", "4.0.0"})
+    void treatsFloorOrHigherVersionsAsSatisfied(String version) {
+        // given / when / then
+        assertThat(ThymeleafVersionPolicy.isBelowFloor(version)).isFalse();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void treatsUnknownVersionAsBelowFloor(String version) {
+        // given / when / then
+        assertThat(ThymeleafVersionPolicy.isBelowFloor(version)).isTrue();
+    }
+
+    @Test
+    void floorConstantIsResolvableThymeleafCoordinate() {
+        // given / when / then
+        assertThat(ThymeleafVersionPolicy.FLOOR).isEqualTo("3.1.5.RELEASE");
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,4 +10,5 @@ include(
     ":common:auth",
     ":common:domain",
     ":common:utils",
+    ":plugins:axelix-maven-plugin",
 )


### PR DESCRIPTION
Closes #1222

## Summary

Adds a **Maven plugin** (built as a Gradle subproject under `plugins/axelix-maven-plugin`, coordinates `com.axelixlabs:axelix-maven-plugin`) that wires the Axelix `spring-test-profiler` diagnostics into Maven-based Spring Boot **test** builds, supporting **Spring Boot 2 → 4**. It is the Maven counterpart of the Axelix Gradle plugin.

For every reactor project that declares it, the plugin:

1. Adds `digital.pragmatech.testing:spring-test-profiler` (scope `test`) when absent — default version `0.1.2`, overridable via the `axelix.spring-test-profiler.version` property.
2. Ensures `META-INF/spring.factories` on the test classpath registers the Axelix `TestExecutionListener` and `ApplicationContextInitializer`, **merging** into any existing consumer file rather than overwriting.
3. Ensures `org.thymeleaf:thymeleaf` is at least `3.1.5.RELEASE` on the test classpath — added when absent, or version raised in place (preserving scope) when declared below the floor.

## Design

- **Dependency injection** is performed by an `AbstractMavenLifecycleParticipant` (`afterProjectsRead`, registered via `META-INF/plexus/components.xml`), so injected deps reliably reach the Surefire test classpath. This requires the consumer to declare the plugin with `<extensions>true</extensions>`.
- **`spring.factories` merge** is performed by the `prepare-test-profiler` Mojo, bound to `process-test-resources`.
- A hand-written `plugin.xml` (version-tokenized at build time) is used instead of a third-party Gradle plugin, keeping the build compatible with Gradle 9.5.1.
- Compiled to **Java 8** bytecode so it loads inside Maven on the JDKs SB2–SB4 consumers use.

## Consumer wiring

```xml
<plugin>
  <groupId>com.axelixlabs</groupId>
  <artifactId>axelix-maven-plugin</artifactId>
  <version>1.0.0-M2</version>
  <extensions>true</extensions>
  <executions>
    <execution>
      <goals><goal>prepare-test-profiler</goal></goals>
    </execution>
  </executions>
</plugin>
```

## Tests

- **Unit tests** — `spring.factories` merge logic and the Thymeleaf version policy.
- **Integration tests** (opt-in, `./gradlew :plugins:axelix-maven-plugin:integrationTest`) — `maven-invoker` drives real Spring Boot **2.7.18** and **4.0.0** sample projects, asserting the injected test classpath and generated `spring.factories`. They publish the plugin to the local Maven repo first and are skipped when no Maven installation is found.

Verified end-to-end: both sample builds resolve `spring-test-profiler:0.1.2` and `thymeleaf:3.1.5.RELEASE` onto the test classpath, the merged/created `spring.factories` is correct, and the profiler listener executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)