### PR TITLE
GH-1216: Copy spring-test-profiler report onto the application classpath (4/4)

### DIFF
--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
@@ -28,7 +28,7 @@ import org.gradle.api.Project;
  * wiring, no sourceSets/conventions access ({@code JavaPluginConvention} was removed in Gradle 9,
  * {@code JavaPluginExtension.getSourceSets()} was only added in 7.1).
  *
- * <p>The plugin defers all work until the {@code java} plugin is applied, because the
+ * <p>The plugin is a no-op until the {@code java} plugin is applied, because the
  * {@code testRuntimeOnly} configuration only exists once it is.
  */
 public class AxelixGradlePlugin implements Plugin<Project> {
@@ -39,6 +39,9 @@ public class AxelixGradlePlugin implements Plugin<Project> {
     }
 
     private void configure(Project project) {
-        // Configuration is added incrementally in subsequent changes.
+        // Deferred to afterEvaluate so the project's own dependency declarations are visible:
+        // the profiler and Thymeleaf are only contributed when the test classpath does not
+        // already carry them, leaving a project's chosen version untouched.
+        project.afterEvaluate(TestDependencyContributor::contributeMissingTestDependencies);
     }
 }

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
@@ -43,5 +43,6 @@ public class AxelixGradlePlugin implements Plugin<Project> {
         // the profiler and Thymeleaf are only contributed when the test classpath does not
         // already carry them, leaving a project's chosen version untouched.
         project.afterEvaluate(TestDependencyContributor::contributeMissingTestDependencies);
+        SpringFactoriesGenerator.configure(project);
     }
 }

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/AxelixGradlePlugin.java
@@ -44,5 +44,6 @@ public class AxelixGradlePlugin implements Plugin<Project> {
         // already carry them, leaving a project's chosen version untouched.
         project.afterEvaluate(TestDependencyContributor::contributeMissingTestDependencies);
         SpringFactoriesGenerator.configure(project);
+        TestProfilerReportCopy.configure(project);
     }
 }

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/BuildDirCompat.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/BuildDirCompat.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.File;
+
+import org.gradle.api.Project;
+import org.gradle.util.GradleVersion;
+
+/**
+ * Resolves the project build directory across Gradle 4.0 through 9.x: {@code getBuildDir()} on
+ * old versions, {@code layout.buildDirectory} on 5.0+ where the former triggers deprecation
+ * warnings (8.3+).
+ */
+final class BuildDirCompat {
+
+    private static final GradleVersion MODERN = GradleVersion.version("5.0");
+
+    private BuildDirCompat() {}
+
+    static File buildDir(Project project) {
+        if (GradleVersion.current().getBaseVersion().compareTo(MODERN) >= 0) {
+            return Modern.buildDir(project);
+        }
+        return legacyBuildDir(project);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static File legacyBuildDir(Project project) {
+        return project.getBuildDir();
+    }
+
+    /**
+     * Separate class so that Gradle 4.0 daemons never resolve
+     * {@code ProjectLayout.getBuildDirectory()}, which did not exist back then.
+     */
+    private static final class Modern {
+
+        private Modern() {}
+
+        static File buildDir(Project project) {
+            return project.getLayout().getBuildDirectory().get().getAsFile();
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/SpringFactoriesGenerator.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/SpringFactoriesGenerator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+
+/**
+ * Generates the {@code META-INF/spring.factories} registration for the Spring Test Profiler and
+ * puts the generated directory on the test runtime classpath.
+ */
+final class SpringFactoriesGenerator {
+
+    static final String GENERATE_TASK_NAME = "generateAxelixSpringFactories";
+
+    static final String SPRING_FACTORIES_CONTENT = "org.springframework.test.context.TestExecutionListener=\\\n"
+            + "digital.pragmatech.testing.SpringTestProfilerListener\n"
+            + "org.springframework.context.ApplicationContextInitializer=\\\n"
+            + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer\n";
+
+    private SpringFactoriesGenerator() {}
+
+    static void configure(final Project project) {
+        final File generatedDir = new File(BuildDirCompat.buildDir(project), "generated/axelix");
+
+        Task generateTask = project.getTasks().create(GENERATE_TASK_NAME);
+        generateTask.setGroup("axelix");
+        generateTask.setDescription("Generates META-INF/spring.factories registering the Spring Test Profiler.");
+        // getInputs().properties(Map) keeps the same signature on Gradle 4.0 and 9.x, while
+        // getInputs().property(String, Object) changed its return type in 4.3 and would throw
+        // NoSuchMethodError on 4.0 daemons.
+        generateTask.getInputs().properties(Collections.singletonMap("content", SPRING_FACTORIES_CONTENT));
+        generateTask.getOutputs().dir(generatedDir);
+        generateTask.doLast(task -> writeSpringFactories(generatedDir));
+
+        // Puts the generated directory on the test runtime classpath without touching
+        // sourceSets; builtBy ensures the generator runs before any consumer of the
+        // configuration.
+        project.getDependencies()
+                .add("testRuntimeOnly", project.files(generatedDir).builtBy(generateTask));
+    }
+
+    private static void writeSpringFactories(File generatedDir) {
+        File target = new File(new File(generatedDir, "META-INF"), "spring.factories");
+        File parent = target.getParentFile();
+        if (!parent.isDirectory() && !parent.mkdirs()) {
+            throw new GradleException("Cannot create directory " + parent);
+        }
+        try (Writer writer = new OutputStreamWriter(Files.newOutputStream(target.toPath()), StandardCharsets.UTF_8)) {
+            writer.write(SPRING_FACTORIES_CONTENT);
+        } catch (IOException e) {
+            throw new GradleException("Failed to write " + target, e);
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/TestDependencyContributor.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/TestDependencyContributor.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.util.GradleVersion;
+
+/**
+ * Contributes the Spring Test Profiler and Thymeleaf to the project's test classpath when they are
+ * missing, leaving a project's own declarations untouched.
+ */
+final class TestDependencyContributor {
+
+    static final String PROFILER_DEPENDENCY = "digital.pragmatech.testing:spring-test-profiler:0.1.2";
+
+    static final String PROFILER_GROUP = "digital.pragmatech.testing";
+
+    static final String PROFILER_NAME = "spring-test-profiler";
+
+    static final String THYMELEAF_DEPENDENCY = "org.thymeleaf:thymeleaf:3.1.3.RELEASE";
+
+    static final String THYMELEAF_GROUP = "org.thymeleaf";
+
+    static final String THYMELEAF_NAME = "thymeleaf";
+
+    /** Minimum Thymeleaf version the profiler's HTML report renders on. */
+    private static final GradleVersion MIN_THYMELEAF_VERSION = GradleVersion.version("3.1.3");
+
+    private TestDependencyContributor() {}
+
+    /**
+     * Adds the Spring Test Profiler and Thymeleaf to the test classpath. The profiler is added only
+     * when it is not already declared. Thymeleaf is added when it is absent and bumped when a
+     * version older than {@code 3.1.3} is declared, because the profiler's HTML report fails to
+     * render on older Thymeleaf; a project already on {@code 3.1.3} or newer is left untouched.
+     */
+    static void contributeMissingTestDependencies(final Project project) {
+        if (!isOnTestClasspath(project, PROFILER_GROUP, PROFILER_NAME)) {
+            project.getDependencies().add("testRuntimeOnly", PROFILER_DEPENDENCY);
+        }
+        if (shouldContributeThymeleaf(project)) {
+            project.getDependencies().add("testImplementation", THYMELEAF_DEPENDENCY);
+        }
+    }
+
+    /**
+     * Whether the plugin should put Thymeleaf {@code 3.1.3} on the test classpath: it does so when
+     * Thymeleaf is not declared at all, or is declared at a version below {@code 3.1.3}. When an
+     * older version is pinned directly, the contributed dependency wins by Gradle's newest-version
+     * conflict resolution; a project already on {@code 3.1.3} or newer is left untouched.
+     */
+    private static boolean shouldContributeThymeleaf(final Project project) {
+        Dependency declared = findDeclaredOnTestClasspath(project, THYMELEAF_GROUP, THYMELEAF_NAME);
+        return declared == null || isBelowMinimumThymeleaf(declared.getVersion());
+    }
+
+    private static boolean isOnTestClasspath(final Project project, final String group, final String name) {
+        return findDeclaredOnTestClasspath(project, group, name) != null;
+    }
+
+    /**
+     * Returns the dependency with the given group and name declared on the test runtime classpath,
+     * including dependencies inherited from extended configurations (e.g. an {@code implementation}
+     * dependency that propagates to {@code testRuntimeClasspath}), or {@code null} if none is
+     * declared. Only declared dependencies are inspected; the configuration is not resolved.
+     */
+    private static Dependency findDeclaredOnTestClasspath(
+            final Project project, final String group, final String name) {
+        Configuration testRuntimeClasspath = project.getConfigurations().findByName("testRuntimeClasspath");
+        if (testRuntimeClasspath == null) {
+            return null;
+        }
+        for (Dependency dependency : testRuntimeClasspath.getAllDependencies()) {
+            if (group.equals(dependency.getGroup()) && name.equals(dependency.getName())) {
+                return dependency;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Whether a declared Thymeleaf version is below {@code 3.1.3}, using {@link GradleVersion} for
+     * the comparison. Only the leading dot-separated numeric components are compared; a trailing
+     * qualifier such as {@code .RELEASE} is stripped first, since {@link GradleVersion} does not
+     * accept it. A {@code null} or non-numeric version is treated as not below the minimum, leaving
+     * an unrecognised version untouched.
+     */
+    private static boolean isBelowMinimumThymeleaf(final String version) {
+        if (version == null) {
+            return false;
+        }
+        String numericVersion = leadingNumericVersion(version);
+        if (numericVersion == null) {
+            return false;
+        }
+        return GradleVersion.version(numericVersion).getBaseVersion().compareTo(MIN_THYMELEAF_VERSION) < 0;
+    }
+
+    /**
+     * Extracts the leading dot-separated numeric components of a version (e.g. {@code "3.0.15"} from
+     * {@code "3.0.15.RELEASE"}) as a string {@link GradleVersion} can parse, dropping any trailing
+     * qualifier. Returns {@code null} when there is no leading numeric component. A single numeric
+     * component is padded to {@code major.minor} form, which {@link GradleVersion} requires.
+     */
+    private static String leadingNumericVersion(final String version) {
+        String[] segments = version.split("\\.");
+        int count = 0;
+        while (count < segments.length && isNumeric(segments[count])) {
+            count++;
+        }
+        if (count == 0) {
+            return null;
+        }
+        StringBuilder builder = new StringBuilder(segments[0]);
+        for (int i = 1; i < count; i++) {
+            builder.append('.').append(segments[i]);
+        }
+        if (count == 1) {
+            builder.append(".0");
+        }
+        return builder.toString();
+    }
+
+    private static boolean isNumeric(final String segment) {
+        if (segment.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < segment.length(); i++) {
+            if (!Character.isDigit(segment.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/TestProfilerReportCopy.java
+++ b/plugins/axelix-gradle-plugin/src/main/java/com/axelixlabs/gradle/plugin/TestProfilerReportCopy.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.File;
+
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.bundling.Jar;
+
+/**
+ * Copies the Spring Test Profiler HTML report onto the application classpath after tests pass, so
+ * the {@code build} task produces a jar containing the report.
+ */
+final class TestProfilerReportCopy {
+
+    static final String COPY_REPORT_TASK_NAME = "copyAxelixTestProfilerReport";
+
+    private TestProfilerReportCopy() {}
+
+    /**
+     * Copies the profiler report into {@code build/resources/main} so it ends up on the
+     * application runtime classpath. The task depends on {@code test}, so it never runs when
+     * tests fail. It deliberately declares no inputs/outputs: the destination is owned by
+     * {@code processResources}, and registering it as an output here would create overlapping
+     * outputs that degrade caching — the report is regenerated on every test run anyway, so an
+     * always-run copy is correct. Jar tasks are ordered after the copy so the report lands in
+     * the packaged jar deterministically instead of depending on whether {@code jar} happened
+     * to run before or after {@code test}.
+     */
+    static void configure(final Project project) {
+        final File buildDir = BuildDirCompat.buildDir(project);
+        final File reportDir = new File(buildDir, "spring-test-profiler");
+        final File destinationDir = new File(buildDir, "resources/main/spring-test-profiler");
+
+        Task copyTask = project.getTasks().create(COPY_REPORT_TASK_NAME);
+        copyTask.setGroup("axelix");
+        copyTask.setDescription("Copies the Spring Test Profiler report onto the application classpath.");
+        copyTask.dependsOn("test");
+        // Copying from a nonexistent source dir is a silent no-op, so projects whose tests
+        // produce no report still build fine.
+        copyTask.doLast(task -> {
+            project.delete(destinationDir);
+
+            project.copy(spec -> {
+                spec.from(reportDir);
+                spec.into(destinationDir);
+            });
+        });
+
+        project.getTasks().getByName("build").dependsOn(copyTask);
+        project.getTasks().withType(Jar.class).all(jar -> jar.mustRunAfter(copyTask));
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AxelixGradlePluginFunctionalTest {
+
+    private static final String MIN_GRADLE_VERSION = "4.0";
+    private static final String MAX_GRADLE_VERSION = "9.5.1";
+
+    @TempDir
+    Path projectDir;
+
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void addsProfilerDependencyToTestRuntimeClasspath(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("profiler-dependency.gradle"));
+
+        // when.
+        BuildResult result = createRunner(gradleVersion, "printTestRuntimeClasspath", "--stacktrace")
+                .build();
+
+        // then.
+        assertThat(result.task(":printTestRuntimeClasspath").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput()).contains("spring-test-profiler-0.1.2.jar");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void doesNotContributeProfilerOrThymeleafWhenAlreadyDeclared(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("preexisting-versions.gradle"));
+
+        // when.
+        BuildResult result =
+                createRunner(gradleVersion, "printDeclaredDeps", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":printDeclaredDeps").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput())
+                .contains("DEP>> digital.pragmatech.testing:spring-test-profiler:0.1.1")
+                .doesNotContain("digital.pragmatech.testing:spring-test-profiler:0.1.2")
+                .contains("DEP>> org.thymeleaf:thymeleaf:3.1.5.RELEASE")
+                .doesNotContain("org.thymeleaf:thymeleaf:3.1.3.RELEASE");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void bumpsThymeleafWhenDeclaredVersionIsBelowMinimum(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("outdated-thymeleaf.gradle"));
+
+        // when.
+        BuildResult result =
+                createRunner(gradleVersion, "printDeclaredDeps", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":printDeclaredDeps").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.getOutput())
+                .contains("DEP>> org.thymeleaf:thymeleaf:3.0.15.RELEASE")
+                .contains("DEP>> org.thymeleaf:thymeleaf:3.1.3.RELEASE");
+    }
+
+    private GradleRunner createRunner(String gradleVersion, String... arguments) {
+        // Never call withDebug(true) here: a debug run executes the build in-process on the
+        // current (modern) JVM, bypassing the JDK 8 daemon required by Gradle 4.0.
+        return GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withPluginClasspath()
+                .withGradleVersion(gradleVersion)
+                .withArguments(arguments);
+    }
+
+    private void writeCommonProjectFiles(String gradleVersion) throws IOException {
+        writeFile("settings.gradle", "rootProject.name = 'axelix-plugin-test'\n");
+        if (gradleVersion.startsWith("4.")) {
+            // Gradle 4.0 daemons cannot run on Java 9+, so fork them on a JDK 8.
+            writeFile(
+                    "gradle.properties",
+                    "org.gradle.java.home=" + locateJdk8Home() + "\n" + "org.gradle.jvmargs=-Xmx512m\n");
+        }
+    }
+
+    private void writeFile(String relativePath, String content) throws IOException {
+        Path file = projectDir.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.write(file, content.getBytes(UTF_8));
+    }
+
+    private static String locateJdk8Home() {
+        String override = System.getenv("AXELIX_TEST_JDK8_HOME");
+        if (override != null && !override.isEmpty()) {
+            return override;
+        }
+        throw new IllegalStateException("No JDK 8 found for the Gradle "
+                + MIN_GRADLE_VERSION
+                + " functional tests. Install Liberica JDK 8 via sdkman:\n"
+                + "  source ~/.sdkman/bin/sdkman-init.sh && echo n | sdk install java"
+                + " 8.0.492-librca\n"
+                + "and point AXELIX_TEST_JDK8_HOME at the JDK 8 installation.");
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
@@ -36,12 +36,18 @@ class AxelixGradlePluginFunctionalTest {
     private static final String MIN_GRADLE_VERSION = "4.0";
     private static final String MAX_GRADLE_VERSION = "9.5.1";
 
+    private static final String EXPECTED_SPRING_FACTORIES =
+            "org.springframework.test.context.TestExecutionListener=\\\n"
+                    + "digital.pragmatech.testing.SpringTestProfilerListener\n"
+                    + "org.springframework.context.ApplicationContextInitializer=\\\n"
+                    + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer\n";
+
     @TempDir
     Path projectDir;
 
     @ParameterizedTest
     @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
-    void addsProfilerDependencyToTestRuntimeClasspath(String gradleVersion) throws IOException {
+    void addsProfilerDependencyAndGeneratesSpringFactories(String gradleVersion) throws IOException {
         // given.
         writeCommonProjectFiles(gradleVersion);
         writeFile("build.gradle", GradleProjectFixtures.buildScript("profiler-dependency.gradle"));
@@ -52,7 +58,17 @@ class AxelixGradlePluginFunctionalTest {
 
         // then.
         assertThat(result.task(":printTestRuntimeClasspath").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":generateAxelixSpringFactories").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
         assertThat(result.getOutput()).contains("spring-test-profiler-0.1.2.jar");
+        assertThat(result.getOutput()
+                        .lines()
+                        .filter(line -> line.startsWith("TRC>> "))
+                        .map(line -> line.replace('\\', '/')))
+                .anySatisfy(line -> assertThat(line).endsWith("build/generated/axelix"));
+
+        Path springFactories = projectDir.resolve("build/generated/axelix/META-INF/spring.factories");
+        assertThat(springFactories).exists();
+        assertThat(new String(Files.readAllBytes(springFactories), UTF_8)).isEqualTo(EXPECTED_SPRING_FACTORIES);
     }
 
     @ParameterizedTest
@@ -91,6 +107,24 @@ class AxelixGradlePluginFunctionalTest {
         assertThat(result.getOutput())
                 .contains("DEP>> org.thymeleaf:thymeleaf:3.0.15.RELEASE")
                 .contains("DEP>> org.thymeleaf:thymeleaf:3.1.3.RELEASE");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void springFactoriesIsVisibleToTestsAtRuntime(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("spring-factories-visible.gradle"));
+        // The test source must stay Java-8 compatible: on Gradle 4.0 it is compiled by JDK 8.
+        writeFile(
+                "src/test/java/FactoriesVisibleTest.java",
+                GradleProjectFixtures.javaSource("FactoriesVisibleTest.java"));
+
+        // when.
+        BuildResult result = createRunner(gradleVersion, "test", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
     }
 
     private GradleRunner createRunner(String gradleVersion, String... arguments) {

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/AxelixGradlePluginFunctionalTest.java
@@ -127,6 +127,23 @@ class AxelixGradlePluginFunctionalTest {
         assertThat(result.task(":test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {MIN_GRADLE_VERSION, MAX_GRADLE_VERSION})
+    void buildSucceedsWhenNoProfilerReportWasProduced(String gradleVersion) throws IOException {
+        // given.
+        writeCommonProjectFiles(gradleVersion);
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("bare-java.gradle"));
+
+        // when.
+        BuildResult result =
+                createRunner(gradleVersion, "build", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":copyAxelixTestProfilerReport").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(projectDir.resolve("build/resources/main/spring-test-profiler"))
+                .doesNotExist();
+    }
+
     private GradleRunner createRunner(String gradleVersion, String... arguments) {
         // Never call withDebug(true) here: a debug run executes the build in-process on the
         // current (modern) JVM, bypassing the JDK 8 daemon required by Gradle 4.0.

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/GradleProjectFixtures.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/GradleProjectFixtures.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/** Loads build-script and Java-source fixtures bundled as test resources alongside this package. */
+final class GradleProjectFixtures {
+
+    private GradleProjectFixtures() {}
+
+    static String buildScript(String fixtureName) {
+        return load(fixtureName);
+    }
+
+    /**
+     * Loads a Java-source fixture. The sources are stored with a {@code .java.txt} suffix so that
+     * Spotless (which targets {@code src/**}/{@code *.java}) does not reformat them or inject a
+     * license header into the generated test project.
+     */
+    static String javaSource(String fixtureName) {
+        return load(fixtureName);
+    }
+
+    private static String load(String fixtureName) {
+        try (InputStream in = GradleProjectFixtures.class.getResourceAsStream(fixtureName)) {
+            if (in == null) {
+                throw new IllegalStateException("Missing test fixture: " + fixtureName);
+            }
+            return new String(in.readAllBytes(), UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/SpringBootApplicationFunctionalTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/java/com/axelixlabs/gradle/plugin/SpringBootApplicationFunctionalTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.gradle.plugin;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.JarFile;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the plugin end-to-end on empty Spring Boot applications: after running their tests,
+ * the Spring Test Profiler must have produced its HTML report. The profiler requires Java 17+.
+ * The Boot 4 builds run on the current JVM under Gradle 9.5.1; the Boot 2 build is pinned to
+ * Gradle 8.14, which cannot run on JDK 25, so its daemon is forked onto a JDK in the 17-24 range.
+ */
+class SpringBootApplicationFunctionalTest {
+
+    /** Boot-2-era Gradle; the io.spring.dependency-management plugin predates Gradle 9. */
+    private static final String SPRING_BOOT_2_GRADLE_VERSION = "8.14";
+
+    @TempDir
+    Path projectDir;
+
+    /**
+     * The realistic Spring Boot 2 setup: the io.spring.dependency-management plugin applies the
+     * Boot BOM with Maven semantics, managing Thymeleaf at 3.0.x — without the plugin's explicit
+     * Thymeleaf 3.1 test dependency the report silently fails to render.
+     */
+    @Test
+    void springBoot2WithDependencyManagementGeneratesProfilerReport() throws IOException {
+        // given.
+        writeSpringBootApplicationSources();
+        writeFile("build.gradle", GradleProjectFixtures.buildScript("spring-boot-2.gradle"));
+        // Gradle 8.14 cannot run on JDK 25, so fork its daemon onto a JDK 17-24.
+        writeFile("gradle.properties", "org.gradle.java.home=" + locateGradle8JdkHome() + "\n");
+
+        // when.
+        BuildResult result = createRunner("test", "--stacktrace")
+                .withGradleVersion(SPRING_BOOT_2_GRADLE_VERSION)
+                .build();
+
+        // then.
+        assertProfilerReportGenerated(result);
+    }
+
+    @Test
+    void springBoot4GeneratesProfilerReport() throws IOException {
+        // given.
+        writeSpringBootApplicationSources();
+        writeFile("build.gradle", springBoot4BuildScript());
+
+        // when.
+        BuildResult result = createRunner("test", "--stacktrace").build();
+
+        // then.
+        assertProfilerReportGenerated(result);
+    }
+
+    @Test
+    void buildCopiesProfilerReportOntoApplicationClasspathAndIntoJar() throws IOException {
+        // given.
+        writeSpringBootApplicationSources();
+        writeFile("build.gradle", springBoot4BuildScript());
+
+        // when.
+        BuildResult result = createRunner("build", "--stacktrace").build();
+
+        // then.
+        assertThat(result.task(":test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":copyAxelixTestProfilerReport").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(projectDir.resolve("build/resources/main/spring-test-profiler/latest.html"))
+                .exists();
+
+        Path jar = projectDir.resolve("build/libs/axelix-spring-boot-test.jar");
+        assertThat(jar).exists();
+        try (JarFile jarFile = new JarFile(jar.toFile())) {
+            assertThat(jarFile.getEntry("spring-test-profiler/latest.html")).isNotNull();
+        }
+    }
+
+    private GradleRunner createRunner(String... arguments) {
+        return GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withPluginClasspath()
+                .withArguments(arguments);
+    }
+
+    private void assertProfilerReportGenerated(BuildResult result) {
+        assertThat(result.task(":test").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(result.task(":generateAxelixSpringFactories").getOutcome()).isEqualTo(TaskOutcome.SUCCESS);
+        assertThat(projectDir.resolve("build/spring-test-profiler/latest.html")).exists();
+    }
+
+    private static String springBoot4BuildScript() {
+        return GradleProjectFixtures.buildScript("spring-boot-4.gradle");
+    }
+
+    private void writeSpringBootApplicationSources() throws IOException {
+        writeFile("settings.gradle", "rootProject.name = 'axelix-spring-boot-test'\n");
+        writeFile(
+                "src/main/java/com/example/DemoApplication.java",
+                GradleProjectFixtures.javaSource("DemoApplication.java"));
+        writeFile(
+                "src/test/java/com/example/DemoApplicationTest.java",
+                GradleProjectFixtures.javaSource("DemoApplicationTest.java"));
+    }
+
+    private void writeFile(String relativePath, String content) throws IOException {
+        Path file = projectDir.resolve(relativePath);
+        Files.createDirectories(file.getParent());
+        Files.write(file, content.getBytes(UTF_8));
+    }
+
+    private static String locateGradle8JdkHome() {
+        String override = System.getenv("AXELIX_TEST_JDK17_HOME");
+        if (override != null && !override.isEmpty()) {
+            return override;
+        }
+        throw new IllegalStateException("No JDK 17-24 found for the Gradle "
+                + SPRING_BOOT_2_GRADLE_VERSION
+                + " functional test. Gradle 8.14 cannot run on JDK 25, and the Spring Test"
+                + " Profiler requires JDK 17+. Install a JDK in the 17-24 range, e.g. via sdkman:\n"
+                + "  source ~/.sdkman/bin/sdkman-init.sh && echo n | sdk install java 21.0.10-librca\n"
+                + "and point AXELIX_TEST_JDK17_HOME at the JDK installation.");
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/DemoApplication.java
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/DemoApplication.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.example;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/DemoApplicationTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/DemoApplicationTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.example;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class DemoApplicationTest {
+    @Test
+    void contextLoads() {}
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/FactoriesVisibleTest.java
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/FactoriesVisibleTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Enumeration;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class FactoriesVisibleTest {
+    @Test
+    public void factoriesOnClasspath() throws Exception {
+        Enumeration<URL> urls = getClass().getClassLoader().getResources("META-INF/spring.factories");
+        boolean found = false;
+        while (urls.hasMoreElements()) {
+            BufferedReader reader =
+                    new BufferedReader(new InputStreamReader(urls.nextElement().openStream(), "UTF-8"));
+            StringBuilder content = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                content.append(line).append('\n');
+            }
+            reader.close();
+            if (content.toString().contains("digital.pragmatech.testing.SpringTestProfilerListener")) {
+                found = true;
+            }
+        }
+        assertTrue(found);
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/bare-java.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/bare-java.gradle
@@ -1,0 +1,6 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/outdated-thymeleaf.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/outdated-thymeleaf.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencies {
+    // A Thymeleaf older than the plugin's 3.1.3 minimum: the plugin must contribute
+    // 3.1.3 so it wins by Gradle's newest-version conflict resolution.
+    implementation 'org.thymeleaf:thymeleaf:3.0.15.RELEASE'
+}
+
+// Prints the *declared* modules (not resolved files) of the test runtime classpath,
+// so the plugin's contributed 3.1.3 only appears if it added it. allDependencies
+// omits transitives, keeping the assertion focused on declared modules.
+task printDeclaredDeps {
+    doLast {
+        configurations.testRuntimeClasspath.allDependencies.each { d ->
+            println 'DEP>> ' + d.group + ':' + d.name + ':' + d.version
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/preexisting-versions.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/preexisting-versions.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencies {
+    // testRuntimeOnly mirrors how the plugin declares the profiler.
+    testRuntimeOnly 'digital.pragmatech.testing:spring-test-profiler:0.1.1'
+    // implementation exercises the extended-configuration lookup path; the version
+    // is at or above the plugin's minimum, so it must be left untouched.
+    implementation 'org.thymeleaf:thymeleaf:3.1.5.RELEASE'
+}
+
+// Prints the *declared* modules (not resolved files) of the test runtime
+// classpath, so the plugin's own pinned versions only appear if it added
+// them. allDependencies omits transitives, so the thymeleaf the profiler
+// pulls in does not muddy the assertion.
+task printDeclaredDeps {
+    doLast {
+        configurations.testRuntimeClasspath.allDependencies.each { d ->
+            println 'DEP>> ' + d.group + ':' + d.name + ':' + d.version
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/profiler-dependency.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/profiler-dependency.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+// Applied after our plugin on purpose: exercises the withPlugin reaction.
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+task printTestRuntimeClasspath {
+    dependsOn configurations.testRuntimeClasspath
+    doLast {
+        configurations.testRuntimeClasspath.files.each { f ->
+            println 'TRC>> ' + f.absolutePath
+        }
+    }
+}

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-boot-2.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-boot-2.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencyManagement {
+    imports { mavenBom 'org.springframework.boot:spring-boot-dependencies:2.7.18' }
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+test { useJUnitPlatform() }

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-boot-4.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-boot-4.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencies {
+    implementation platform('org.springframework.boot:spring-boot-dependencies:4.0.7')
+    implementation 'org.springframework.boot:spring-boot-starter'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    // Gradle 9 requires the launcher on the test runtime classpath; the Boot
+    // BOM supplies its version via the imported junit-bom.
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+test { useJUnitPlatform() }

--- a/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-factories-visible.gradle
+++ b/plugins/axelix-gradle-plugin/src/test/resources/com/axelixlabs/gradle/plugin/spring-factories-visible.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'com.axelixlabs.axelix'
+}
+apply plugin: 'java'
+
+repositories { mavenCentral() }
+
+dependencies { testImplementation 'junit:junit:4.13.2' }


### PR DESCRIPTION
Part **4/4** of splitting #1218 (closes #1216). Builds on #1235, #1238 and #1239.

## What

Adds `copyAxelixTestProfilerReport`, which runs after tests pass and copies
`build/spring-test-profiler/` into `build/resources/main/spring-test-profiler/`
so the report lands on the application runtime classpath. Jar tasks are ordered
after the copy (`mustRunAfter`) so the report deterministically ends up inside
the packaged jar. Copying from a missing source dir is a no-op, so projects
whose tests produce no report still build.

## Testing

Functional tests cover empty Spring Boot 2.7.18 (`io.spring.dependency-management`,
Gradle 8.14) and Spring Boot 4.0 (Gradle 9.5.1) apps end-to-end: after `test` the
profiler report exists; after `build` it is copied onto the application classpath
and packaged into the jar; and a report-less plain Java build succeeds with a
no-op copy.

## Splitting note

Logically stacked on #1235, #1238 and #1239; since these target this repo from a
fork, the diff shown here includes the preceding commits. Review the `GH-1216:
Copy spring-test-profiler report...` commit. The cumulative branch is
byte-identical to #1218 minus the unrelated `apm.lock.yaml` tooling churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)