### PR TITLE
GH-1222: Integration tests for axelix:add-test-dependencies goal

### DIFF
--- a/plugins/axelix-maven-plugin/build.gradle.kts
+++ b/plugins/axelix-maven-plugin/build.gradle.kts
@@ -1,0 +1,99 @@
+plugins {
+    id("java")
+    id("org.gradlex.maven-plugin-development") version "1.0.3"
+}
+
+// groupId is inherited from the root `allprojects { group = "com.axelixlabs" }` block.
+// artifactId is derived from this project's name: `axelix-maven-plugin`.
+// The maven-plugin-development plugin reads groupId/artifactId/version/description from these
+// project properties to generate META-INF/maven/plugin.xml and wires it into processResources/jar.
+
+val mavenApiVersion = "3.9.9"
+val mavenAnnotationsVersion = "3.15.1"
+val mavenPluginTestingVersion = "3.5.1"
+val assertJVersion = "3.27.3"
+val junitBomVersion = "5.12.2"
+val junit4Version = "4.13.2"
+
+dependencies {
+    // Provided by the Maven runtime; must not be bundled into the plugin jar.
+    compileOnly("org.apache.maven:maven-plugin-api:$mavenApiVersion")
+    compileOnly("org.apache.maven.plugin-tools:maven-plugin-annotations:$mavenAnnotationsVersion")
+    // MavenProject, Artifact, ResolutionScope (maven-core); ComparableVersion (maven-artifact).
+    compileOnly("org.apache.maven:maven-core:$mavenApiVersion")
+    compileOnly("org.apache.maven:maven-artifact:$mavenApiVersion")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release = 11
+    options.compilerArgs.add("-parameters")
+}
+
+testing {
+    suites {
+        // The root build forces useJUnitJupiter() on every JvmTestSuite, so Jupiter is present here.
+        val test by getting(JvmTestSuite::class) {
+            dependencies {
+                implementation("org.assertj:assertj-core:$assertJVersion")
+                // The planner builds org.apache.maven.model.Dependency and reads Artifact/ComparableVersion.
+                implementation("org.apache.maven:maven-core:$mavenApiVersion")
+                implementation("org.apache.maven:maven-artifact:$mavenApiVersion")
+            }
+        }
+
+        val integrationTestSuite = "integrationTest"
+
+        register<JvmTestSuite>(integrationTestSuite) {
+
+            sources {
+                java {
+                    setSrcDirs(listOf("src/$integrationTestSuite/java"))
+                }
+                resources {
+                    setSrcDirs(listOf("src/$integrationTestSuite/resources"))
+                }
+            }
+
+            dependencies {
+                // Additional Test Suites do not inherit production dependencies automatically.
+                // Depending on the module output pulls in the compiled Mojos AND the generated
+                // META-INF/maven/plugin.xml that the testing harness uses to locate the Mojo.
+                implementation(project())
+
+                // The compile-only Maven API the Mojos were compiled against is not on the suite
+                // classpath; the harness needs the plugin-api + annotations at runtime too.
+                implementation("org.apache.maven:maven-plugin-api:$mavenApiVersion")
+                implementation("org.apache.maven.plugin-tools:maven-plugin-annotations:$mavenAnnotationsVersion")
+
+                // The harness; the Maven 3 Mojo path (MojoRule / AbstractMojoTestCase) is JUnit4.
+                implementation("org.apache.maven.plugin-testing:maven-plugin-testing-harness:$mavenPluginTestingVersion")
+
+                // The harness declares maven-core/-model/-artifact/-resolver at `provided` scope,
+                // which Gradle does NOT bring transitively. Without an explicit Maven runtime the
+                // Plexus container fails to boot. maven-compat supplies the legacy project-builder
+                // components MojoRule relies on.
+                implementation("org.apache.maven:maven-core:$mavenApiVersion")
+                implementation("org.apache.maven:maven-compat:$mavenApiVersion")
+
+                // MojoRule is a JUnit4 TestRule; run it via the vintage engine alongside Jupiter.
+                implementation(platform("org.junit:junit-bom:$junitBomVersion"))
+                implementation("junit:junit:$junit4Version")
+                runtimeOnly("org.junit.vintage:junit-vintage-engine")
+
+                implementation("org.assertj:assertj-core:$assertJVersion")
+            }
+
+            targets {
+                all {
+                    testTask.configure {
+                        shouldRunAfter(test)
+                    }
+                }
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(testing.suites.named("integrationTest"))
+}

--- a/plugins/axelix-maven-plugin/src/integrationTest/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojoIntegrationTest.java
+++ b/plugins/axelix-maven-plugin/src/integrationTest/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojoIntegrationTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.project.MavenProject;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * In-process integration tests driving the real Mojo (looked up through its generated plugin
+ * descriptor) with the maven-plugin-testing-harness against representative Spring Boot 2 and Spring
+ * Boot 4 application POMs.
+ *
+ * <p>The harness does not perform real transitive dependency resolution, so each scenario's resolved
+ * classpath is simulated by setting the project's artifacts before execution; the rest of the wiring
+ * (descriptor lookup, parameter-default injection, model mutation) is exercised end-to-end.
+ */
+public class AddTestDependenciesMojoIntegrationTest {
+
+    private static final String GOAL = "add-test-dependencies";
+
+    private static final String PROFILER_GROUP_ID = "digital.pragmatech.testing";
+    private static final String PROFILER_ARTIFACT_ID = "spring-test-profiler";
+
+    @Rule
+    public final MojoRule rule = new MojoRule();
+
+    @Test
+    public void springBoot2AppWithoutProfilerGetsProfiler() throws Exception {
+        // given
+        // A Spring Boot 2 app whose resolved classpath does not contain the profiler.
+        MavenProject project = readProject("/sb2-app");
+        project.setArtifacts(artifacts());
+
+        // when
+        execute(project);
+
+        // then
+        List<Dependency> added = addedDependencies(project);
+        assertThat(added).hasSize(1);
+        assertDependency(added.get(0), PROFILER_GROUP_ID, PROFILER_ARTIFACT_ID, "0.1.2");
+    }
+
+    @Test
+    public void springBoot4AppWithProfilerGetsNothing() throws Exception {
+        // given
+        // A Spring Boot 4 app that already has the profiler on its resolved classpath.
+        MavenProject project = readProject("/sb4-app");
+        project.setArtifacts(artifacts(profiler("0.1.2")));
+
+        // when
+        execute(project);
+
+        // then
+        assertThat(addedDependencies(project)).isEmpty();
+    }
+
+    private MavenProject readProject(String classpathDir) throws Exception {
+        File baseDir = new File(getClass().getResource(classpathDir).toURI());
+        return rule.readMavenProject(baseDir);
+    }
+
+    private void execute(MavenProject project) throws Exception {
+        AddTestDependenciesMojo mojo = rule.lookupConfiguredMojo(project, GOAL);
+        mojo.execute();
+    }
+
+    /**
+     * Returns the dependencies our Mojo injects (identified by the profiler artifactId), so the
+     * assertions are independent of whatever the fixture POM itself declares.
+     */
+    private static List<Dependency> addedDependencies(MavenProject project) {
+        return project.getDependencies().stream()
+                .filter(dependency -> PROFILER_ARTIFACT_ID.equals(dependency.getArtifactId()))
+                .collect(Collectors.toList());
+    }
+
+    private static void assertDependency(Dependency dependency, String groupId, String artifactId, String version) {
+        assertThat(dependency.getGroupId()).isEqualTo(groupId);
+        assertThat(dependency.getArtifactId()).isEqualTo(artifactId);
+        assertThat(dependency.getVersion()).isEqualTo(version);
+        assertThat(dependency.getScope()).isEqualTo("test");
+    }
+
+    private static Set<Artifact> artifacts(Artifact... artifacts) {
+        return new LinkedHashSet<>(List.of(artifacts));
+    }
+
+    private static Artifact profiler(String version) {
+        return artifact(PROFILER_GROUP_ID, PROFILER_ARTIFACT_ID, version);
+    }
+
+    private static Artifact artifact(String groupId, String artifactId, String version) {
+        return new DefaultArtifact(
+                groupId, artifactId, version, "test", "jar", null, new DefaultArtifactHandler("jar"));
+    }
+}

--- a/plugins/axelix-maven-plugin/src/integrationTest/resources/sb2-app/pom.xml
+++ b/plugins/axelix-maven-plugin/src/integrationTest/resources/sb2-app/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  A representative Spring Boot 2 application used by AddTestDependenciesMojoIT.
+  No parent BOM is declared so the testing harness can build the project model without
+  attempting network resolution; the resolved classpath is supplied by the test itself.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.axelixlabs.it</groupId>
+    <artifactId>spring-boot-2-app</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>2.7.18</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.7.18</version>
+            </plugin>
+            <plugin>
+                <groupId>com.axelixlabs</groupId>
+                <artifactId>axelix-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugins/axelix-maven-plugin/src/integrationTest/resources/sb4-app/pom.xml
+++ b/plugins/axelix-maven-plugin/src/integrationTest/resources/sb4-app/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  A representative Spring Boot 4 application used by AddTestDependenciesMojoIT.
+  No parent BOM is declared so the testing harness can build the project model without
+  attempting network resolution; the resolved classpath is supplied by the test itself.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.axelixlabs.it</groupId>
+    <artifactId>spring-boot-4-app</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>4.0.0</version>
+            </plugin>
+            <plugin>
+                <groupId>com.axelixlabs</groupId>
+                <artifactId>axelix-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojo.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojo.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.List;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Injects Axelix's recommended test-scoped dependencies into the building project when they are
+ * missing from the resolved test classpath. Currently it adds
+ * {@code digital.pragmatech.testing:spring-test-profiler} when it is absent.
+ *
+ * <p>The goal binds to {@code initialize} and requires test-scope dependency resolution, so it can
+ * inspect the fully resolved (transitive) classpath via {@link MavenProject#getArtifacts()} and add
+ * the dependencies to the model before the test-compile and test phases run.
+ */
+@Mojo(
+        name = "add-test-dependencies",
+        defaultPhase = LifecyclePhase.INITIALIZE,
+        requiresDependencyResolution = ResolutionScope.TEST,
+        threadSafe = true)
+public class AddTestDependenciesMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Parameter(property = "axelix.springTestProfiler.version", defaultValue = "0.1.2")
+    private String springTestProfilerVersion;
+
+    @Parameter(property = "axelix.addTestDependencies.skip", defaultValue = "false")
+    private boolean skip;
+
+    @Override
+    public void execute() {
+        if (skip) {
+            getLog().info("axelix:add-test-dependencies skipped (axelix.addTestDependencies.skip=true)");
+            return;
+        }
+
+        ResolvedClasspath classpath = new ResolvedClasspath(project.getArtifacts());
+        TestDependencyPlanner planner = new TestDependencyPlanner(springTestProfilerVersion);
+
+        List<Dependency> additions = planner.plan(classpath);
+        if (additions.isEmpty()) {
+            getLog().info("No test dependencies need to be added; classpath already satisfies the requirements.");
+            return;
+        }
+
+        for (Dependency dependency : additions) {
+            project.getDependencies().add(dependency);
+            getLog().info(String.format(
+                    "Added test dependency %s:%s:%s",
+                    dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion()));
+        }
+    }
+}

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/ResolvedClasspath.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/ResolvedClasspath.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+
+/**
+ * A read-only view over the resolved (transitive) dependency artifacts of a Maven project that
+ * answers questions about presence and resolved version of a given {@code groupId:artifactId}.
+ */
+final class ResolvedClasspath {
+
+    private final Set<Artifact> artifacts;
+
+    ResolvedClasspath(Set<Artifact> artifacts) {
+        this.artifacts = Objects.requireNonNull(artifacts, "artifacts");
+    }
+
+    /**
+     * Returns the resolved version of the first artifact matching {@code groupId:artifactId}, or an
+     * empty optional when no such artifact is present on the classpath.
+     */
+    Optional<String> versionOf(String groupId, String artifactId) {
+        return artifacts.stream()
+                .filter(artifact ->
+                        groupId.equals(artifact.getGroupId()) && artifactId.equals(artifact.getArtifactId()))
+                .map(Artifact::getVersion)
+                .findFirst();
+    }
+}

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/TestDependencyPlanner.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/TestDependencyPlanner.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.model.Dependency;
+
+/**
+ * Pure decision logic that, given a project's {@link ResolvedClasspath}, computes which test-scoped
+ * dependencies Axelix wants to inject. Currently it adds
+ * {@code digital.pragmatech.testing:spring-test-profiler} when it is absent from the classpath.
+ *
+ * <p>This class deliberately depends only on the Maven model (not on the plugin runtime), so the
+ * rules can be exercised by plain unit tests.
+ */
+final class TestDependencyPlanner {
+
+    static final String TEST_SCOPE = "test";
+
+    static final String SPRING_TEST_PROFILER_GROUP_ID = "digital.pragmatech.testing";
+    static final String SPRING_TEST_PROFILER_ARTIFACT_ID = "spring-test-profiler";
+
+    private final String springTestProfilerVersion;
+
+    TestDependencyPlanner(String springTestProfilerVersion) {
+        this.springTestProfilerVersion = springTestProfilerVersion;
+    }
+
+    /**
+     * Returns the test-scoped dependencies that should be added to the project for the given
+     * classpath, in declaration order. An empty list means nothing needs to be injected.
+     */
+    List<Dependency> plan(ResolvedClasspath classpath) {
+        List<Dependency> additions = new ArrayList<>();
+
+        if (classpath
+                .versionOf(SPRING_TEST_PROFILER_GROUP_ID, SPRING_TEST_PROFILER_ARTIFACT_ID)
+                .isEmpty()) {
+            additions.add(testDependency(
+                    SPRING_TEST_PROFILER_GROUP_ID, SPRING_TEST_PROFILER_ARTIFACT_ID, springTestProfilerVersion));
+        }
+
+        return additions;
+    }
+
+    private static Dependency testDependency(String groupId, String artifactId, String version) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion(version);
+        dependency.setScope(TEST_SCOPE);
+        return dependency;
+    }
+}

--- a/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/ResolvedClasspathTest.java
+++ b/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/ResolvedClasspathTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResolvedClasspathTest {
+
+    @Test
+    void returnsResolvedVersionWhenArtifactPresent() {
+        // given
+        Artifact thymeleaf = artifact("org.thymeleaf", "thymeleaf", "3.1.2");
+        ResolvedClasspath subject = new ResolvedClasspath(Collections.singleton(thymeleaf));
+
+        // when
+        Optional<String> version = subject.versionOf("org.thymeleaf", "thymeleaf");
+
+        // then
+        assertThat(version).contains("3.1.2");
+    }
+
+    @Test
+    void returnsEmptyWhenArtifactAbsent() {
+        // given
+        ResolvedClasspath subject = new ResolvedClasspath(Set.of(artifact("org.thymeleaf", "thymeleaf", "3.1.2")));
+
+        // when
+        Optional<String> version = subject.versionOf("digital.pragmatech.testing", "spring-test-profiler");
+
+        // then
+        assertThat(version).isEmpty();
+    }
+
+    private static Artifact artifact(String groupId, String artifactId, String version) {
+        return new DefaultArtifact(
+                groupId, artifactId, version, "test", "jar", null, new DefaultArtifactHandler("jar"));
+    }
+}

--- a/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/TestDependencyPlannerTest.java
+++ b/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/TestDependencyPlannerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.model.Dependency;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestDependencyPlannerTest {
+
+    private static final String PROFILER_VERSION = "0.1.2";
+
+    private final TestDependencyPlanner subject = new TestDependencyPlanner(PROFILER_VERSION);
+
+    @Test
+    void addsProfilerWhenAbsent() {
+        // given
+        ResolvedClasspath classpath = classpathOf();
+
+        // when
+        List<Dependency> additions = subject.plan(classpath);
+
+        // then
+        assertThat(additions)
+                .singleElement()
+                .satisfies(dependency -> assertTestDependency(
+                        dependency,
+                        TestDependencyPlanner.SPRING_TEST_PROFILER_GROUP_ID,
+                        TestDependencyPlanner.SPRING_TEST_PROFILER_ARTIFACT_ID,
+                        PROFILER_VERSION));
+    }
+
+    @Test
+    void doesNotAddProfilerWhenAlreadyPresent() {
+        // given
+        ResolvedClasspath classpath = classpathOf(profiler("0.1.1"));
+
+        // when
+        List<Dependency> additions = subject.plan(classpath);
+
+        // then
+        assertThat(additions).isEmpty();
+    }
+
+    private static Artifact profiler(String version) {
+        return artifact(
+                TestDependencyPlanner.SPRING_TEST_PROFILER_GROUP_ID,
+                TestDependencyPlanner.SPRING_TEST_PROFILER_ARTIFACT_ID,
+                version);
+    }
+
+    private static Artifact artifact(String groupId, String artifactId, String version) {
+        return new DefaultArtifact(
+                groupId, artifactId, version, "test", "jar", null, new DefaultArtifactHandler("jar"));
+    }
+
+    private static ResolvedClasspath classpathOf(Artifact... artifacts) {
+        Set<Artifact> set = new HashSet<>(Arrays.asList(artifacts));
+        return new ResolvedClasspath(set);
+    }
+
+    private static void assertTestDependency(Dependency dependency, String groupId, String artifactId, String version) {
+        assertThat(dependency.getGroupId()).isEqualTo(groupId);
+        assertThat(dependency.getArtifactId()).isEqualTo(artifactId);
+        assertThat(dependency.getVersion()).isEqualTo(version);
+        assertThat(dependency.getScope()).isEqualTo(TestDependencyPlanner.TEST_SCOPE);
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,4 +10,5 @@ include(
     ":common:auth",
     ":common:domain",
     ":common:utils",
+    ":plugins:axelix-maven-plugin",
 )


### PR DESCRIPTION
## What

Adds the maven-plugin-testing-harness integration tests for the `axelix:add-test-dependencies` goal, split out of #1241 so the production code and unit tests review separately from the heavier in-process Mojo tests.

## Details

- `AddTestDependenciesMojoIntegrationTest` runs the real Mojo in-process via `MojoRule` against Spring Boot 2 and Spring Boot 4 application POMs.
- Test fixtures: `src/integrationTest/resources/sb2-app/pom.xml` and `sb4-app/pom.xml`.

## Verification

`./gradlew :plugins:axelix-maven-plugin:check` — unit + harness integration tests, spotless, PMD all green.

## Dependencies

**Depends on #1241** (`maven-plugin-add-profiler`, the goal's production code + unit tests). This branch is stacked on top of it; merge #1241 first. Until then the diff also shows the profiler and scaffold commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Tracking issue: #1222.