### PR TITLE
GH-1222: Register spring-test-profiler via META-INF/spring.factories

### DIFF
--- a/plugins/axelix-maven-plugin/build.gradle.kts
+++ b/plugins/axelix-maven-plugin/build.gradle.kts
@@ -1,15 +1,99 @@
 plugins {
     id("java")
+    id("org.gradlex.maven-plugin-development") version "1.0.3"
 }
 
 // groupId is inherited from the root `allprojects { group = "com.axelixlabs" }` block.
 // artifactId is derived from this project's name: `axelix-maven-plugin`.
+// The maven-plugin-development plugin reads groupId/artifactId/version/description from these
+// project properties to generate META-INF/maven/plugin.xml and wires it into processResources/jar.
 
 val mavenApiVersion = "3.9.9"
 val mavenAnnotationsVersion = "3.15.1"
+val mavenPluginTestingVersion = "3.5.1"
+val assertJVersion = "3.27.3"
+val junitBomVersion = "5.12.2"
+val junit4Version = "4.13.2"
 
 dependencies {
     // Provided by the Maven runtime; must not be bundled into the plugin jar.
     compileOnly("org.apache.maven:maven-plugin-api:$mavenApiVersion")
     compileOnly("org.apache.maven.plugin-tools:maven-plugin-annotations:$mavenAnnotationsVersion")
+    // MavenProject, Artifact, ResolutionScope (maven-core); ComparableVersion (maven-artifact).
+    compileOnly("org.apache.maven:maven-core:$mavenApiVersion")
+    compileOnly("org.apache.maven:maven-artifact:$mavenApiVersion")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release = 11
+    options.compilerArgs.add("-parameters")
+}
+
+testing {
+    suites {
+        // The root build forces useJUnitJupiter() on every JvmTestSuite, so Jupiter is present here.
+        val test by getting(JvmTestSuite::class) {
+            dependencies {
+                implementation("org.assertj:assertj-core:$assertJVersion")
+                // The planner builds org.apache.maven.model.Dependency and reads Artifact/ComparableVersion.
+                implementation("org.apache.maven:maven-core:$mavenApiVersion")
+                implementation("org.apache.maven:maven-artifact:$mavenApiVersion")
+            }
+        }
+
+        val integrationTestSuite = "integrationTest"
+
+        register<JvmTestSuite>(integrationTestSuite) {
+
+            sources {
+                java {
+                    setSrcDirs(listOf("src/$integrationTestSuite/java"))
+                }
+                resources {
+                    setSrcDirs(listOf("src/$integrationTestSuite/resources"))
+                }
+            }
+
+            dependencies {
+                // Additional Test Suites do not inherit production dependencies automatically.
+                // Depending on the module output pulls in the compiled Mojos AND the generated
+                // META-INF/maven/plugin.xml that the testing harness uses to locate the Mojo.
+                implementation(project())
+
+                // The compile-only Maven API the Mojos were compiled against is not on the suite
+                // classpath; the harness needs the plugin-api + annotations at runtime too.
+                implementation("org.apache.maven:maven-plugin-api:$mavenApiVersion")
+                implementation("org.apache.maven.plugin-tools:maven-plugin-annotations:$mavenAnnotationsVersion")
+
+                // The harness; the Maven 3 Mojo path (MojoRule / AbstractMojoTestCase) is JUnit4.
+                implementation("org.apache.maven.plugin-testing:maven-plugin-testing-harness:$mavenPluginTestingVersion")
+
+                // The harness declares maven-core/-model/-artifact/-resolver at `provided` scope,
+                // which Gradle does NOT bring transitively. Without an explicit Maven runtime the
+                // Plexus container fails to boot. maven-compat supplies the legacy project-builder
+                // components MojoRule relies on.
+                implementation("org.apache.maven:maven-core:$mavenApiVersion")
+                implementation("org.apache.maven:maven-compat:$mavenApiVersion")
+
+                // MojoRule is a JUnit4 TestRule; run it via the vintage engine alongside Jupiter.
+                implementation(platform("org.junit:junit-bom:$junitBomVersion"))
+                implementation("junit:junit:$junit4Version")
+                runtimeOnly("org.junit.vintage:junit-vintage-engine")
+
+                implementation("org.assertj:assertj-core:$assertJVersion")
+            }
+
+            targets {
+                all {
+                    testTask.configure {
+                        shouldRunAfter(test)
+                    }
+                }
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(testing.suites.named("integrationTest"))
 }

--- a/plugins/axelix-maven-plugin/build.gradle.kts
+++ b/plugins/axelix-maven-plugin/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id("java")
+}
+
+// groupId is inherited from the root `allprojects { group = "com.axelixlabs" }` block.
+// artifactId is derived from this project's name: `axelix-maven-plugin`.
+
+val mavenApiVersion = "3.9.9"
+val mavenAnnotationsVersion = "3.15.1"
+
+dependencies {
+    // Provided by the Maven runtime; must not be bundled into the plugin jar.
+    compileOnly("org.apache.maven:maven-plugin-api:$mavenApiVersion")
+    compileOnly("org.apache.maven.plugin-tools:maven-plugin-annotations:$mavenAnnotationsVersion")
+}

--- a/plugins/axelix-maven-plugin/src/integrationTest/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojoIntegrationTest.java
+++ b/plugins/axelix-maven-plugin/src/integrationTest/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojoIntegrationTest.java
@@ -18,8 +18,14 @@
 package com.axelixlabs.maven.plugin;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -27,6 +33,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.testing.MojoRule;
 import org.apache.maven.project.MavenProject;
 import org.junit.Rule;
@@ -52,6 +59,12 @@ public class AddTestDependenciesMojoIntegrationTest {
     private static final String THYMELEAF_GROUP_ID = "org.thymeleaf";
     private static final String THYMELEAF_ARTIFACT_ID = "thymeleaf";
 
+    private static final String SPRING_FACTORIES_PATH = "META-INF/spring.factories";
+    private static final String FRESH_SPRING_FACTORIES = "org.springframework.test.context.TestExecutionListener=\\\n"
+            + "digital.pragmatech.testing.SpringTestProfilerListener\n"
+            + "org.springframework.context.ApplicationContextInitializer=\\\n"
+            + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer\n";
+
     @Rule
     public final MojoRule rule = new MojoRule();
 
@@ -72,10 +85,11 @@ public class AddTestDependenciesMojoIntegrationTest {
                 findByArtifactId(added, PROFILER_ARTIFACT_ID), PROFILER_GROUP_ID, PROFILER_ARTIFACT_ID, "0.1.2");
         assertDependency(
                 findByArtifactId(added, THYMELEAF_ARTIFACT_ID), THYMELEAF_GROUP_ID, THYMELEAF_ARTIFACT_ID, "3.1.5");
+        assertThat(readGeneratedSpringFactories(project)).isEqualTo(FRESH_SPRING_FACTORIES);
     }
 
     @Test
-    public void springBoot4AppWithUpToDateClasspathGetsNothing() throws Exception {
+    public void springBoot4AppWithUpToDateClasspathGetsNothingButStillRegistersSpringFactories() throws Exception {
         // given
         // A Spring Boot 4 app that already has the profiler and a current thymeleaf on the classpath.
         MavenProject project = readProject("/sb4-app");
@@ -86,6 +100,29 @@ public class AddTestDependenciesMojoIntegrationTest {
 
         // then
         assertThat(addedDependencies(project)).isEmpty();
+        assertThat(readGeneratedSpringFactories(project)).isEqualTo(FRESH_SPRING_FACTORIES);
+    }
+
+    @Test
+    public void mergesExistingProjectSpringFactories() throws Exception {
+        // given
+        // A Spring Boot 4 app that already declares its own spring.factories on a test-resource root.
+        MavenProject project = readProject("/sb4-app");
+        project.setArtifacts(artifacts(thymeleaf("3.1.6"), profiler("0.1.2")));
+        project.addTestResource(existingSpringFactoriesResource());
+
+        // when
+        execute(project);
+
+        // then
+        Properties merged = parse(readGeneratedSpringFactories(project));
+        assertThat(valuesOf(merged, "org.springframework.test.context.TestExecutionListener"))
+                .containsExactlyInAnyOrder(
+                        "com.app.AppListener", "digital.pragmatech.testing.SpringTestProfilerListener");
+        assertThat(valuesOf(merged, "org.springframework.context.ApplicationContextInitializer"))
+                .containsExactly("digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer");
+        assertThat(valuesOf(merged, "org.springframework.boot.SpringApplicationRunListener"))
+                .containsExactly("com.app.AppRunListener");
     }
 
     @Test
@@ -103,6 +140,41 @@ public class AddTestDependenciesMojoIntegrationTest {
         assertThat(added).hasSize(1);
         assertDependency(
                 findByArtifactId(added, PROFILER_ARTIFACT_ID), PROFILER_GROUP_ID, PROFILER_ARTIFACT_ID, "0.1.2");
+    }
+
+    /**
+     * Reads the {@code META-INF/spring.factories} the Mojo generated, located through the test resource
+     * it registered on the project (whose directory is the generated {@code .../axelix} root).
+     */
+    private static String readGeneratedSpringFactories(MavenProject project) throws IOException {
+        List<Resource> generated = project.getTestResources().stream()
+                .filter(resource -> resource.getDirectory() != null
+                        && resource.getDirectory().replace('\\', '/').endsWith("generated-test-resources/axelix"))
+                .collect(Collectors.toList());
+        assertThat(generated).hasSize(1);
+
+        File file = new File(generated.get(0).getDirectory(), SPRING_FACTORIES_PATH);
+        assertThat(file).isFile();
+        return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+    }
+
+    private Resource existingSpringFactoriesResource() throws Exception {
+        Resource resource = new Resource();
+        resource.setDirectory(
+                new File(getClass().getResource("/existing-spring-factories").toURI()).getAbsolutePath());
+        return resource;
+    }
+
+    private static Properties parse(String content) throws IOException {
+        Properties properties = new Properties();
+        try (Reader reader = new StringReader(content)) {
+            properties.load(reader);
+        }
+        return properties;
+    }
+
+    private static List<String> valuesOf(Properties properties, String key) {
+        return List.of(properties.getProperty(key, "").split(","));
     }
 
     private MavenProject readProject(String classpathDir) throws Exception {

--- a/plugins/axelix-maven-plugin/src/integrationTest/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojoIntegrationTest.java
+++ b/plugins/axelix-maven-plugin/src/integrationTest/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojoIntegrationTest.java
@@ -49,16 +49,51 @@ public class AddTestDependenciesMojoIntegrationTest {
 
     private static final String PROFILER_GROUP_ID = "digital.pragmatech.testing";
     private static final String PROFILER_ARTIFACT_ID = "spring-test-profiler";
+    private static final String THYMELEAF_GROUP_ID = "org.thymeleaf";
+    private static final String THYMELEAF_ARTIFACT_ID = "thymeleaf";
 
     @Rule
     public final MojoRule rule = new MojoRule();
 
     @Test
-    public void springBoot2AppWithoutProfilerGetsProfiler() throws Exception {
+    public void springBoot2AppGetsProfilerAndThymeleafUpgrade() throws Exception {
         // given
-        // A Spring Boot 2 app whose resolved classpath does not contain the profiler.
+        // A Spring Boot 2 app whose resolved classpath has an outdated thymeleaf and no profiler.
         MavenProject project = readProject("/sb2-app");
-        project.setArtifacts(artifacts());
+        project.setArtifacts(artifacts(thymeleaf("3.0.15")));
+
+        // when
+        execute(project);
+
+        // then
+        List<Dependency> added = addedDependencies(project);
+        assertThat(added).hasSize(2);
+        assertDependency(
+                findByArtifactId(added, PROFILER_ARTIFACT_ID), PROFILER_GROUP_ID, PROFILER_ARTIFACT_ID, "0.1.2");
+        assertDependency(
+                findByArtifactId(added, THYMELEAF_ARTIFACT_ID), THYMELEAF_GROUP_ID, THYMELEAF_ARTIFACT_ID, "3.1.5");
+    }
+
+    @Test
+    public void springBoot4AppWithUpToDateClasspathGetsNothing() throws Exception {
+        // given
+        // A Spring Boot 4 app that already has the profiler and a current thymeleaf on the classpath.
+        MavenProject project = readProject("/sb4-app");
+        project.setArtifacts(artifacts(thymeleaf("3.1.6"), profiler("0.1.2")));
+
+        // when
+        execute(project);
+
+        // then
+        assertThat(addedDependencies(project)).isEmpty();
+    }
+
+    @Test
+    public void springBoot4AppMissingOnlyProfilerGetsProfilerOnly() throws Exception {
+        // given
+        // Current thymeleaf is on the classpath, but the profiler is missing.
+        MavenProject project = readProject("/sb4-app");
+        project.setArtifacts(artifacts(thymeleaf("3.1.6")));
 
         // when
         execute(project);
@@ -66,21 +101,8 @@ public class AddTestDependenciesMojoIntegrationTest {
         // then
         List<Dependency> added = addedDependencies(project);
         assertThat(added).hasSize(1);
-        assertDependency(added.get(0), PROFILER_GROUP_ID, PROFILER_ARTIFACT_ID, "0.1.2");
-    }
-
-    @Test
-    public void springBoot4AppWithProfilerGetsNothing() throws Exception {
-        // given
-        // A Spring Boot 4 app that already has the profiler on its resolved classpath.
-        MavenProject project = readProject("/sb4-app");
-        project.setArtifacts(artifacts(profiler("0.1.2")));
-
-        // when
-        execute(project);
-
-        // then
-        assertThat(addedDependencies(project)).isEmpty();
+        assertDependency(
+                findByArtifactId(added, PROFILER_ARTIFACT_ID), PROFILER_GROUP_ID, PROFILER_ARTIFACT_ID, "0.1.2");
     }
 
     private MavenProject readProject(String classpathDir) throws Exception {
@@ -94,13 +116,21 @@ public class AddTestDependenciesMojoIntegrationTest {
     }
 
     /**
-     * Returns the dependencies our Mojo injects (identified by the profiler artifactId), so the
+     * Returns the dependencies our Mojo injects (identified by their well-known artifactIds), so the
      * assertions are independent of whatever the fixture POM itself declares.
      */
     private static List<Dependency> addedDependencies(MavenProject project) {
         return project.getDependencies().stream()
-                .filter(dependency -> PROFILER_ARTIFACT_ID.equals(dependency.getArtifactId()))
+                .filter(dependency -> PROFILER_ARTIFACT_ID.equals(dependency.getArtifactId())
+                        || THYMELEAF_ARTIFACT_ID.equals(dependency.getArtifactId()))
                 .collect(Collectors.toList());
+    }
+
+    private static Dependency findByArtifactId(List<Dependency> dependencies, String artifactId) {
+        return dependencies.stream()
+                .filter(dependency -> artifactId.equals(dependency.getArtifactId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Expected an added dependency with artifactId " + artifactId));
     }
 
     private static void assertDependency(Dependency dependency, String groupId, String artifactId, String version) {
@@ -116,6 +146,10 @@ public class AddTestDependenciesMojoIntegrationTest {
 
     private static Artifact profiler(String version) {
         return artifact(PROFILER_GROUP_ID, PROFILER_ARTIFACT_ID, version);
+    }
+
+    private static Artifact thymeleaf(String version) {
+        return artifact(THYMELEAF_GROUP_ID, THYMELEAF_ARTIFACT_ID, version);
     }
 
     private static Artifact artifact(String groupId, String artifactId, String version) {

--- a/plugins/axelix-maven-plugin/src/integrationTest/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojoIntegrationTest.java
+++ b/plugins/axelix-maven-plugin/src/integrationTest/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojoIntegrationTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.project.MavenProject;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * In-process integration tests driving the real Mojo (looked up through its generated plugin
+ * descriptor) with the maven-plugin-testing-harness against representative Spring Boot 2 and Spring
+ * Boot 4 application POMs.
+ *
+ * <p>The harness does not perform real transitive dependency resolution, so each scenario's resolved
+ * classpath is simulated by setting the project's artifacts before execution; the rest of the wiring
+ * (descriptor lookup, parameter-default injection, model mutation) is exercised end-to-end.
+ */
+public class AddTestDependenciesMojoIntegrationTest {
+
+    private static final String GOAL = "add-test-dependencies";
+
+    private static final String PROFILER_GROUP_ID = "digital.pragmatech.testing";
+    private static final String PROFILER_ARTIFACT_ID = "spring-test-profiler";
+
+    @Rule
+    public final MojoRule rule = new MojoRule();
+
+    @Test
+    public void springBoot2AppWithoutProfilerGetsProfiler() throws Exception {
+        // given
+        // A Spring Boot 2 app whose resolved classpath does not contain the profiler.
+        MavenProject project = readProject("/sb2-app");
+        project.setArtifacts(artifacts());
+
+        // when
+        execute(project);
+
+        // then
+        List<Dependency> added = addedDependencies(project);
+        assertThat(added).hasSize(1);
+        assertDependency(added.get(0), PROFILER_GROUP_ID, PROFILER_ARTIFACT_ID, "0.1.2");
+    }
+
+    @Test
+    public void springBoot4AppWithProfilerGetsNothing() throws Exception {
+        // given
+        // A Spring Boot 4 app that already has the profiler on its resolved classpath.
+        MavenProject project = readProject("/sb4-app");
+        project.setArtifacts(artifacts(profiler("0.1.2")));
+
+        // when
+        execute(project);
+
+        // then
+        assertThat(addedDependencies(project)).isEmpty();
+    }
+
+    private MavenProject readProject(String classpathDir) throws Exception {
+        File baseDir = new File(getClass().getResource(classpathDir).toURI());
+        return rule.readMavenProject(baseDir);
+    }
+
+    private void execute(MavenProject project) throws Exception {
+        AddTestDependenciesMojo mojo = rule.lookupConfiguredMojo(project, GOAL);
+        mojo.execute();
+    }
+
+    /**
+     * Returns the dependencies our Mojo injects (identified by the profiler artifactId), so the
+     * assertions are independent of whatever the fixture POM itself declares.
+     */
+    private static List<Dependency> addedDependencies(MavenProject project) {
+        return project.getDependencies().stream()
+                .filter(dependency -> PROFILER_ARTIFACT_ID.equals(dependency.getArtifactId()))
+                .collect(Collectors.toList());
+    }
+
+    private static void assertDependency(Dependency dependency, String groupId, String artifactId, String version) {
+        assertThat(dependency.getGroupId()).isEqualTo(groupId);
+        assertThat(dependency.getArtifactId()).isEqualTo(artifactId);
+        assertThat(dependency.getVersion()).isEqualTo(version);
+        assertThat(dependency.getScope()).isEqualTo("test");
+    }
+
+    private static Set<Artifact> artifacts(Artifact... artifacts) {
+        return new LinkedHashSet<>(List.of(artifacts));
+    }
+
+    private static Artifact profiler(String version) {
+        return artifact(PROFILER_GROUP_ID, PROFILER_ARTIFACT_ID, version);
+    }
+
+    private static Artifact artifact(String groupId, String artifactId, String version) {
+        return new DefaultArtifact(
+                groupId, artifactId, version, "test", "jar", null, new DefaultArtifactHandler("jar"));
+    }
+}

--- a/plugins/axelix-maven-plugin/src/integrationTest/resources/existing-spring-factories/META-INF/spring.factories
+++ b/plugins/axelix-maven-plugin/src/integrationTest/resources/existing-spring-factories/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.test.context.TestExecutionListener=com.app.AppListener
+org.springframework.boot.SpringApplicationRunListener=com.app.AppRunListener

--- a/plugins/axelix-maven-plugin/src/integrationTest/resources/sb2-app/pom.xml
+++ b/plugins/axelix-maven-plugin/src/integrationTest/resources/sb2-app/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  A representative Spring Boot 2 application used by AddTestDependenciesMojoIT.
+  No parent BOM is declared so the testing harness can build the project model without
+  attempting network resolution; the resolved classpath is supplied by the test itself.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.axelixlabs.it</groupId>
+    <artifactId>spring-boot-2-app</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.release>11</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>2.7.18</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.axelixlabs</groupId>
+                <artifactId>axelix-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugins/axelix-maven-plugin/src/integrationTest/resources/sb4-app/pom.xml
+++ b/plugins/axelix-maven-plugin/src/integrationTest/resources/sb4-app/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  A representative Spring Boot 4 application used by AddTestDependenciesMojoIT.
+  No parent BOM is declared so the testing harness can build the project model without
+  attempting network resolution; the resolved classpath is supplied by the test itself.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.axelixlabs.it</groupId>
+    <artifactId>spring-boot-4-app</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.axelixlabs</groupId>
+                <artifactId>axelix-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojo.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojo.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.List;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Injects Axelix's recommended test-scoped dependencies into the building project when they are
+ * missing from the resolved test classpath. Currently it adds
+ * {@code digital.pragmatech.testing:spring-test-profiler} when it is absent.
+ *
+ * <p>The goal binds to {@code initialize} and requires test-scope dependency resolution, so it can
+ * inspect the fully resolved (transitive) classpath via {@link MavenProject#getArtifacts()} and add
+ * the dependencies to the model before the test-compile and test phases run.
+ */
+@Mojo(
+        name = "add-test-dependencies",
+        defaultPhase = LifecyclePhase.INITIALIZE,
+        requiresDependencyResolution = ResolutionScope.TEST,
+        threadSafe = true)
+public class AddTestDependenciesMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Parameter(property = "axelix.springTestProfiler.version", defaultValue = "0.1.2")
+    private String springTestProfilerVersion;
+
+    @Parameter(property = "axelix.addTestDependencies.skip", defaultValue = "false")
+    private boolean skip;
+
+    @Override
+    public void execute() {
+        if (skip) {
+            getLog().info("axelix:add-test-dependencies skipped (axelix.addTestDependencies.skip=true)");
+            return;
+        }
+
+        ResolvedClasspath classpath = new ResolvedClasspath(project.getArtifacts());
+        TestDependencyPlanner planner = new TestDependencyPlanner(springTestProfilerVersion);
+
+        List<Dependency> additions = planner.plan(classpath);
+        if (additions.isEmpty()) {
+            getLog().info("No test dependencies need to be added; classpath already satisfies the requirements.");
+            return;
+        }
+
+        for (Dependency dependency : additions) {
+            project.getDependencies().add(dependency);
+            getLog().info(String.format(
+                    "Added test dependency %s:%s:%s",
+                    dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion()));
+        }
+    }
+}

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojo.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojo.java
@@ -29,8 +29,12 @@ import org.apache.maven.project.MavenProject;
 
 /**
  * Injects Axelix's recommended test-scoped dependencies into the building project when they are
- * missing from the resolved test classpath. Currently it adds
- * {@code digital.pragmatech.testing:spring-test-profiler} when it is absent.
+ * missing from (or outdated on) the resolved test classpath:
+ *
+ * <ul>
+ *   <li>{@code digital.pragmatech.testing:spring-test-profiler} — added when absent;</li>
+ *   <li>{@code org.thymeleaf:thymeleaf} — added when absent or resolved below {@code thymeleafMinVersion}.</li>
+ * </ul>
  *
  * <p>The goal binds to {@code initialize} and requires test-scope dependency resolution, so it can
  * inspect the fully resolved (transitive) classpath via {@link MavenProject#getArtifacts()} and add
@@ -49,6 +53,12 @@ public class AddTestDependenciesMojo extends AbstractMojo {
     @Parameter(property = "axelix.springTestProfiler.version", defaultValue = "0.1.2")
     private String springTestProfilerVersion;
 
+    @Parameter(property = "axelix.thymeleaf.version", defaultValue = "3.1.5")
+    private String thymeleafVersion;
+
+    @Parameter(property = "axelix.thymeleaf.minVersion", defaultValue = "3.1.3")
+    private String thymeleafMinVersion;
+
     @Parameter(property = "axelix.addTestDependencies.skip", defaultValue = "false")
     private boolean skip;
 
@@ -60,7 +70,8 @@ public class AddTestDependenciesMojo extends AbstractMojo {
         }
 
         ResolvedClasspath classpath = new ResolvedClasspath(project.getArtifacts());
-        TestDependencyPlanner planner = new TestDependencyPlanner(springTestProfilerVersion);
+        TestDependencyPlanner planner =
+                new TestDependencyPlanner(springTestProfilerVersion, thymeleafVersion, thymeleafMinVersion);
 
         List<Dependency> additions = planner.plan(classpath);
         if (additions.isEmpty()) {

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojo.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/AddTestDependenciesMojo.java
@@ -17,10 +17,15 @@
  */
 package com.axelixlabs.maven.plugin;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -39,6 +44,11 @@ import org.apache.maven.project.MavenProject;
  * <p>The goal binds to {@code initialize} and requires test-scope dependency resolution, so it can
  * inspect the fully resolved (transitive) classpath via {@link MavenProject#getArtifacts()} and add
  * the dependencies to the model before the test-compile and test phases run.
+ *
+ * <p>After resolving the dependencies the goal also registers a {@code META-INF/spring.factories} on
+ * the test classpath (via a generated test resource) that wires spring-test-profiler's
+ * {@code TestExecutionListener} and diagnostic {@code ApplicationContextInitializer}, merging with any
+ * {@code spring.factories} the project already provides.
  */
 @Mojo(
         name = "add-test-dependencies",
@@ -63,7 +73,7 @@ public class AddTestDependenciesMojo extends AbstractMojo {
     private boolean skip;
 
     @Override
-    public void execute() {
+    public void execute() throws MojoExecutionException {
         if (skip) {
             getLog().info("axelix:add-test-dependencies skipped (axelix.addTestDependencies.skip=true)");
             return;
@@ -76,14 +86,53 @@ public class AddTestDependenciesMojo extends AbstractMojo {
         List<Dependency> additions = planner.plan(classpath);
         if (additions.isEmpty()) {
             getLog().info("No test dependencies need to be added; classpath already satisfies the requirements.");
-            return;
+        } else {
+            for (Dependency dependency : additions) {
+                project.getDependencies().add(dependency);
+                getLog().info(String.format(
+                        "Added test dependency %s:%s:%s",
+                        dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion()));
+            }
         }
 
-        for (Dependency dependency : additions) {
-            project.getDependencies().add(dependency);
-            getLog().info(String.format(
-                    "Added test dependency %s:%s:%s",
-                    dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion()));
+        registerSpringFactories();
+    }
+
+    /**
+     * Writes {@code META-INF/spring.factories} into a generated test-resources directory and registers
+     * it on the project so {@code process-test-resources} copies it onto the test classpath. Any
+     * {@code spring.factories} the project already declares on a test-resource root is merged in.
+     */
+    private void registerSpringFactories() throws MojoExecutionException {
+        List<File> existing = new ArrayList<>();
+        File rootDir = new File(project.getBuild().getDirectory(), "generated-test-resources/axelix");
+        for (Resource resource : project.getTestResources()) {
+            if (resource.getDirectory() == null || rootDir.getAbsolutePath().equals(resource.getDirectory())) {
+                continue;
+            }
+            File candidate = new File(resource.getDirectory(), SpringFactoriesWriter.RELATIVE_PATH);
+            if (candidate.isFile()) {
+                existing.add(candidate);
+            }
         }
+
+        File written;
+        try {
+            written = new SpringFactoriesWriter().write(rootDir, existing);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to write " + SpringFactoriesWriter.RELATIVE_PATH, e);
+        }
+
+        Resource resource = new Resource();
+        resource.setDirectory(rootDir.getAbsolutePath());
+        resource.addInclude(SpringFactoriesWriter.RELATIVE_PATH);
+        resource.setFiltering(false);
+        project.addTestResource(resource);
+
+        getLog().info(String.format(
+                "Registered Axelix %s on the test classpath at %s%s",
+                SpringFactoriesWriter.RELATIVE_PATH,
+                written,
+                existing.isEmpty() ? "" : " (merged with existing project declarations)"));
     }
 }

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/ResolvedClasspath.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/ResolvedClasspath.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+
+/**
+ * A read-only view over the resolved (transitive) dependency artifacts of a Maven project that
+ * answers questions about presence and resolved version of a given {@code groupId:artifactId}.
+ */
+final class ResolvedClasspath {
+
+    private final Set<Artifact> artifacts;
+
+    ResolvedClasspath(Set<Artifact> artifacts) {
+        this.artifacts = Objects.requireNonNull(artifacts, "artifacts");
+    }
+
+    /**
+     * Returns the resolved version of the first artifact matching {@code groupId:artifactId}, or an
+     * empty optional when no such artifact is present on the classpath.
+     */
+    Optional<String> versionOf(String groupId, String artifactId) {
+        return artifacts.stream()
+                .filter(artifact ->
+                        groupId.equals(artifact.getGroupId()) && artifactId.equals(artifact.getArtifactId()))
+                .map(Artifact::getVersion)
+                .findFirst();
+    }
+}

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/SpringFactoriesWriter.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/SpringFactoriesWriter.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Writes the {@code META-INF/spring.factories} that registers Axelix's spring-test-profiler listener
+ * and diagnostic context initializer onto a directory destined for the test classpath.
+ *
+ * <p>When the project already provides its own {@code META-INF/spring.factories} on the test
+ * classpath, those declarations are merged in (union per factory key, de-duplicated) so the existing
+ * registrations survive alongside Axelix's.
+ *
+ * <p>This class deliberately depends only on the JDK (not on the plugin runtime), so it can be
+ * exercised by plain unit tests.
+ */
+final class SpringFactoriesWriter {
+
+    static final String RELATIVE_PATH = "META-INF/spring.factories";
+
+    /**
+     * The verbatim content written when the project does not already provide a
+     * {@code META-INF/spring.factories}.
+     */
+    static final String SPRING_FACTORIES_CONTENT = "org.springframework.test.context.TestExecutionListener=\\\n"
+            + "digital.pragmatech.testing.SpringTestProfilerListener\n"
+            + "org.springframework.context.ApplicationContextInitializer=\\\n"
+            + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer\n";
+
+    /** The factory registrations Axelix contributes, in declaration order. */
+    static final Map<String, String> REQUIRED_ENTRIES = requiredEntries();
+
+    private static Map<String, String> requiredEntries() {
+        Map<String, String> entries = new LinkedHashMap<>();
+        entries.put(
+                "org.springframework.test.context.TestExecutionListener",
+                "digital.pragmatech.testing.SpringTestProfilerListener");
+        entries.put(
+                "org.springframework.context.ApplicationContextInitializer",
+                "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer");
+        return entries;
+    }
+
+    /**
+     * Writes {@code META-INF/spring.factories} under {@code rootDir}, creating parent directories as
+     * needed. When {@code existing} is empty the verbatim {@link #SPRING_FACTORIES_CONTENT} is written;
+     * otherwise the entries of the existing files are merged with Axelix's. Returns the written file.
+     */
+    File write(File rootDir, List<File> existing) throws IOException {
+        File target = new File(rootDir, RELATIVE_PATH);
+        Files.createDirectories(target.toPath().getParent());
+
+        String content = existing.isEmpty() ? SPRING_FACTORIES_CONTENT : merge(existing);
+        Files.write(target.toPath(), content.getBytes(StandardCharsets.UTF_8));
+        return target;
+    }
+
+    private static String merge(List<File> existing) throws IOException {
+        Map<String, Set<String>> entries = new LinkedHashMap<>();
+        for (File file : existing) {
+            Properties properties = new Properties();
+            try (Reader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+                properties.load(reader);
+            }
+            for (String key : properties.stringPropertyNames()) {
+                Set<String> values = entries.computeIfAbsent(key, ignored -> new LinkedHashSet<>());
+                for (String value : properties.getProperty(key).split(",")) {
+                    String trimmed = value.trim();
+                    if (!trimmed.isEmpty()) {
+                        values.add(trimmed);
+                    }
+                }
+            }
+        }
+
+        REQUIRED_ENTRIES.forEach((key, value) ->
+                entries.computeIfAbsent(key, ignored -> new LinkedHashSet<>()).add(value));
+
+        StringBuilder builder = new StringBuilder();
+        entries.forEach((key, values) ->
+                builder.append(key).append('=').append(String.join(",", values)).append('\n'));
+        return builder.toString();
+    }
+}

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/TestDependencyPlanner.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/TestDependencyPlanner.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.model.Dependency;
+
+/**
+ * Pure decision logic that, given a project's {@link ResolvedClasspath}, computes which test-scoped
+ * dependencies Axelix wants to inject. Currently it adds
+ * {@code digital.pragmatech.testing:spring-test-profiler} when it is absent from the classpath.
+ *
+ * <p>This class deliberately depends only on the Maven model (not on the plugin runtime), so the
+ * rules can be exercised by plain unit tests.
+ */
+final class TestDependencyPlanner {
+
+    static final String TEST_SCOPE = "test";
+
+    static final String SPRING_TEST_PROFILER_GROUP_ID = "digital.pragmatech.testing";
+    static final String SPRING_TEST_PROFILER_ARTIFACT_ID = "spring-test-profiler";
+
+    private final String springTestProfilerVersion;
+
+    TestDependencyPlanner(String springTestProfilerVersion) {
+        this.springTestProfilerVersion = springTestProfilerVersion;
+    }
+
+    /**
+     * Returns the test-scoped dependencies that should be added to the project for the given
+     * classpath, in declaration order. An empty list means nothing needs to be injected.
+     */
+    List<Dependency> plan(ResolvedClasspath classpath) {
+        List<Dependency> additions = new ArrayList<>();
+
+        if (classpath
+                .versionOf(SPRING_TEST_PROFILER_GROUP_ID, SPRING_TEST_PROFILER_ARTIFACT_ID)
+                .isEmpty()) {
+            additions.add(testDependency(
+                    SPRING_TEST_PROFILER_GROUP_ID, SPRING_TEST_PROFILER_ARTIFACT_ID, springTestProfilerVersion));
+        }
+
+        return additions;
+    }
+
+    private static Dependency testDependency(String groupId, String artifactId, String version) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion(version);
+        dependency.setScope(TEST_SCOPE);
+        return dependency;
+    }
+}

--- a/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/TestDependencyPlanner.java
+++ b/plugins/axelix-maven-plugin/src/main/java/com/axelixlabs/maven/plugin/TestDependencyPlanner.java
@@ -19,16 +19,22 @@ package com.axelixlabs.maven.plugin;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.maven.model.Dependency;
 
 /**
  * Pure decision logic that, given a project's {@link ResolvedClasspath}, computes which test-scoped
- * dependencies Axelix wants to inject. Currently it adds
- * {@code digital.pragmatech.testing:spring-test-profiler} when it is absent from the classpath.
+ * dependencies Axelix wants to inject:
  *
- * <p>This class deliberately depends only on the Maven model (not on the plugin runtime), so the
- * rules can be exercised by plain unit tests.
+ * <ul>
+ *   <li>{@code digital.pragmatech.testing:spring-test-profiler} when it is absent;</li>
+ *   <li>{@code org.thymeleaf:thymeleaf} when it is absent or resolved below a minimum version.</li>
+ * </ul>
+ *
+ * <p>This class deliberately depends only on the Maven model + versioning utilities (not on the
+ * plugin runtime), so the rules can be exercised by plain unit tests.
  */
 final class TestDependencyPlanner {
 
@@ -37,10 +43,17 @@ final class TestDependencyPlanner {
     static final String SPRING_TEST_PROFILER_GROUP_ID = "digital.pragmatech.testing";
     static final String SPRING_TEST_PROFILER_ARTIFACT_ID = "spring-test-profiler";
 
-    private final String springTestProfilerVersion;
+    static final String THYMELEAF_GROUP_ID = "org.thymeleaf";
+    static final String THYMELEAF_ARTIFACT_ID = "thymeleaf";
 
-    TestDependencyPlanner(String springTestProfilerVersion) {
+    private final String springTestProfilerVersion;
+    private final String thymeleafVersion;
+    private final ComparableVersion thymeleafMinVersion;
+
+    TestDependencyPlanner(String springTestProfilerVersion, String thymeleafVersion, String thymeleafMinVersion) {
         this.springTestProfilerVersion = springTestProfilerVersion;
+        this.thymeleafVersion = thymeleafVersion;
+        this.thymeleafMinVersion = new ComparableVersion(thymeleafMinVersion);
     }
 
     /**
@@ -57,7 +70,18 @@ final class TestDependencyPlanner {
                     SPRING_TEST_PROFILER_GROUP_ID, SPRING_TEST_PROFILER_ARTIFACT_ID, springTestProfilerVersion));
         }
 
+        if (thymeleafNeedsUpgrade(classpath.versionOf(THYMELEAF_GROUP_ID, THYMELEAF_ARTIFACT_ID))) {
+            additions.add(testDependency(THYMELEAF_GROUP_ID, THYMELEAF_ARTIFACT_ID, thymeleafVersion));
+        }
+
         return additions;
+    }
+
+    private boolean thymeleafNeedsUpgrade(Optional<String> resolvedVersion) {
+        if (resolvedVersion.isEmpty()) {
+            return true;
+        }
+        return new ComparableVersion(resolvedVersion.get()).compareTo(thymeleafMinVersion) < 0;
     }
 
     private static Dependency testDependency(String groupId, String artifactId, String version) {

--- a/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/ResolvedClasspathTest.java
+++ b/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/ResolvedClasspathTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResolvedClasspathTest {
+
+    @Test
+    void returnsResolvedVersionWhenArtifactPresent() {
+        // given
+        Artifact thymeleaf = artifact("org.thymeleaf", "thymeleaf", "3.1.2");
+        ResolvedClasspath subject = new ResolvedClasspath(Collections.singleton(thymeleaf));
+
+        // when
+        Optional<String> version = subject.versionOf("org.thymeleaf", "thymeleaf");
+
+        // then
+        assertThat(version).contains("3.1.2");
+    }
+
+    @Test
+    void returnsEmptyWhenArtifactAbsent() {
+        // given
+        ResolvedClasspath subject = new ResolvedClasspath(Set.of(artifact("org.thymeleaf", "thymeleaf", "3.1.2")));
+
+        // when
+        Optional<String> version = subject.versionOf("digital.pragmatech.testing", "spring-test-profiler");
+
+        // then
+        assertThat(version).isEmpty();
+    }
+
+    private static Artifact artifact(String groupId, String artifactId, String version) {
+        return new DefaultArtifact(
+                groupId, artifactId, version, "test", "jar", null, new DefaultArtifactHandler("jar"));
+    }
+}

--- a/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/SpringFactoriesWriterTest.java
+++ b/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/SpringFactoriesWriterTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpringFactoriesWriterTest {
+
+    private static final String TEST_EXECUTION_LISTENER_KEY = "org.springframework.test.context.TestExecutionListener";
+    private static final String CONTEXT_INITIALIZER_KEY = "org.springframework.context.ApplicationContextInitializer";
+    private static final String PROFILER_LISTENER = "digital.pragmatech.testing.SpringTestProfilerListener";
+    private static final String DIAGNOSTIC_INITIALIZER =
+            "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer";
+
+    private final SpringFactoriesWriter subject = new SpringFactoriesWriter();
+
+    @Nested
+    class Greenfield {
+
+        @Test
+        void writesVerbatimContentAtMetaInfPath(@TempDir Path tempDir) throws IOException {
+            // given
+            File rootDir = tempDir.toFile();
+
+            // when
+            File written = subject.write(rootDir, List.of());
+
+            // then
+            assertThat(written).isEqualTo(new File(rootDir, "META-INF/spring.factories"));
+            assertThat(contentOf(written))
+                    .isEqualTo("org.springframework.test.context.TestExecutionListener=\\\n"
+                            + "digital.pragmatech.testing.SpringTestProfilerListener\n"
+                            + "org.springframework.context.ApplicationContextInitializer=\\\n"
+                            + "digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer\n");
+        }
+
+        @Test
+        void createsParentDirectoriesWhenAbsent(@TempDir Path tempDir) throws IOException {
+            // given
+            File rootDir = tempDir.resolve("nested/generated/axelix").toFile();
+
+            // when
+            File written = subject.write(rootDir, List.of());
+
+            // then
+            assertThat(written).exists();
+        }
+    }
+
+    @Nested
+    class Merge {
+
+        @Test
+        void unionsExistingDeclarationsWithAxelixEntries(@TempDir Path tempDir) throws IOException {
+            // given
+            File existing = writeExisting(
+                    tempDir,
+                    TEST_EXECUTION_LISTENER_KEY + "=com.app.AppListener\n"
+                            + "org.springframework.boot.SpringApplicationRunListener=com.app.AppRunListener\n");
+
+            // when
+            File written = subject.write(tempDir.resolve("out").toFile(), List.of(existing));
+
+            // then
+            Properties merged = load(written);
+            assertThat(valuesOf(merged, TEST_EXECUTION_LISTENER_KEY))
+                    .containsExactlyInAnyOrder("com.app.AppListener", PROFILER_LISTENER);
+            assertThat(valuesOf(merged, CONTEXT_INITIALIZER_KEY)).containsExactly(DIAGNOSTIC_INITIALIZER);
+            assertThat(valuesOf(merged, "org.springframework.boot.SpringApplicationRunListener"))
+                    .containsExactly("com.app.AppRunListener");
+        }
+
+        @Test
+        void doesNotDuplicateAlreadyDeclaredAxelixEntry(@TempDir Path tempDir) throws IOException {
+            // given
+            File existing = writeExisting(tempDir, TEST_EXECUTION_LISTENER_KEY + "=" + PROFILER_LISTENER + "\n");
+
+            // when
+            File written = subject.write(tempDir.resolve("out").toFile(), List.of(existing));
+
+            // then
+            Properties merged = load(written);
+            assertThat(valuesOf(merged, TEST_EXECUTION_LISTENER_KEY)).containsExactly(PROFILER_LISTENER);
+        }
+
+        private File writeExisting(Path tempDir, String content) throws IOException {
+            Path file = tempDir.resolve("existing.factories");
+            Files.write(file, content.getBytes(StandardCharsets.UTF_8));
+            return file.toFile();
+        }
+    }
+
+    private static String contentOf(File file) throws IOException {
+        return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+    }
+
+    private static Properties load(File file) throws IOException {
+        Properties properties = new Properties();
+        try (Reader reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8)) {
+            properties.load(reader);
+        }
+        return properties;
+    }
+
+    private static List<String> valuesOf(Properties properties, String key) {
+        return List.of(properties.getProperty(key, "").split(","));
+    }
+}

--- a/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/TestDependencyPlannerTest.java
+++ b/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/TestDependencyPlannerTest.java
@@ -21,49 +21,151 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.model.Dependency;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TestDependencyPlannerTest {
 
     private static final String PROFILER_VERSION = "0.1.2";
+    private static final String THYMELEAF_VERSION = "3.1.5";
+    private static final String THYMELEAF_MIN_VERSION = "3.1.3";
 
-    private final TestDependencyPlanner subject = new TestDependencyPlanner(PROFILER_VERSION);
+    private final TestDependencyPlanner subject =
+            new TestDependencyPlanner(PROFILER_VERSION, THYMELEAF_VERSION, THYMELEAF_MIN_VERSION);
 
-    @Test
-    void addsProfilerWhenAbsent() {
-        // given
-        ResolvedClasspath classpath = classpathOf();
+    @Nested
+    class SpringTestProfiler {
 
-        // when
-        List<Dependency> additions = subject.plan(classpath);
+        @Test
+        void addsProfilerWhenAbsent() {
+            // given
+            ResolvedClasspath classpath = classpathOf(thymeleaf("3.1.5"));
 
-        // then
-        assertThat(additions)
-                .singleElement()
-                .satisfies(dependency -> assertTestDependency(
-                        dependency,
-                        TestDependencyPlanner.SPRING_TEST_PROFILER_GROUP_ID,
-                        TestDependencyPlanner.SPRING_TEST_PROFILER_ARTIFACT_ID,
-                        PROFILER_VERSION));
+            // when
+            List<Dependency> additions = subject.plan(classpath);
+
+            // then
+            assertThat(additions)
+                    .anySatisfy(dependency -> assertTestDependency(
+                            dependency,
+                            TestDependencyPlanner.SPRING_TEST_PROFILER_GROUP_ID,
+                            TestDependencyPlanner.SPRING_TEST_PROFILER_ARTIFACT_ID,
+                            PROFILER_VERSION));
+        }
+
+        @Test
+        void doesNotAddProfilerWhenAlreadyPresent() {
+            // given
+            ResolvedClasspath classpath = classpathOf(profiler("0.1.1"), thymeleaf("3.1.5"));
+
+            // when
+            List<Dependency> additions = subject.plan(classpath);
+
+            // then
+            assertThat(coordinatesOf(additions))
+                    .doesNotContain(TestDependencyPlanner.SPRING_TEST_PROFILER_GROUP_ID + ":"
+                            + TestDependencyPlanner.SPRING_TEST_PROFILER_ARTIFACT_ID);
+        }
     }
 
-    @Test
-    void doesNotAddProfilerWhenAlreadyPresent() {
-        // given
-        ResolvedClasspath classpath = classpathOf(profiler("0.1.1"));
+    @Nested
+    class Thymeleaf {
 
-        // when
-        List<Dependency> additions = subject.plan(classpath);
+        @Test
+        void addsThymeleafWhenAbsent() {
+            // given
+            ResolvedClasspath classpath = classpathOf(profiler("0.1.2"));
 
-        // then
-        assertThat(additions).isEmpty();
+            // when
+            List<Dependency> additions = subject.plan(classpath);
+
+            // then
+            assertThat(additions)
+                    .anySatisfy(dependency -> assertTestDependency(
+                            dependency,
+                            TestDependencyPlanner.THYMELEAF_GROUP_ID,
+                            TestDependencyPlanner.THYMELEAF_ARTIFACT_ID,
+                            THYMELEAF_VERSION));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"3.0.15", "3.1.0", "3.1.2"})
+        void addsThymeleafWhenResolvedBelowMinimum(String resolvedVersion) {
+            // given
+            ResolvedClasspath classpath = classpathOf(profiler("0.1.2"), thymeleaf(resolvedVersion));
+
+            // when
+            List<Dependency> additions = subject.plan(classpath);
+
+            // then
+            assertThat(additions)
+                    .anySatisfy(dependency -> assertTestDependency(
+                            dependency,
+                            TestDependencyPlanner.THYMELEAF_GROUP_ID,
+                            TestDependencyPlanner.THYMELEAF_ARTIFACT_ID,
+                            THYMELEAF_VERSION));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"3.1.3", "3.1.5", "3.1.6", "3.2.0"})
+        void doesNotAddThymeleafWhenResolvedAtOrAboveMinimum(String resolvedVersion) {
+            // given
+            ResolvedClasspath classpath = classpathOf(profiler("0.1.2"), thymeleaf(resolvedVersion));
+
+            // when
+            List<Dependency> additions = subject.plan(classpath);
+
+            // then
+            assertThat(coordinatesOf(additions))
+                    .doesNotContain(TestDependencyPlanner.THYMELEAF_GROUP_ID + ":"
+                            + TestDependencyPlanner.THYMELEAF_ARTIFACT_ID);
+        }
+    }
+
+    @Nested
+    class Combined {
+
+        @Test
+        void addsBothWhenProfilerAbsentAndThymeleafOutdated() {
+            // given
+            ResolvedClasspath classpath = classpathOf(thymeleaf("3.0.15"));
+
+            // when
+            List<Dependency> additions = subject.plan(classpath);
+
+            // then
+            assertThat(coordinatesOf(additions))
+                    .containsExactlyInAnyOrder(
+                            TestDependencyPlanner.SPRING_TEST_PROFILER_GROUP_ID + ":"
+                                    + TestDependencyPlanner.SPRING_TEST_PROFILER_ARTIFACT_ID,
+                            TestDependencyPlanner.THYMELEAF_GROUP_ID + ":"
+                                    + TestDependencyPlanner.THYMELEAF_ARTIFACT_ID);
+            assertThat(additions)
+                    .allSatisfy(dependency ->
+                            assertThat(dependency.getScope()).isEqualTo(TestDependencyPlanner.TEST_SCOPE));
+        }
+
+        @Test
+        void addsNothingWhenBothPresentAndUpToDate() {
+            // given
+            ResolvedClasspath classpath = classpathOf(profiler("0.1.2"), thymeleaf("3.1.6"));
+
+            // when
+            List<Dependency> additions = subject.plan(classpath);
+
+            // then
+            assertThat(additions).isEmpty();
+        }
     }
 
     private static Artifact profiler(String version) {
@@ -71,6 +173,10 @@ class TestDependencyPlannerTest {
                 TestDependencyPlanner.SPRING_TEST_PROFILER_GROUP_ID,
                 TestDependencyPlanner.SPRING_TEST_PROFILER_ARTIFACT_ID,
                 version);
+    }
+
+    private static Artifact thymeleaf(String version) {
+        return artifact(TestDependencyPlanner.THYMELEAF_GROUP_ID, TestDependencyPlanner.THYMELEAF_ARTIFACT_ID, version);
     }
 
     private static Artifact artifact(String groupId, String artifactId, String version) {
@@ -81,6 +187,12 @@ class TestDependencyPlannerTest {
     private static ResolvedClasspath classpathOf(Artifact... artifacts) {
         Set<Artifact> set = new HashSet<>(Arrays.asList(artifacts));
         return new ResolvedClasspath(set);
+    }
+
+    private static List<String> coordinatesOf(List<Dependency> dependencies) {
+        return dependencies.stream()
+                .map(dependency -> dependency.getGroupId() + ":" + dependency.getArtifactId())
+                .collect(Collectors.toList());
     }
 
     private static void assertTestDependency(Dependency dependency, String groupId, String artifactId, String version) {

--- a/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/TestDependencyPlannerTest.java
+++ b/plugins/axelix-maven-plugin/src/test/java/com/axelixlabs/maven/plugin/TestDependencyPlannerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.maven.plugin;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.model.Dependency;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestDependencyPlannerTest {
+
+    private static final String PROFILER_VERSION = "0.1.2";
+
+    private final TestDependencyPlanner subject = new TestDependencyPlanner(PROFILER_VERSION);
+
+    @Test
+    void addsProfilerWhenAbsent() {
+        // given
+        ResolvedClasspath classpath = classpathOf();
+
+        // when
+        List<Dependency> additions = subject.plan(classpath);
+
+        // then
+        assertThat(additions)
+                .singleElement()
+                .satisfies(dependency -> assertTestDependency(
+                        dependency,
+                        TestDependencyPlanner.SPRING_TEST_PROFILER_GROUP_ID,
+                        TestDependencyPlanner.SPRING_TEST_PROFILER_ARTIFACT_ID,
+                        PROFILER_VERSION));
+    }
+
+    @Test
+    void doesNotAddProfilerWhenAlreadyPresent() {
+        // given
+        ResolvedClasspath classpath = classpathOf(profiler("0.1.1"));
+
+        // when
+        List<Dependency> additions = subject.plan(classpath);
+
+        // then
+        assertThat(additions).isEmpty();
+    }
+
+    private static Artifact profiler(String version) {
+        return artifact(
+                TestDependencyPlanner.SPRING_TEST_PROFILER_GROUP_ID,
+                TestDependencyPlanner.SPRING_TEST_PROFILER_ARTIFACT_ID,
+                version);
+    }
+
+    private static Artifact artifact(String groupId, String artifactId, String version) {
+        return new DefaultArtifact(
+                groupId, artifactId, version, "test", "jar", null, new DefaultArtifactHandler("jar"));
+    }
+
+    private static ResolvedClasspath classpathOf(Artifact... artifacts) {
+        Set<Artifact> set = new HashSet<>(Arrays.asList(artifacts));
+        return new ResolvedClasspath(set);
+    }
+
+    private static void assertTestDependency(Dependency dependency, String groupId, String artifactId, String version) {
+        assertThat(dependency.getGroupId()).isEqualTo(groupId);
+        assertThat(dependency.getArtifactId()).isEqualTo(artifactId);
+        assertThat(dependency.getVersion()).isEqualTo(version);
+        assertThat(dependency.getScope()).isEqualTo(TestDependencyPlanner.TEST_SCOPE);
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,4 +10,5 @@ include(
     ":common:auth",
     ":common:domain",
     ":common:utils",
+    ":plugins:axelix-maven-plugin",
 )


### PR DESCRIPTION
## What

Extends the `axelix:add-test-dependencies` goal so that, after resolving the test dependencies, it registers a `META-INF/spring.factories` on the project's **test** classpath wiring spring-test-profiler:

```
org.springframework.test.context.TestExecutionListener=\
digital.pragmatech.testing.SpringTestProfilerListener
org.springframework.context.ApplicationContextInitializer=\
digital.pragmatech.testing.diagnostic.ContextDiagnosticApplicationInitializer
```

## Details

- New `SpringFactoriesWriter` (JDK-only, unit-testable) writes the file. Greenfield case writes the content verbatim; when the project already ships its own `spring.factories` on a test-resource root, entries are **merged** (union per factory key, de-duplicated) so existing registrations survive.
- The Mojo generates the file into `target/generated-test-resources/axelix` and registers it via `project.addTestResource(...)`. Since the goal binds to `initialize` (before `process-test-resources`), `maven-resources-plugin` copies it into `target/test-classes` for the test run.
- Runs **always** when the goal is not skipped — including the zero-additions case — since the profiler is guaranteed present on the classpath post-goal.
- Adds a `SpringFactoriesWriterTest` unit test (greenfield + merge) and extends the in-process integration test (fresh content, registration with zero additions, and a merge scenario backed by a new fixture).

## Verification

`./gradlew :plugins:axelix-maven-plugin:check` — unit + harness integration tests, spotless, PMD all green.

## Dependencies

**Depends on #1242** (`maven-plugin-override-thymeleaf`); this branch is stacked on top of it. Merge #1242 (and its parents) first — until then the diff also shows those stacked commits.

Tracking issue: GH-1222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)