### PR TITLE
GH-1216: Contribute test dependency and generate spring.factories (2/3)

### DIFF
--- a/plugins/axelix-gradle-plugin/build.gradle.kts
+++ b/plugins/axelix-gradle-plugin/build.gradle.kts
@@ -1,0 +1,33 @@
+plugins {
+    `java-gradle-plugin`
+}
+
+repositories {
+    mavenCentral()
+}
+
+// The plugin must run inside Gradle 4.0 daemons, which require JDK 8.
+tasks.compileJava {
+    options.release = 8
+}
+
+gradlePlugin {
+    plugins {
+        create("axelix") {
+            id = "com.axelixlabs.axelix"
+            implementationClass = "com.axelixlabs.gradle.plugin.AxelixGradlePlugin"
+        }
+    }
+}
+
+dependencies {
+    testImplementation(platform("org.junit:junit-bom:5.14.0"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation("org.assertj:assertj-core:3.27.6")
+    testImplementation(gradleTestKit())
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+/**
+ * Axelix Gradle plugin entry point. The configuration it performs is built up incrementally; this
+ * is the module skeleton and is currently a no-op once the {@code java} plugin is applied.
+ *
+ * <p>Compatible with Gradle 4.0 through 9.x. Only APIs present in BOTH Gradle 4.0 and 9.x may be
+ * used here: no {@code tasks.register} (added in 4.9), no lazy {@code Provider}/{@code Property}
+ * wiring, no sourceSets/conventions access ({@code JavaPluginConvention} was removed in Gradle 9,
+ * {@code JavaPluginExtension.getSourceSets()} was only added in 7.1).
+ *
+ * <p>The plugin defers all work until the {@code java} plugin is applied, because the
+ * {@code testRuntimeOnly} configuration only exists once it is.
+ */
+public class AxelixGradlePlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(final Project project) {
+        project.getPluginManager().withPlugin("java", appliedPlugin -> configure(project));
+    }
+
+    private void configure(Project project) {
+        // Configuration is added incrementally in subsequent changes.
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
@@ -21,15 +21,15 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 /**
- * Axelix Gradle plugin entry point. The configuration it performs is built up incrementally; this
- * is the module skeleton and is currently a no-op once the {@code java} plugin is applied.
+ * Adds the Spring Test Profiler to the test runtime classpath of the project and generates the
+ * {@code META-INF/spring.factories} registration for it.
  *
  * <p>Compatible with Gradle 4.0 through 9.x. Only APIs present in BOTH Gradle 4.0 and 9.x may be
  * used here: no {@code tasks.register} (added in 4.9), no lazy {@code Provider}/{@code Property}
  * wiring, no sourceSets/conventions access ({@code JavaPluginConvention} was removed in Gradle 9,
  * {@code JavaPluginExtension.getSourceSets()} was only added in 7.1).
  *
- * <p>The plugin defers all work until the {@code java} plugin is applied, because the
+ * <p>The plugin is a no-op until the {@code java} plugin is applied, because the
  * {@code testRuntimeOnly} configuration only exists once it is.
  */
 public class AxelixGradlePlugin implements Plugin<Project> {
@@ -40,6 +40,10 @@ public class AxelixGradlePlugin implements Plugin<Project> {
     }
 
     private void configure(Project project) {
-        // Configuration is added incrementally in subsequent changes.
+        // Deferred to afterEvaluate so the project's own dependency declarations are visible:
+        // the profiler and Thymeleaf are only contributed when the test classpath does not
+        // already carry them, leaving a project's chosen version untouched.
+        project.afterEvaluate(TestDependencyContributor::contributeMissingTestDependencies);
+        SpringFactoriesGenerator.configure(project);
     }
 }

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/BuildDirCompat.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/BuildDirCompat.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.File;
+
+import org.gradle.api.Project;
+import org.gradle.util.GradleVersion;
+
+/**
+ * Resolves the project build directory across Gradle 4.0 through 9.x: {@code getBuildDir()} on
+ * old versions, {@code layout.buildDirectory} on 5.0+ where the former triggers deprecation
+ * warnings (8.3+).
+ */
+final class BuildDirCompat {
+
+    private static final GradleVersion MODERN = GradleVersion.version("5.0");
+
+    private BuildDirCompat() {}
+
+    static File buildDir(Project project) {
+        if (GradleVersion.current().getBaseVersion().compareTo(MODERN) >= 0) {
+            return Modern.buildDir(project);
+        }
+        return legacyBuildDir(project);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static File legacyBuildDir(Project project) {
+        return project.getBuildDir();
+    }
+
+    /**
+     * Separate class so that Gradle 4.0 daemons never resolve
+     * {@code ProjectLayout.getBuildDirectory()}, which did not exist back then.
+     */
+    private static final class Modern {
+
+        private Modern() {}
+
+        static File buildDir(Project project) {
+            return project.getLayout().getBuildDirectory().get().getAsFile();
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/SpringFactoriesGenerator.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/SpringFactoriesGenerator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+
+/**
+ * Generates the {@code META-INF/spring.factories} registration for the Spring Test Profiler and
+ * puts the generated directory on the test runtime classpath.
+ */
+final class SpringFactoriesGenerator {
+
+    static final String GENERATE_TASK_NAME = "generateAxelixSpringFactories";
+
+    static final String SPRING_FACTORIES_CONTENT = "org.springframework.test.context.TestExecutionListener=\\\n"
+            + "digital.pragmatech.testing.SpringTestProfilerListener\n"
+            + "org.springframework.context.ApplicationContextInitializer=\\\n"
+            + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer\n";
+
+    private SpringFactoriesGenerator() {}
+
+    static void configure(final Project project) {
+        final File generatedDir = new File(BuildDirCompat.buildDir(project), "generated/axelix");
+
+        Task generateTask = project.getTasks().create(GENERATE_TASK_NAME);
+        generateTask.setGroup("axelix");
+        generateTask.setDescription("Generates META-INF/spring.factories registering the Spring Test Profiler.");
+        // getInputs().properties(Map) keeps the same signature on Gradle 4.0 and 9.x, while
+        // getInputs().property(String, Object) changed its return type in 4.3 and would throw
+        // NoSuchMethodError on 4.0 daemons.
+        generateTask.getInputs().properties(Collections.singletonMap("content", SPRING_FACTORIES_CONTENT));
+        generateTask.getOutputs().dir(generatedDir);
+        generateTask.doLast(task -> writeSpringFactories(generatedDir));
+
+        // Puts the generated directory on the test runtime classpath without touching
+        // sourceSets; builtBy ensures the generator runs before any consumer of the
+        // configuration.
+        project.getDependencies()
+                .add("testRuntimeOnly", project.files(generatedDir).builtBy(generateTask));
+    }
+
+    private static void writeSpringFactories(File generatedDir) {
+        File target = new File(new File(generatedDir, "META-INF"), "spring.factories");
+        File parent = target.getParentFile();
+        if (!parent.isDirectory() && !parent.mkdirs()) {
+            throw new GradleException("Cannot create directory " + parent);
+        }
+        try (Writer writer = new OutputStreamWriter(Files.newOutputStream(target.toPath()), StandardCharsets.UTF_8)) {
+            writer.write(SPRING_FACTORIES_CONTENT);
+        } catch (IOException e) {
+            throw new GradleException("Failed to write " + target, e);
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/TestDependencyContributor.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/TestDependencyContributor.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.util.GradleVersion;
+
+/**
+ * Contributes the Spring Test Profiler and Thymeleaf to the project's test classpath when they are
+ * missing, leaving a project's own declarations untouched.
+ */
+final class TestDependencyContributor {
+
+    static final String PROFILER_DEPENDENCY = "digital.pragmatech.testing:spring-test-profiler:0.1.2";
+
+    static final String PROFILER_GROUP = "digital.pragmatech.testing";
+
+    static final String PROFILER_NAME = "spring-test-profiler";
+
+    static final String THYMELEAF_DEPENDENCY = "org.thymeleaf:thymeleaf:3.1.3.RELEASE";
+
+    static final String THYMELEAF_GROUP = "org.thymeleaf";
+
+    static final String THYMELEAF_NAME = "thymeleaf";
+
+    /** Minimum Thymeleaf version the profiler's HTML report renders on. */
+    private static final GradleVersion MIN_THYMELEAF_VERSION = GradleVersion.version("3.1.3");
+
+    private TestDependencyContributor() {}
+
+    /**
+     * Adds the Spring Test Profiler and Thymeleaf to the test classpath. The profiler is added only
+     * when it is not already declared. Thymeleaf is added when it is absent and bumped when a
+     * version older than {@code 3.1.3} is declared, because the profiler's HTML report fails to
+     * render on older Thymeleaf; a project already on {@code 3.1.3} or newer is left untouched.
+     */
+    static void contributeMissingTestDependencies(final Project project) {
+        if (!isOnTestClasspath(project, PROFILER_GROUP, PROFILER_NAME)) {
+            project.getDependencies().add("testRuntimeOnly", PROFILER_DEPENDENCY);
+        }
+        if (shouldContributeThymeleaf(project)) {
+            project.getDependencies().add("testImplementation", THYMELEAF_DEPENDENCY);
+        }
+    }
+
+    /**
+     * Whether the plugin should put Thymeleaf {@code 3.1.3} on the test classpath: it does so when
+     * Thymeleaf is not declared at all, or is declared at a version below {@code 3.1.3}. When an
+     * older version is pinned directly, the contributed dependency wins by Gradle's newest-version
+     * conflict resolution; a project already on {@code 3.1.3} or newer is left untouched.
+     */
+    private static boolean shouldContributeThymeleaf(final Project project) {
+        Dependency declared = findDeclaredOnTestClasspath(project, THYMELEAF_GROUP, THYMELEAF_NAME);
+        return declared == null || isBelowMinimumThymeleaf(declared.getVersion());
+    }
+
+    private static boolean isOnTestClasspath(final Project project, final String group, final String name) {
+        return findDeclaredOnTestClasspath(project, group, name) != null;
+    }
+
+    /**
+     * Returns the dependency with the given group and name declared on the test runtime classpath,
+     * including dependencies inherited from extended configurations (e.g. an {@code implementation}
+     * dependency that propagates to {@code testRuntimeClasspath}), or {@code null} if none is
+     * declared. Only declared dependencies are inspected; the configuration is not resolved.
+     */
+    private static Dependency findDeclaredOnTestClasspath(
+            final Project project, final String group, final String name) {
+        Configuration testRuntimeClasspath = project.getConfigurations().findByName("testRuntimeClasspath");
+        if (testRuntimeClasspath == null) {
+            return null;
+        }
+        for (Dependency dependency : testRuntimeClasspath.getAllDependencies()) {
+            if (group.equals(dependency.getGroup()) && name.equals(dependency.getName())) {
+                return dependency;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Whether a declared Thymeleaf version is below {@code 3.1.3}, using {@link GradleVersion} for
+     * the comparison. Only the leading dot-separated numeric components are compared; a trailing
+     * qualifier such as {@code .RELEASE} is stripped first, since {@link GradleVersion} does not
+     * accept it. A {@code null} or non-numeric version is treated as not below the minimum, leaving
+     * an unrecognised version untouched.
+     */
+    private static boolean isBelowMinimumThymeleaf(final String version) {
+        if (version == null) {
+            return false;
+        }
+        String numericVersion = leadingNumericVersion(version);
+        if (numericVersion == null) {
+            return false;
+        }
+        return GradleVersion.version(numericVersion).getBaseVersion().compareTo(MIN_THYMELEAF_VERSION) < 0;
+    }
+
+    /**
+     * Extracts the leading dot-separated numeric components of a version (e.g. {@code "3.0.15"} from
+     * {@code "3.0.15.RELEASE"}) as a string {@link GradleVersion} can parse, dropping any trailing
+     * qualifier. Returns {@code null} when there is no leading numeric component. A single numeric
+     * component is padded to {@code major.minor} form, which {@link GradleVersion} requires.
+     */
+    private static String leadingNumericVersion(final String version) {
+        String[] segments = version.split("\\.");
+        int count = 0;
+        while (count < segments.length && isNumeric(segments[count])) {
+            count++;
+        }
+        if (count == 0) {
+            return null;
+        }
+        StringBuilder builder = new StringBuilder(segments[0]);
+        for (int i = 1; i < count; i++) {
+            builder.append('.').append(segments[i]);
+        }
+        if (count == 1) {
+            builder.append(".0");
+        }
+        return builder.toString();
+    }
+
+    private static boolean isNumeric(final String segment) {
+        if (segment.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < segment.length(); i++) {
+            if (!Character.isDigit(segment.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AxelixGradlePluginFunctionalTest {
+
+    private static final String MIN_GRADLE_VERSION = "4.0";
+    private static final String MAX_GRADLE_VERSION = "9.5.1";
+
+    private static final String EXPECTED_SPRING_FACTORIES =
+            "org.springframework.test.context.TestExecutionListener=\\\n"
+                    + "digital.pragmatech.testing.SpringTestProfilerListener\n"
+                    + "org.springframework.context.ApplicationContextInitializer=\\\n"
+                    + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer\n";
+
+    @TempDir
+    Path projectDir;
+
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void addsProfilerDependencyAndGeneratesSpringFactories(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("profiler-dependency.gradle"));
+
+        // when.
+        BuildResult result = createRunner(gradleVersion, "printTestRuntimeClasspath", "--stacktrace")
+                .build();
+
+        // then.
+        assertThat(result.task(":printTestRuntimeClasspath").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":generateAxelixSpringFactories").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput()).contains("spring-test-profiler-0.1.2.jar");
+        assertThat(result.getOutput()
+                        .lines()
+                        .filter(line -> line.startsWith("TRC>> "))
+                        .map(line -> line.replace('\\', '/')))
+                .anySatisfy(line -> assertThat(line).endsWith("build/generated/axelix"));
+
+        Path springFactories = projectDir.resolve("build/generated/axelix/META-INF/spring.factories");
+        assertThat(springFactories).exists();
+        assertThat(new String(Files.readAllBytes(springFactories), UTF_8)).isEqualTo(EXPECTED_SPRING_FACTORIES);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void doesNotContributeProfilerOrThymeleafWhenAlreadyDeclared(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("preexisting-versions.gradle"));
+
+        // when.
+        BuildResult result =
+                createRunner(gradleVersion, "printDeclaredDeps", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":printDeclaredDeps").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput())
+                .contains("DEP>> digital.pragmatech.testing:spring-test-profiler:0.1.1")
+                .doesNotContain("digital.pragmatech.testing:spring-test-profiler:0.1.2")
+                .contains("DEP>> org.thymeleaf:thymeleaf:3.1.5.RELEASE")
+                .doesNotContain("org.thymeleaf:thymeleaf:3.1.3.RELEASE");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void bumpsThymeleafWhenDeclaredVersionIsBelowMinimum(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("outdated-thymeleaf.gradle"));
+
+        // when.
+        BuildResult result =
+                createRunner(gradleVersion, "printDeclaredDeps", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":printDeclaredDeps").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput())
+                .contains("DEP>> org.thymeleaf:thymeleaf:3.0.15.RELEASE")
+                .contains("DEP>> org.thymeleaf:thymeleaf:3.1.3.RELEASE");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void springFactoriesIsVisibleToTestsAtRuntime(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("spring-factories-visible.gradle"));
+        // The test source must stay Java-8 compatible: on Gradle 4.0 it is compiled by JDK 8.
+        writeFile(
+                "src/test/java/FactoriesVisibleTest.java",
+                GradleProjectFixtures.javaSource("FactoriesVisibleTest.java"));
+
+        // when.
+        BuildResult result = createRunner(gradleVersion, "test", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+    }
+
+    private GradleRunner createRunner(String gradleVersion, String... arguments) {
+        // Never call withDebug(true) here: a debug run executes the build in-process on the
+        // current (modern) JVM, bypassing the JDK 8 daemon required by Gradle 4.0.
+        return GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withPluginClasspath()
+                .withGradleVersion(gradleVersion)
+                .withArguments(arguments);
+    }
+
+    private void writeCommonProjectFiles(String gradleVersion) throws IOException {
+        writeFile("settings.gradle", "rootProject.name = 'axelix-plugin-test'\n");
+        if (gradleVersion.startsWith("4.")) {
+            // Gradle 4.0 daemons cannot run on Java 9+, so fork them on a JDK 8.
+            writeFile(
+                    "gradle.properties",
+                    "org.gradle.java.home=" + locateJdk8Home() + "\n" + "org.gradle.jvmargs=-Xmx512m\n");
+        }
+    }
+
+    private void writeFile(String relativePath, String content) throws IOException {
+        Path file = projectDir.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.write(file, content.getBytes(UTF_8));
+    }
+
+    private static String locateJdk8Home() {
+        String override = System.getenv("AXELIX_TEST_JDK8_HOME");
+        if (override != null && !override.isEmpty()) {
+            return override;
+        }
+        throw new IllegalStateException("No JDK 8 found for the Gradle "
+                + MIN_GRADLE_VERSION
+                + " functional tests. Install Liberica JDK 8 via sdkman:\n"
+                + "  source ~/.sdkman/bin/sdkman-init.sh && echo n | sdk install java"
+                + " 8.0.492-librca\n"
+                + "and point AXELIX_TEST_JDK8_HOME at the JDK 8 installation.");
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/GradleProjectFixtures.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/GradleProjectFixtures.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/** Loads build-script and Java-source fixtures bundled as test resources alongside this package. */
+final class GradleProjectFixtures {
+
+    private GradleProjectFixtures() {}
+
+    static String buildScript(String fixtureName) {
+        return load(fixtureName);
+    }
+
+    /**
+     * Loads a Java-source fixture. The sources are stored with a {@code .java.txt} suffix so that
+     * Spotless (which targets {@code src/**}/{@code *.java}) does not reformat them or inject a
+     * license header into the generated test project.
+     */
+    static String javaSource(String fixtureName) {
+        return load(fixtureName);
+    }
+
+    private static String load(String fixtureName) {
+        try (InputStream in = GradleProjectFixtures.class.getResourceAsStream(fixtureName)) {
+            if (in == null) {
+                throw new IllegalStateException("Missing test fixture: " + fixtureName);
+            }
+            return new String(in.readAllBytes(), UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/FactoriesVisibleTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/FactoriesVisibleTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Enumeration;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class FactoriesVisibleTest {
+    @Test
+    public void factoriesOnClasspath() throws Exception {
+        Enumeration<URL> urls = getClass().getClassLoader().getResources("META-INF/spring.factories");
+        boolean found = false;
+        while (urls.hasMoreElements()) {
+            BufferedReader reader =
+                    new BufferedReader(new InputStreamReader(urls.nextElement().openStream(), "UTF-8"));
+            StringBuilder content = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                content.append(line).append('\n');
+            }
+            reader.close();
+            if (content.toString().contains("digital.pragmatech.testing.SpringTestProfilerListener")) {
+                found = true;
+            }
+        }
+        assertTrue(found);
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/outdated-thymeleaf.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/outdated-thymeleaf.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencies {
+    // A Thymeleaf older than the plugin's 3.1.3 minimum: the plugin must contribute
+    // 3.1.3 so it wins by Gradle's newest-version conflict resolution.
+    implementation 'org.thymeleaf:thymeleaf:3.0.15.RELEASE'
+}
+
+// Prints the *declared* modules (not resolved files) of the test runtime classpath,
+// so the plugin's contributed 3.1.3 only appears if it added it. allDependencies
+// omits transitives, keeping the assertion focused on declared modules.
+task printDeclaredDeps {
+    doLast {
+        configurations.testRuntimeClasspath.allDependencies.each { d ->
+            println 'DEP>> ' + d.group + ':' + d.name + ':' + d.version
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/preexisting-versions.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/preexisting-versions.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencies {
+    // testRuntimeOnly mirrors how the plugin declares the profiler.
+    testRuntimeOnly 'digital.pragmatech.testing:spring-test-profiler:0.1.1'
+    // implementation exercises the extended-configuration lookup path; the version
+    // is at or above the plugin's minimum, so it must be left untouched.
+    implementation 'org.thymeleaf:thymeleaf:3.1.5.RELEASE'
+}
+
+// Prints the *declared* modules (not resolved files) of the test runtime
+// classpath, so the plugin's own pinned versions only appear if it added
+// them. allDependencies omits transitives, so the thymeleaf the profiler
+// pulls in does not muddy the assertion.
+task printDeclaredDeps {
+    doLast {
+        configurations.testRuntimeClasspath.allDependencies.each { d ->
+            println 'DEP>> ' + d.group + ':' + d.name + ':' + d.version
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/profiler-dependency.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/profiler-dependency.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+// Applied after our plugin on purpose: exercises the withPlugin reaction.
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+task printTestRuntimeClasspath {
+    dependsOn configurations.testRuntimeClasspath
+    doLast {
+        configurations.testRuntimeClasspath.files.each { f ->
+            println 'TRC>> ' + f.absolutePath
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-factories-visible.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-factories-visible.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencies { testImplementation 'junit:junit:4.13.2' }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,4 +10,5 @@ include(
     ":common:auth",
     ":common:domain",
     ":common:utils",
+    ":plugins:axelix-gradle-plugin",
 )


### PR DESCRIPTION
Part **2/3** of splitting #1218 (closes #1216). Builds on #1235.

## What

Wires the Spring Test Profiler activation into the plugin:

- `TestDependencyContributor` adds `digital.pragmatech.testing:spring-test-profiler:0.1.2`
  to `testRuntimeOnly` when absent, and contributes/bumps Thymeleaf to `3.1.3`
  (the profiler's HTML report fails to render on older Thymeleaf), leaving a
  project's own declarations untouched.
- `SpringFactoriesGenerator` writes `META-INF/spring.factories` registering the
  profiler's `TestExecutionListener` and `ApplicationContextInitializer` onto the
  test runtime classpath via the `generateAxelixSpringFactories` task.
- `BuildDirCompat` resolves the build directory across Gradle 4.0 through 9.x.

The dependency is added to `testRuntimeOnly` (not `testImplementation`): the
profiler is activated purely via `spring.factories`, so nothing compiles against
it.

## Testing

TestKit functional tests on both Gradle extremes (4.0 and 9.5.1): the dependency
lands on the test runtime classpath, `spring.factories` content is byte-exact,
the resource is visible to tests through the classloader, pre-declared
profiler/Thymeleaf versions are left untouched, and an outdated Thymeleaf is
bumped.

## Splitting note

Logically stacked on #1235; since these target this repo from a fork, the diff
shown here includes the 1/3 commit. Review the `GH-1216: Contribute test
dependency...` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)