### PR TITLE
GH-1216: Add axelix-gradle-plugin module skeleton (1/4)

### DIFF
--- a/plugins/axelix-gradle-plugin/build.gradle.kts
+++ b/plugins/axelix-gradle-plugin/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    `java-gradle-plugin`
+}
+
+repositories {
+    mavenCentral()
+}
+
+// The plugin must run inside Gradle 4.0 daemons, which require JDK 8.
+tasks.compileJava {
+    options.release = 8
+}
+
+gradlePlugin {
+    plugins {
+        create("axelix") {
+            id = "com.axelixlabs.axelix"
+            implementationClass = "com.axelixlabs.gradle.plugin.AxelixGradlePlugin"
+        }
+    }
+}
+
+dependencies {
+    testImplementation(platform("org.junit:junit-bom:5.14.0"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.assertj:assertj-core:3.27.6")
+    testImplementation(gradleTestKit())
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/**
+ * Axelix Gradle plugin entry point. The configuration it performs is built up incrementally; this
+ * is the module skeleton and is currently a no-op once the {@code java} plugin is applied.
+ *
+ * <p>Compatible with Gradle 4.0 through 9.x. Only APIs present in BOTH Gradle 4.0 and 9.x may be
+ * used here: no {@code tasks.register} (added in 4.9), no lazy {@code Provider}/{@code Property}
+ * wiring, no sourceSets/conventions access ({@code JavaPluginConvention} was removed in Gradle 9,
+ * {@code JavaPluginExtension.getSourceSets()} was only added in 7.1).
+ *
+ * <p>The plugin defers all work until the {@code java} plugin is applied, because the
+ * {@code testRuntimeOnly} configuration only exists once it is.
+ */
+public class AxelixGradlePlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(final Project project) {
+        project.getPluginManager().withPlugin("java", appliedPlugin -> configure(project));
+    }
+
+    private void configure(Project project) {
+        // Configuration is added incrementally in subsequent changes.
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,4 +10,5 @@ include(
     ":common:auth",
     ":common:domain",
     ":common:utils",
+    ":plugins:axelix-gradle-plugin",
 )


### PR DESCRIPTION
Part **1/4** of splitting #1218 (closes #1216).

## What

Introduces the `plugins/axelix-gradle-plugin` Gradle module registering the
`com.axelixlabs.axelix` plugin id, and wires it into the multi-project build via
`settings.gradle.kts`.

`AxelixGradlePlugin` defers all work until the `java` plugin is applied and is
currently a **no-op** — behavior lands in the follow-up PRs:

- 2/4 (#1238): contribute the Spring Test Profiler test dependency
- 3/4 (#1239): generate `spring.factories` to activate the profiler
- 4/4 (#1237): copy the profiler report onto the application classpath

The plugin is compiled to Java 8 bytecode and restricted to APIs present in both
Gradle 4.0 and 9.x.

## Splitting note

PR #1218 is being split into four sequential PRs for reviewability. They are
logically stacked (each builds on the previous); since they target this repo
from a fork, GitHub shows each diff against `master`, so later PRs include the
preceding commits. Review per-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)