### PR TITLE
GH-1222: Add axelix:add-test-dependencies goal injecting spring-test-profiler

### DIFF
--- a/plugins/axelix-maven-plugin/build.gradle.kts
+++ b/plugins/axelix-maven-plugin/build.gradle.kts
@@ -1,0 +1,99 @@
+plugins {
+    id("java")
+    id("org.gradlex.maven-plugin-development") version "1.0.3"
+}
+
+// groupId is inherited from the root `allprojects { group = "com.axelixlabs" }` block.
+// artifactId is derived from this project's name: `axelix-maven-plugin`.
+// The maven-plugin-development plugin reads groupId/artifactId/version/description from these
+// project properties to generate META-INF/maven/plugin.xml and wires it into processResources/jar.
+
+val mavenApiVersion = "3.9.9"
+val mavenAnnotationsVersion = "3.15.1"
+val mavenPluginTestingVersion = "3.5.1"
+val assertJVersion = "3.27.3"
+val junitBomVersion = "5.12.2"
+val junit4Version = "4.13.2"
+
+dependencies {
+    // Provided by the Maven runtime; must not be bundled into the plugin jar.
+    compileOnly("org.apache.maven:maven-plugin-api:$mavenApiVersion")
+    compileOnly("org.apache.maven.plugin-tools:maven-plugin-annotations:$mavenAnnotationsVersion")
+    // MavenProject, Artifact, ResolutionScope (maven-core); ComparableVersion (maven-artifact).
+    compileOnly("org.apache.maven:maven-core:$mavenApiVersion")
+    compileOnly("org.apache.maven:maven-artifact:$mavenApiVersion")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release = 11
+    options.compilerArgs.add("-parameters")
+}
+
+testing {
+    suites {
+        // The root build forces useJUnitJupiter() on every JvmTestSuite, so Jupiter is present here.
+        val test by getting(JvmTestSuite::class) {
+            dependencies {
+                implementation("org.assertj:assertj-core:$assertJVersion")
+                // The planner builds org.apache.maven.model.Dependency and reads Artifact/ComparableVersion.
+                implementation("org.apache.maven:maven-core:$mavenApiVersion")
+                implementation("org.apache.maven:maven-artifact:$mavenApiVersion")
+            }
+        }
+
+        val integrationTestSuite = "integrationTest"
+
+        register<JvmTestSuite>(integrationTestSuite) {
+
+            sources {
+                java {
+                    setSrcDirs(listOf("src/$integrationTestSuite/java"))
+                }
+                resources {
+                    setSrcDirs(listOf("src/$integrationTestSuite/resources"))
+                }
+            }
+
+            dependencies {
+                // Additional Test Suites do not inherit production dependencies automatically.
+                // Depending on the module output pulls in the compiled Mojos AND the generated
+                // META-INF/maven/plugin.xml that the testing harness uses to locate the Mojo.
+                implementation(project())
+
+                // The compile-only Maven API the Mojos were compiled against is not on the suite
+                // classpath; the harness needs the plugin-api + annotations at runtime too.
+                implementation("org.apache.maven:maven-plugin-api:$mavenApiVersion")
+                implementation("org.apache.maven.plugin-tools:maven-plugin-annotations:$mavenAnnotationsVersion")
+
+                // The harness; the Maven 3 Mojo path (MojoRule / AbstractMojoTestCase) is JUnit4.
+                implementation("org.apache.maven.plugin-testing:maven-plugin-testing-harness:$mavenPluginTestingVersion")
+
+                // The harness declares maven-core/-model/-artifact/-resolver at `provided` scope,
+                // which Gradle does NOT bring transitively. Without an explicit Maven runtime the
+                // Plexus container fails to boot. maven-compat supplies the legacy project-builder
+                // components MojoRule relies on.
+                implementation("org.apache.maven:maven-core:$mavenApiVersion")
+                implementation("org.apache.maven:maven-compat:$mavenApiVersion")
+
+                // MojoRule is a JUnit4 TestRule; run it via the vintage engine alongside Jupiter.
+                implementation(platform("org.junit:junit-bom:$junitBomVersion"))
+                implementation("junit:junit:$junit4Version")
+                runtimeOnly("org.junit.vintage:junit-vintage-engine")
+
+                implementation("org.assertj:assertj-core:$assertJVersion")
+            }
+
+            targets {
+                all {
+                    testTask.configure {
+                        shouldRunAfter(test)
+                    }
+                }
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(testing.suites.named("integrationTest"))
+}

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojo.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojo.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.List;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Injects Axelix's recommended test-scoped dependencies into the building project when they are
+ * missing from the resolved test classpath. Currently it adds
+ * {@code digital.pragmatech.testing:spring-test-profiler} when it is absent.
+ *
+ * <p>The goal binds to {@code initialize} and requires test-scope dependency resolution, so it can
+ * inspect the fully resolved (transitive) classpath via {@link MavenProject#getArtifacts()} and add
+ * the dependencies to the model before the test-compile and test phases run.
+ */
+@Mojo(
+        name = "add-test-dependencies",
+        defaultPhase = LifecyclePhase.INITIALIZE,
+        requiresDependencyResolution = ResolutionScope.TEST,
+        threadSafe = true)
+public class AddTestDependenciesMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Parameter(property = "axelix.springTestProfiler.version", defaultValue = "0.1.2")
+    private String springTestProfilerVersion;
+
+    @Parameter(property = "axelix.addTestDependencies.skip", defaultValue = "false")
+    private boolean skip;
+
+    @Override
+    public void execute() {
+        if (skip) {
+            getLog().info("axelix:add-test-dependencies skipped (axelix.addTestDependencies.skip=true)");
+            return;
+        }
+
+        ResolvedClasspath classpath = new ResolvedClasspath(project.getArtifacts());
+        TestDependencyPlanner planner = new TestDependencyPlanner(springTestProfilerVersion);
+
+        List<Dependency> additions = planner.plan(classpath);
+        if (additions.isEmpty()) {
+            getLog().info("No test dependencies need to be added; classpath already satisfies the requirements.");
+            return;
+        }
+
+        for (Dependency dependency : additions) {
+            project.getDependencies().add(dependency);
+            getLog().info(String.format(
+                    "Added test dependency %s:%s:%s",
+                    dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion()));
+        }
+    }
+}

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/ResolvedClasspath.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/ResolvedClasspath.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+
+/**
+ * A read-only view over the resolved (transitive) dependency artifacts of a Maven project that
+ * answers questions about presence and resolved version of a given {@code groupId:artifactId}.
+ */
+final class ResolvedClasspath {
+
+    private final Set<Artifact> artifacts;
+
+    ResolvedClasspath(Set<Artifact> artifacts) {
+        this.artifacts = Objects.requireNonNull(artifacts, "artifacts");
+    }
+
+    /**
+     * Returns the resolved version of the first artifact matching {@code groupId:artifactId}, or an
+     * empty optional when no such artifact is present on the classpath.
+     */
+    Optional<String> versionOf(String groupId, String artifactId) {
+        return artifacts.stream()
+                .filter(artifact ->
+                        groupId.equals(artifact.getGroupId()) && artifactId.equals(artifact.getArtifactId()))
+                .map(Artifact::getVersion)
+                .findFirst();
+    }
+}

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/TestDependencyPlanner.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/TestDependencyPlanner.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.model.Dependency;
+
+/**
+ * Pure decision logic that, given a project's {@link ResolvedClasspath}, computes which test-scoped
+ * dependencies Axelix wants to inject. Currently it adds
+ * {@code digital.pragmatech.testing:spring-test-profiler} when it is absent from the classpath.
+ *
+ * <p>This class deliberately depends only on the Maven model (not on the plugin runtime), so the
+ * rules can be exercised by plain unit tests.
+ */
+final class TestDependencyPlanner {
+
+    static final String TEST_SCOPE = "test";
+
+    static final String SPRING_TEST_PROFILER_GROUP_ID = "digital.pragmatech.testing";
+    static final String SPRING_TEST_PROFILER_ARTIFACT_ID = "spring-test-profiler";
+
+    private final String springTestProfilerVersion;
+
+    TestDependencyPlanner(String springTestProfilerVersion) {
+        this.springTestProfilerVersion = springTestProfilerVersion;
+    }
+
+    /**
+     * Returns the test-scoped dependencies that should be added to the project for the given
+     * classpath, in declaration order. An empty list means nothing needs to be injected.
+     */
+    List<Dependency> plan(ResolvedClasspath classpath) {
+        List<Dependency> additions = new ArrayList<>();
+
+        if (classpath
+                .versionOf(SPRING_TEST_PROFILER_GROUP_ID, SPRING_TEST_PROFILER_ARTIFACT_ID)
+                .isEmpty()) {
+            additions.add(testDependency(
+                    SPRING_TEST_PROFILER_GROUP_ID, SPRING_TEST_PROFILER_ARTIFACT_ID, springTestProfilerVersion));
+        }
+
+        return additions;
+    }
+
+    private static Dependency testDependency(String groupId, String artifactId, String version) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion(version);
+        dependency.setScope(TEST_SCOPE);
+        return dependency;
+    }
+}

--- a/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/ResolvedClasspathTest.java
+++ b/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/ResolvedClasspathTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResolvedClasspathTest {
+
+    @Test
+    void returnsResolvedVersionWhenArtifactPresent() {
+        // given
+        Artifact thymeleaf = artifact("org.thymeleaf", "thymeleaf", "3.1.2");
+        ResolvedClasspath subject = new ResolvedClasspath(Collections.singleton(thymeleaf));
+
+        // when
+        Optional<String> version = subject.versionOf("org.thymeleaf", "thymeleaf");
+
+        // then
+        assertThat(version).contains("3.1.2");
+    }
+
+    @Test
+    void returnsEmptyWhenArtifactAbsent() {
+        // given
+        ResolvedClasspath subject = new ResolvedClasspath(Set.of(artifact("org.thymeleaf", "thymeleaf", "3.1.2")));
+
+        // when
+        Optional<String> version = subject.versionOf("digital.pragmatech.testing", "spring-test-profiler");
+
+        // then
+        assertThat(version).isEmpty();
+    }
+
+    private static Artifact artifact(String groupId, String artifactId, String version) {
+        return new DefaultArtifact(
+                groupId, artifactId, version, "test", "jar", null, new DefaultArtifactHandler("jar"));
+    }
+}

--- a/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/TestDependencyPlannerTest.java
+++ b/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/TestDependencyPlannerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.model.Dependency;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestDependencyPlannerTest {
+
+    private static final String PROFILER_VERSION = "0.1.2";
+
+    private final TestDependencyPlanner subject = new TestDependencyPlanner(PROFILER_VERSION);
+
+    @Test
+    void addsProfilerWhenAbsent() {
+        // given
+        ResolvedClasspath classpath = classpathOf();
+
+        // when
+        List<Dependency> additions = subject.plan(classpath);
+
+        // then
+        assertThat(additions)
+                .singleElement()
+                .satisfies(dependency -> assertTestDependency(
+                        dependency,
+                        TestDependencyPlanner.SPRING_TEST_PROFILER_GROUP_ID,
+                        TestDependencyPlanner.SPRING_TEST_PROFILER_ARTIFACT_ID,
+                        PROFILER_VERSION));
+    }
+
+    @Test
+    void doesNotAddProfilerWhenAlreadyPresent() {
+        // given
+        ResolvedClasspath classpath = classpathOf(profiler("0.1.1"));
+
+        // when
+        List<Dependency> additions = subject.plan(classpath);
+
+        // then
+        assertThat(additions).isEmpty();
+    }
+
+    private static Artifact profiler(String version) {
+        return artifact(
+                TestDependencyPlanner.SPRING_TEST_PROFILER_GROUP_ID,
+                TestDependencyPlanner.SPRING_TEST_PROFILER_ARTIFACT_ID,
+                version);
+    }
+
+    private static Artifact artifact(String groupId, String artifactId, String version) {
+        return new DefaultArtifact(
+                groupId, artifactId, version, "test", "jar", null, new DefaultArtifactHandler("jar"));
+    }
+
+    private static ResolvedClasspath classpathOf(Artifact... artifacts) {
+        Set<Artifact> set = new HashSet<>(Arrays.asList(artifacts));
+        return new ResolvedClasspath(set);
+    }
+
+    private static void assertTestDependency(Dependency dependency, String groupId, String artifactId, String version) {
+        assertThat(dependency.getGroupId()).isEqualTo(groupId);
+        assertThat(dependency.getArtifactId()).isEqualTo(artifactId);
+        assertThat(dependency.getVersion()).isEqualTo(version);
+        assertThat(dependency.getScope()).isEqualTo(TestDependencyPlanner.TEST_SCOPE);
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,4 +10,5 @@ include(
     ":common:auth",
     ":common:domain",
     ":common:utils",
+    ":plugins:axelix-maven-plugin",
 )


### PR DESCRIPTION
## What

Introduces the first goal of the Axelix Maven plugin: `axelix:add-test-dependencies`. It inspects the resolved test classpath and adds `digital.pragmatech.testing:spring-test-profiler:0.1.2` with `test` scope when the profiler is absent, so consuming Spring Boot projects pick it up automatically.

## Details

- `AddTestDependenciesMojo` — bound to `initialize`, `requiresDependencyResolution=test`; reads the resolved/transitive `MavenProject.getArtifacts()` and mutates the project model before test-compile.
- `TestDependencyPlanner` / `ResolvedClasspath` — pure decision logic, unit-tested without a Maven runtime.

> **Note:** the in-process maven-plugin-testing-harness integration tests now live in their own stacked PR #1246, so this PR carries only the production code and the unit tests. The module's `build.gradle.kts` build configuration lives in the base scaffold PR #1240.

## Verification

`./gradlew :plugins:axelix-maven-plugin:check` — unit tests, spotless, PMD all green.

## Dependencies

**Depends on #1240** (base `axelix-maven-plugin` scaffold + build config). This branch is stacked on `base-maven-plugin`; merge #1240 first. Until then the diff also shows the scaffold commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Tracking issue: #1222.