### PR TITLE
test(sbs3): share one Spring context across details integration tests

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/details/AbstractDetailsSharedContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/details/AbstractDetailsSharedContextTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.details;
+
+import java.util.Properties;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.master.CommitIdPluginGitInformationProvider;
+import com.axelixlabs.axelix.sbs.spring.core.master.DefaultLibraryInformationProvider;
+import com.axelixlabs.axelix.sbs.spring.core.master.GitInformationProvider;
+import com.axelixlabs.axelix.sbs.spring.core.master.LibraryInformationProvider;
+
+/**
+ * Shared base for the {@code details} integration tests. It defines a single, unioned context
+ * configuration — the same web environment, properties, imports and shared beans — so every
+ * subclass resolves an identical context cache key and the whole package shares one cached
+ * {@link org.springframework.context.ApplicationContext} instead of each test building its own.
+ *
+ * <p>The context uses {@link SpringBootTest.WebEnvironment#RANDOM_PORT} because the endpoint test
+ * relies on a real servlet web server (the component-scanned {@code TestRestTemplateBuilder} learns
+ * the port from a {@code ServletWebServerInitializedEvent}). The assembler test runs unchanged in
+ * this same context.
+ *
+ * @author Mikhail Polivakha
+ * @author Nikita Kirillov
+ * @author Artemiy Degtyarev
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {"management.endpoints.web.exposure.include=axelix-details"})
+@Import({
+    AbstractDetailsSharedContextTest.SharedConfig.class,
+    AxelixDetailsEndpoint.class,
+    JwtAuthTestConfiguration.class
+})
+abstract class AbstractDetailsSharedContextTest {
+
+    @TestConfiguration
+    static class SharedConfig {
+
+        @Bean
+        @Primary
+        public BuildProperties buildProperties() {
+            Properties props = new Properties();
+            props.setProperty("group", "com.axelixlabs.axelix");
+            props.setProperty("artifact", "axelix-sbs");
+            props.setProperty("version", "1.0.0-SNAPSHOT");
+            props.setProperty("name", "test-application");
+            props.setProperty("time", "2025-10-30T09:10:13.428Z");
+
+            return new BuildProperties(props);
+        }
+
+        @Bean
+        public GitInformationProvider gitInformationProvider(GitProperties gitProperties) {
+            return new CommitIdPluginGitInformationProvider(gitProperties);
+        }
+
+        @Bean
+        public LibraryInformationProvider libraryInformationProvider() {
+            return new DefaultLibraryInformationProvider();
+        }
+
+        @Bean
+        public ServiceDetailsAssembler serviceDetailsAssembler(
+                GitInformationProvider gitInformationProvider,
+                ObjectProvider<BuildProperties> providerBuildProperties,
+                LibraryInformationProvider libraryInformationProvider) {
+            return new DefaultServiceDetailsAssembler(
+                    gitInformationProvider, providerBuildProperties, libraryInformationProvider);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/details/AxelixDetailsEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/details/AxelixDetailsEndpointTest.java
@@ -21,15 +21,11 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootVersion;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.SpringVersion;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
-import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
-import com.axelixlabs.axelix.sbs.spring.core.details.DefaultServiceDetailsAssemblerTest.DefaultServiceDetailsAssemblerTestConfig;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
 
@@ -42,12 +38,9 @@ import static org.assertj.core.data.MapEntry.entry;
  *
  * @since 30.10.2025
  * @author Nikita Kirillov
+ * @author Artemiy Degtyarev
  */
-@SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        properties = {"management.endpoints.web.exposure.include=axelix-details"})
-@Import({DefaultServiceDetailsAssemblerTestConfig.class, AxelixDetailsEndpoint.class, JwtAuthTestConfiguration.class})
-class AxelixDetailsEndpointTest {
+class AxelixDetailsEndpointTest extends AbstractDetailsSharedContextTest {
 
     @Autowired
     private TestRestTemplateBuilder restTemplate;

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/details/DefaultServiceDetailsAssemblerTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/details/DefaultServiceDetailsAssemblerTest.java
@@ -17,21 +17,11 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.details;
 
-import java.util.Properties;
-
 import kotlin.KotlinVersion;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootVersion;
-import org.springframework.boot.info.BuildProperties;
-import org.springframework.boot.info.GitProperties;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Primary;
 import org.springframework.core.SpringVersion;
 
 import com.axelixlabs.axelix.common.api.InstanceDetails;
@@ -40,10 +30,6 @@ import com.axelixlabs.axelix.common.api.InstanceDetails.GitDetails;
 import com.axelixlabs.axelix.common.api.InstanceDetails.OsDetails;
 import com.axelixlabs.axelix.common.api.InstanceDetails.RuntimeDetails;
 import com.axelixlabs.axelix.common.api.InstanceDetails.SpringDetails;
-import com.axelixlabs.axelix.sbs.spring.core.master.CommitIdPluginGitInformationProvider;
-import com.axelixlabs.axelix.sbs.spring.core.master.DefaultLibraryInformationProvider;
-import com.axelixlabs.axelix.sbs.spring.core.master.GitInformationProvider;
-import com.axelixlabs.axelix.sbs.spring.core.master.LibraryInformationProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,10 +38,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @since 30.10.2025
  * @author Nikita Kirillov
+ * @author Artemiy Degtyarev
  */
-@SpringBootTest
-@Import(DefaultServiceDetailsAssemblerTest.DefaultServiceDetailsAssemblerTestConfig.class)
-class DefaultServiceDetailsAssemblerTest {
+class DefaultServiceDetailsAssemblerTest extends AbstractDetailsSharedContextTest {
 
     @Autowired
     private ServiceDetailsAssembler serviceDetailsAssembler;
@@ -97,41 +82,5 @@ class DefaultServiceDetailsAssemblerTest {
         assertThat(os.getName()).isNotBlank();
         assertThat(os.getVersion()).isNotBlank();
         assertThat(os.getArch()).isNotBlank();
-    }
-
-    @TestConfiguration
-    static class DefaultServiceDetailsAssemblerTestConfig {
-
-        @Bean
-        @Primary
-        public BuildProperties buildProperties() {
-            Properties props = new Properties();
-            props.setProperty("group", "com.axelixlabs.axelix");
-            props.setProperty("artifact", "axelix-sbs");
-            props.setProperty("version", "1.0.0-SNAPSHOT");
-            props.setProperty("name", "test-application");
-            props.setProperty("time", "2025-10-30T09:10:13.428Z");
-
-            return new BuildProperties(props);
-        }
-
-        @Bean
-        public GitInformationProvider gitInformationProvider(GitProperties gitProperties) {
-            return new CommitIdPluginGitInformationProvider(gitProperties);
-        }
-
-        @Bean
-        public LibraryInformationProvider libraryInformationProvider() {
-            return new DefaultLibraryInformationProvider();
-        }
-
-        @Bean
-        public ServiceDetailsAssembler serviceDetailsAssembler(
-                GitInformationProvider gitInformationProvider,
-                ObjectProvider<BuildProperties> providerBuildProperties,
-                LibraryInformationProvider libraryInformationProvider) {
-            return new DefaultServiceDetailsAssembler(
-                    gitInformationProvider, providerBuildProperties, libraryInformationProvider);
-        }
     }
 }


### PR DESCRIPTION
## What

Refactors the sbs3 `details` integration tests so the whole package shares a single cached Spring `ApplicationContext` instead of each test class building its own — continuing the shared-context effort already applied to `env` (#1228), `configprops` (#1233), `master` (#1230), and `beans`.

## How

- Introduces `AbstractDetailsSharedContextTest` as the shared base. It owns the **union** of both tests' context configuration:
  - `@SpringBootTest(webEnvironment = RANDOM_PORT, properties = {"management.endpoints.web.exposure.include=axelix-details"})`
  - `@Import({SharedConfig, AxelixDetailsEndpoint, JwtAuthTestConfiguration})`
  - a nested `@TestConfiguration SharedConfig` holding the shared `BuildProperties` / `GitInformationProvider` / `LibraryInformationProvider` / `ServiceDetailsAssembler` beans.
- The parent owns **all** configuration — the child's former `DefaultServiceDetailsAssemblerTestConfig` was moved up into the base, so the parent has no reference to its children.
- `DefaultServiceDetailsAssemblerTest` and `AxelixDetailsEndpointTest` now only `extends AbstractDetailsSharedContextTest` and autowire what they need.

`RANDOM_PORT` is required because the endpoint test's component-scanned `TestRestTemplateBuilder` captures the port from a `ServletWebServerInitializedEvent` (needs a real servlet web server); the assembler test runs unchanged in that same context.

## Verification

- `./gradlew :sbs:axelix-spring-boot-3-starter:build` — green (incl. Spotless + PMD).
- The `spring-test-profiler` report confirms a **single** context cache entry for the package, shared by both `DefaultServiceDetailsAssemblerTest` and `AxelixDetailsEndpointTest` (1 cache miss, then hits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)