### PR TITLE
GH-1258 Added support for multiple instances for a single logger when updating levels

### DIFF
--- a/common/api/src/main/java/com/axelixlabs/axelix/common/api/loggers/LogLevelChangeRequest.java
+++ b/common/api/src/main/java/com/axelixlabs/axelix/common/api/loggers/LogLevelChangeRequest.java
@@ -38,7 +38,7 @@ public class LogLevelChangeRequest {
      * Creates a new LogLevelChangeRequest.
      *
      * @param configuredLevel The new logging level to apply.
-     * @param ttlSeconds      Optional duration in minutes before reverting to the original level.
+     * @param ttlSeconds      Optional duration in seconds before reverting to the original level.
      *                        If {@code null}, the change is permanent.
      */
     @JsonCreator

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/error/handle/ApiErrorCodes.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/error/handle/ApiErrorCodes.java
@@ -37,7 +37,8 @@ public enum ApiErrorCodes {
     // Bad request related error codes
     BAD_REQUEST("BAD_REQUEST"),
     INSTANCE_NOT_FOUND("INSTANCE_NOT_FOUND"),
-    INVALID_CRON_EXPRESSION("INVALID_CRON_EXPRESSION");
+    INVALID_CRON_EXPRESSION("INVALID_CRON_EXPRESSION"),
+    PARTIALLY_UPDATED("PARTIALLY_UPDATED");
 
     /**
      * actual code that is sent from the master backend.

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/ApiPaths.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/ApiPaths.java
@@ -151,6 +151,11 @@ public final class ApiPaths {
         public static final String LOGGER_NAME = "/loggers/{instanceId}/logger/{loggerName}";
 
         /**
+         * Endpoint to change a specific logger by name across instances.
+         */
+        public static final String LOGGER_BULK_CHANGE = "/loggers/logger";
+
+        /**
          * Endpoint to retrieve a specific logger group by name from an instance.
          */
         public static final String GROUP_NAME = "/loggers/{instanceId}/group/{groupName}";

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApi.java
@@ -20,16 +20,13 @@ package com.axelixlabs.axelix.master.api.external.endpoint;
 import java.util.List;
 import java.util.Map;
 
-import com.axelixlabs.axelix.master.api.error.handle.ApiErrorCodes;
-import com.axelixlabs.axelix.master.service.transport.BadRequestException;
-import com.axelixlabs.axelix.master.service.transport.PartiallyUpdatedException;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
 import org.jspecify.annotations.Nullable;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -47,6 +44,7 @@ import com.axelixlabs.axelix.common.domain.http.DefaultHttpPayload;
 import com.axelixlabs.axelix.common.domain.http.HttpPayload;
 import com.axelixlabs.axelix.common.domain.http.NoHttpPayload;
 import com.axelixlabs.axelix.master.api.error.SimpleApiError;
+import com.axelixlabs.axelix.master.api.error.handle.ApiErrorCodes;
 import com.axelixlabs.axelix.master.api.external.ApiPaths;
 import com.axelixlabs.axelix.master.api.external.ExternalApiRestController;
 import com.axelixlabs.axelix.master.api.external.request.loggers.LogLevelLoggerBulkChangeRequest;
@@ -56,7 +54,9 @@ import com.axelixlabs.axelix.master.api.external.swagger.DefaultApiResponse;
 import com.axelixlabs.axelix.master.api.external.swagger.InstanceIdParameter;
 import com.axelixlabs.axelix.master.domain.InstanceId;
 import com.axelixlabs.axelix.master.service.serde.JacksonMessageSerializationStrategy;
+import com.axelixlabs.axelix.master.service.transport.BadRequestException;
 import com.axelixlabs.axelix.master.service.transport.EndpointInvoker;
+import com.axelixlabs.axelix.master.service.transport.PartiallyUpdatedException;
 
 /**
  * The API for managing loggers.
@@ -136,7 +136,7 @@ public class LoggersApi {
             summary = "Change the logging level for a given logger by its name across instances.",
             description =
                     "Suggested logging levels that the user can select to configure the logger: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE")
-    @ApiResponse(description = "OK", responseCode = "200")
+    @ApiResponse(description = "No Content", responseCode = "204")
     @PostMapping(path = ApiPaths.LoggersApi.LOGGER_BULK_CHANGE)
     public ResponseEntity<?> setLoggingLevelByLoggerName(@RequestBody LogLevelLoggerBulkChangeRequest request) {
 
@@ -146,15 +146,16 @@ public class LoggersApi {
 
         HttpPayload payload = HttpPayload.json(
                 Map.of("name", request.loggerName()),
-                jacksonMessageSerializationStrategy.serialize(new LogLevelChangeRequest(request.configuredLevel(), request.ttlMinutes())));
+                jacksonMessageSerializationStrategy.serialize(
+                        new LogLevelChangeRequest(request.configuredLevel(), request.ttlSeconds())));
 
         try {
             endpointInvoker.invokeForInstances(request.instanceIds(), ActuatorEndpoints.SET_ONE_LOGGER, payload);
             return ResponseEntity.noContent().build();
         } catch (PartiallyUpdatedException e) {
             return ResponseEntity.badRequest()
-                .body(new SimpleApiError(
-                    ApiErrorCodes.PARTIALLY_UPDATED.getErrorCode(), HttpStatus.BAD_REQUEST.value()));
+                    .body(new SimpleApiError(
+                            ApiErrorCodes.PARTIALLY_UPDATED.getErrorCode(), HttpStatus.BAD_REQUEST.value()));
         } catch (BadRequestException e) {
             return ResponseEntity.badRequest().build();
         }
@@ -194,7 +195,10 @@ public class LoggersApi {
         return ResponseEntity.noContent().build();
     }
 
-    private boolean isInvalid(@Nullable List<String> instanceIds, @Nullable String name, @Nullable String configuredLevel) {
-        return CollectionUtils.isEmpty(instanceIds) || !StringUtils.hasText(name) || !StringUtils.hasText(configuredLevel);
+    private boolean isInvalid(
+            @Nullable List<String> instanceIds, @Nullable String name, @Nullable String configuredLevel) {
+        return CollectionUtils.isEmpty(instanceIds)
+                || !StringUtils.hasText(name)
+                || !StringUtils.hasText(configuredLevel);
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApi.java
@@ -54,7 +54,6 @@ import com.axelixlabs.axelix.master.api.external.swagger.DefaultApiResponse;
 import com.axelixlabs.axelix.master.api.external.swagger.InstanceIdParameter;
 import com.axelixlabs.axelix.master.domain.InstanceId;
 import com.axelixlabs.axelix.master.service.serde.JacksonMessageSerializationStrategy;
-import com.axelixlabs.axelix.master.service.transport.BadRequestException;
 import com.axelixlabs.axelix.master.service.transport.EndpointInvoker;
 import com.axelixlabs.axelix.master.service.transport.PartiallyUpdatedException;
 
@@ -150,14 +149,12 @@ public class LoggersApi {
                         new LogLevelChangeRequest(request.configuredLevel(), request.ttlSeconds())));
 
         try {
-            endpointInvoker.invokeForInstances(request.instanceIds(), ActuatorEndpoints.SET_ONE_LOGGER, payload);
+            endpointInvoker.invokeNoValueForInstances(request.instanceIds(), ActuatorEndpoints.SET_ONE_LOGGER, payload);
             return ResponseEntity.noContent().build();
         } catch (PartiallyUpdatedException e) {
             return ResponseEntity.badRequest()
                     .body(new SimpleApiError(
                             ApiErrorCodes.PARTIALLY_UPDATED.getErrorCode(), HttpStatus.BAD_REQUEST.value()));
-        } catch (BadRequestException e) {
-            return ResponseEntity.badRequest().build();
         }
     }
 

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApi.java
@@ -17,16 +17,24 @@
  */
 package com.axelixlabs.axelix.master.api.external.endpoint;
 
+import java.util.List;
 import java.util.Map;
 
+import com.axelixlabs.axelix.master.api.error.handle.ApiErrorCodes;
+import com.axelixlabs.axelix.master.service.transport.BadRequestException;
+import com.axelixlabs.axelix.master.service.transport.PartiallyUpdatedException;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,8 +46,10 @@ import com.axelixlabs.axelix.common.domain.ActuatorEndpoints;
 import com.axelixlabs.axelix.common.domain.http.DefaultHttpPayload;
 import com.axelixlabs.axelix.common.domain.http.HttpPayload;
 import com.axelixlabs.axelix.common.domain.http.NoHttpPayload;
+import com.axelixlabs.axelix.master.api.error.SimpleApiError;
 import com.axelixlabs.axelix.master.api.external.ApiPaths;
 import com.axelixlabs.axelix.master.api.external.ExternalApiRestController;
+import com.axelixlabs.axelix.master.api.external.request.loggers.LogLevelLoggerBulkChangeRequest;
 import com.axelixlabs.axelix.master.api.external.response.loggers.GroupProfileResponse;
 import com.axelixlabs.axelix.master.api.external.response.loggers.LoggerProfileResponse;
 import com.axelixlabs.axelix.master.api.external.swagger.DefaultApiResponse;
@@ -123,21 +133,31 @@ public class LoggersApi {
     }
 
     @DefaultApiResponse(
-            summary = "Change the logging level for a given logger by its name.",
+            summary = "Change the logging level for a given logger by its name across instances.",
             description =
                     "Suggested logging levels that the user can select to configure the logger: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE")
     @ApiResponse(description = "OK", responseCode = "200")
-    @InstanceIdParameter
-    @Parameter(name = "loggerName", description = "The name of the logger to find", required = true)
-    @PostMapping(path = ApiPaths.LoggersApi.LOGGER_NAME)
-    public void setLoggingLevelByLoggerName(
-            @PathVariable("instanceId") String instanceId,
-            @PathVariable("loggerName") String loggerName,
-            @RequestBody LogLevelChangeRequest request) {
+    @PostMapping(path = ApiPaths.LoggersApi.LOGGER_BULK_CHANGE)
+    public ResponseEntity<?> setLoggingLevelByLoggerName(@RequestBody LogLevelLoggerBulkChangeRequest request) {
 
-        HttpPayload payload =
-                HttpPayload.json(Map.of("name", loggerName), jacksonMessageSerializationStrategy.serialize(request));
-        endpointInvoker.invokeNoValue(InstanceId.of(instanceId), ActuatorEndpoints.SET_ONE_LOGGER, payload);
+        if (request == null || isInvalid(request.instanceIds(), request.loggerName(), request.configuredLevel())) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        HttpPayload payload = HttpPayload.json(
+                Map.of("name", request.loggerName()),
+                jacksonMessageSerializationStrategy.serialize(new LogLevelChangeRequest(request.configuredLevel(), request.ttlMinutes())));
+
+        try {
+            endpointInvoker.invokeForInstances(request.instanceIds(), ActuatorEndpoints.SET_ONE_LOGGER, payload);
+            return ResponseEntity.noContent().build();
+        } catch (PartiallyUpdatedException e) {
+            return ResponseEntity.badRequest()
+                .body(new SimpleApiError(
+                    ApiErrorCodes.PARTIALLY_UPDATED.getErrorCode(), HttpStatus.BAD_REQUEST.value()));
+        } catch (BadRequestException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @DefaultApiResponse(
@@ -172,5 +192,9 @@ public class LoggersApi {
                 new DefaultHttpPayload(Map.of("name", loggerName)));
 
         return ResponseEntity.noContent().build();
+    }
+
+    private boolean isInvalid(@Nullable List<String> instanceIds, @Nullable String name, @Nullable String configuredLevel) {
+        return CollectionUtils.isEmpty(instanceIds) || !StringUtils.hasText(name) || !StringUtils.hasText(configuredLevel);
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/request/loggers/LogLevelLoggerBulkChangeRequest.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/request/loggers/LogLevelLoggerBulkChangeRequest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.api.external.request.loggers;
+
+import java.util.List;
+
+/**
+ * Request to change the logging level of a logger across several instances.
+ *
+ * @param instanceIds     the instances on which to apply the new logging level
+ * @param loggerName      the logger name to update
+ * @param ttlMinutes      optional time-to-live for the logging level override, in minutes
+ * @param configuredLevel the new logging level to apply
+ *
+ * @author Sergey Cherkasov
+ */
+public record LogLevelLoggerBulkChangeRequest(
+        List<String> instanceIds, String loggerName, Long ttlMinutes, String configuredLevel) {}

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/request/loggers/LogLevelLoggerBulkChangeRequest.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/request/loggers/LogLevelLoggerBulkChangeRequest.java
@@ -19,15 +19,21 @@ package com.axelixlabs.axelix.master.api.external.request.loggers;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Request to change the logging level of a logger across several instances.
  *
  * @param instanceIds     the instances on which to apply the new logging level
  * @param loggerName      the logger name to update
- * @param ttlMinutes      optional time-to-live for the logging level override, in minutes
+ * @param ttlSeconds      Optional duration in seconds before reverting to the original level.
+ *                        If {@code null}, the change is permanent.
  * @param configuredLevel the new logging level to apply
  *
  * @author Sergey Cherkasov
  */
 public record LogLevelLoggerBulkChangeRequest(
-        List<String> instanceIds, String loggerName, Long ttlMinutes, String configuredLevel) {}
+        List<String> instanceIds,
+        String loggerName,
+        @Nullable Long ttlSeconds,
+        String configuredLevel) {}

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/transport/DefaultEndpointInvoker.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/transport/DefaultEndpointInvoker.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import com.axelixlabs.axelix.common.domain.ActuatorEndpoint;
 import com.axelixlabs.axelix.common.domain.http.HttpPayload;
@@ -37,6 +38,7 @@ import com.axelixlabs.axelix.master.exception.InstanceNotFoundException;
  * Default {@link EndpointInvoker} that delegates the actual query execution to selected {@link EndpointProber}.
  *
  * @author Mikhail Polivakha
+ * @author Sergey Cherkasov
  */
 @Component
 public class DefaultEndpointInvoker implements EndpointInvoker {
@@ -69,6 +71,36 @@ public class DefaultEndpointInvoker implements EndpointInvoker {
     public void invokeNoValue(InstanceId instanceId, ActuatorEndpoint endpoint, HttpPayload httpPayload)
             throws EndpointInvocationException, BadRequestException, InstanceNotFoundException {
         getEndpointProber(endpoint).invoke(instanceId, httpPayload);
+    }
+
+    @Override
+    public void invokeForInstances(List<String> instanceIds, ActuatorEndpoint endpoint, HttpPayload payload)
+            throws PartiallyUpdatedException, BadRequestException {
+
+        List<String> uniqueInstanceIds = instanceIds.stream()
+            .filter(StringUtils::hasText)
+            .distinct()
+            .toList();
+
+        EndpointProber<?> prober = getEndpointProber(endpoint);
+
+        int failures = 0;
+
+        for (String instanceId : uniqueInstanceIds) {
+            try {
+                prober.invoke(InstanceId.of(instanceId), payload);
+            } catch (EndpointInvocationException | BadRequestException | InstanceNotFoundException e) {
+                failures++;
+            }
+        }
+
+        int instanceIdsSize = uniqueInstanceIds.size();
+
+        if (failures > 0 && failures < instanceIdsSize) {
+            throw new PartiallyUpdatedException("Some instances failed to update");
+        } else if (failures == instanceIdsSize) {
+            throw new BadRequestException("All instances failed to update");
+        }
     }
 
     @NonNull

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/transport/DefaultEndpointInvoker.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/transport/DefaultEndpointInvoker.java
@@ -74,8 +74,8 @@ public class DefaultEndpointInvoker implements EndpointInvoker {
     }
 
     @Override
-    public void invokeForInstances(List<String> instanceIds, ActuatorEndpoint endpoint, HttpPayload payload)
-            throws PartiallyUpdatedException, BadRequestException {
+    public void invokeNoValueForInstances(List<String> instanceIds, ActuatorEndpoint endpoint, HttpPayload payload)
+            throws PartiallyUpdatedException {
 
         List<String> uniqueInstanceIds =
                 instanceIds.stream().filter(StringUtils::hasText).distinct().toList();
@@ -92,12 +92,8 @@ public class DefaultEndpointInvoker implements EndpointInvoker {
             }
         }
 
-        int instanceIdsSize = uniqueInstanceIds.size();
-
-        if (failures > 0 && failures < instanceIdsSize) {
+        if (failures > 0) {
             throw new PartiallyUpdatedException("Some instances failed to update");
-        } else if (failures == instanceIdsSize) {
-            throw new BadRequestException("All instances failed to update");
         }
     }
 

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/transport/DefaultEndpointInvoker.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/transport/DefaultEndpointInvoker.java
@@ -77,10 +77,8 @@ public class DefaultEndpointInvoker implements EndpointInvoker {
     public void invokeForInstances(List<String> instanceIds, ActuatorEndpoint endpoint, HttpPayload payload)
             throws PartiallyUpdatedException, BadRequestException {
 
-        List<String> uniqueInstanceIds = instanceIds.stream()
-            .filter(StringUtils::hasText)
-            .distinct()
-            .toList();
+        List<String> uniqueInstanceIds =
+                instanceIds.stream().filter(StringUtils::hasText).distinct().toList();
 
         EndpointProber<?> prober = getEndpointProber(endpoint);
 

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/transport/EndpointInvoker.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/transport/EndpointInvoker.java
@@ -23,11 +23,14 @@ import com.axelixlabs.axelix.master.domain.Instance;
 import com.axelixlabs.axelix.master.domain.InstanceId;
 import com.axelixlabs.axelix.master.exception.InstanceNotFoundException;
 
+import java.util.List;
+
 /**
  * Abstraction that is capable to invoke the Axelix endpoint on the given instance, given the particular
  * payload.
  *
  * @author Mikhail Polivakha
+ * @author Sergey Cherkasov
  */
 public interface EndpointInvoker {
 
@@ -63,4 +66,17 @@ public interface EndpointInvoker {
      */
     void invokeNoValue(InstanceId instanceId, ActuatorEndpoint endpoint, HttpPayload httpPayload)
             throws EndpointInvocationException, BadRequestException, InstanceNotFoundException;
+
+    /**
+     * Invoke endpoint on multiple instances with the given payload. Blank and duplicated instance IDs are ignored.
+     *
+     * @param instanceIds the IDs of the {@link Instance}s on which the endpoint is supposed to be invoked.
+     * @param endpoint the endpoint that should be invoked.
+     * @param payload the HTTP payload (headers, body etc.) to be sent.
+     *
+     * @throws PartiallyUpdatedException in case the invocation failed only for some of the requested instances.
+     * @throws BadRequestException in case the invocation failed for all requested instances.
+     */
+    void invokeForInstances(List<String> instanceIds, ActuatorEndpoint endpoint, HttpPayload payload)
+        throws PartiallyUpdatedException, BadRequestException;
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/transport/EndpointInvoker.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/transport/EndpointInvoker.java
@@ -17,13 +17,13 @@
  */
 package com.axelixlabs.axelix.master.service.transport;
 
+import java.util.List;
+
 import com.axelixlabs.axelix.common.domain.ActuatorEndpoint;
 import com.axelixlabs.axelix.common.domain.http.HttpPayload;
 import com.axelixlabs.axelix.master.domain.Instance;
 import com.axelixlabs.axelix.master.domain.InstanceId;
 import com.axelixlabs.axelix.master.exception.InstanceNotFoundException;
-
-import java.util.List;
 
 /**
  * Abstraction that is capable to invoke the Axelix endpoint on the given instance, given the particular
@@ -78,5 +78,5 @@ public interface EndpointInvoker {
      * @throws BadRequestException in case the invocation failed for all requested instances.
      */
     void invokeForInstances(List<String> instanceIds, ActuatorEndpoint endpoint, HttpPayload payload)
-        throws PartiallyUpdatedException, BadRequestException;
+            throws PartiallyUpdatedException, BadRequestException;
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/transport/EndpointInvoker.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/transport/EndpointInvoker.java
@@ -74,9 +74,8 @@ public interface EndpointInvoker {
      * @param endpoint the endpoint that should be invoked.
      * @param payload the HTTP payload (headers, body etc.) to be sent.
      *
-     * @throws PartiallyUpdatedException in case the invocation failed only for some of the requested instances.
-     * @throws BadRequestException in case the invocation failed for all requested instances.
+     * @throws PartiallyUpdatedException in case the invocation failed for some of the requested instances (potentially for everything).
      */
-    void invokeForInstances(List<String> instanceIds, ActuatorEndpoint endpoint, HttpPayload payload)
-            throws PartiallyUpdatedException, BadRequestException;
+    void invokeNoValueForInstances(List<String> instanceIds, ActuatorEndpoint endpoint, HttpPayload payload)
+            throws PartiallyUpdatedException;
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/transport/PartiallyUpdatedException.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/transport/PartiallyUpdatedException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.service.transport;
+
+/**
+ * Indicates that a bulk endpoint invocation completed only for a subset of requested instances.
+ *
+ * @author Sergey Cherkasov
+ */
+public class PartiallyUpdatedException extends RuntimeException {
+
+    public PartiallyUpdatedException(String message) {
+        super(message);
+    }
+}

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/BeansApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/BeansApiTest.java
@@ -270,7 +270,8 @@ class BeansApiTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @AfterEach

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/ConditionsApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/ConditionsApiTest.java
@@ -214,7 +214,8 @@ class ConditionsApiTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @AfterEach

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/ConfigPropsApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/ConfigPropsApiTest.java
@@ -303,7 +303,8 @@ public class ConfigPropsApiTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @AfterEach

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/EnvironmentApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/EnvironmentApiTest.java
@@ -258,7 +258,8 @@ class EnvironmentApiTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @AfterEach

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/GcLogFileApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/GcLogFileApiTest.java
@@ -131,7 +131,8 @@ class GcLogFileApiTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @AfterEach

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/HeapDumpApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/HeapDumpApiTest.java
@@ -102,7 +102,8 @@ class HeapDumpApiTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @AfterEach

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiAllLoggersTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiAllLoggersTest.java
@@ -205,7 +205,7 @@ public class LoggersApiAllLoggersTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(
+        registry.reload(TestObjectFactory.createTestInstance(
                 activeInstanceId, mockWebServer.url(activeInstanceId).toString()));
     }
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiGroupByNameTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiGroupByNameTest.java
@@ -116,7 +116,7 @@ public class LoggersApiGroupByNameTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(
+        registry.reload(TestObjectFactory.createTestInstance(
                 activeInstanceId, mockWebServer.url(activeInstanceId).toString()));
     }
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiLoggerByNameTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiLoggerByNameTest.java
@@ -117,7 +117,7 @@ public class LoggersApiLoggerByNameTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(
+        registry.reload(TestObjectFactory.createTestInstance(
                 activeInstanceId, mockWebServer.url(activeInstanceId).toString()));
     }
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiManagementLoggingLevelTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiManagementLoggingLevelTest.java
@@ -122,9 +122,9 @@ public class LoggersApiManagementLoggingLevelTest {
 
         registry.reload(TestObjectFactory.withUrl(
                 activeInstanceId, mockWebServer.url(activeInstanceId).toString()));
-        registry.register(TestObjectFactory.withUrl(
+        registry.reload(TestObjectFactory.withUrl(
                 siblingInstanceId, mockWebServer.url(siblingInstanceId).toString()));
-        registry.register(TestObjectFactory.withUrl(
+        registry.reload(TestObjectFactory.withUrl(
                 failingInstanceId, mockWebServer.url(failingInstanceId).toString()));
     }
 
@@ -133,6 +133,25 @@ public class LoggersApiManagementLoggingLevelTest {
         registry.deRegister(InstanceId.of(activeInstanceId));
         registry.deRegister(InstanceId.of(siblingInstanceId));
         registry.deRegister(InstanceId.of(failingInstanceId));
+    }
+
+    @Test
+    void shouldSetLoggingLevelByGroupName() {
+        String groupName = "groupName";
+        LogLevelChangeRequest requestBody = new LogLevelChangeRequest("INFO", null);
+
+        // when.
+        ResponseEntity<String> body = restTemplate
+                .asViewer()
+                .postForEntity(
+                        "/api/external/loggers/{instanceId}/group/{groupName}",
+                        requestBody,
+                        String.class,
+                        activeInstanceId,
+                        groupName);
+
+        // then.
+        assertThat(body.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
     @Test
@@ -215,12 +234,11 @@ public class LoggersApiManagementLoggingLevelTest {
     }
 
     @Test
-    @DisplayName("Should return 500 on EndpointInvocationError")
-    void shouldReturnInternalServerError_OnLoggerName() {
-        String instanceId = UUID.randomUUID().toString();
-        String loggerName = "logger.name";
-        LogLevelChangeRequest requestBody = new LogLevelChangeRequest("DEBUG", null);
-        registry.reload(createInstance(instanceId));
+    @DisplayName("Should return 400 on EndpointInvocationError")
+    void shouldReturnBadRequest_OnLoggerBulkChangeEndpointInvocationError() {
+        // given.
+        LogLevelLoggerBulkChangeRequest requestBody =
+                new LogLevelLoggerBulkChangeRequest(List.of(failingInstanceId), "logger.name", null, "DEBUG");
 
         // when.
         ResponseEntity<String> response =
@@ -344,7 +362,7 @@ public class LoggersApiManagementLoggingLevelTest {
 
     @ProtectedEndpointTests(method = HttpMethod.POST, path = "/api/external/loggers/logger", jsonBody = """
                     {
-                      "instanceIds": ["00000000-0000-0000-0000-000000000001"],
+                      "instanceIds": ["00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000001"],
                       "loggerName": "logger.name",
                       "configuredLevel": "DEBUG"
                     }

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiManagementLoggingLevelTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiManagementLoggingLevelTest.java
@@ -136,25 +136,6 @@ public class LoggersApiManagementLoggingLevelTest {
     }
 
     @Test
-    void shouldSetLoggingLevelByGroupName() {
-        String groupName = "groupName";
-        LogLevelChangeRequest requestBody = new LogLevelChangeRequest("INFO", null);
-
-        // when.
-        ResponseEntity<String> body = restTemplate
-                .asViewer()
-                .postForEntity(
-                        "/api/external/loggers/{instanceId}/group/{groupName}",
-                        requestBody,
-                        String.class,
-                        activeInstanceId,
-                        groupName);
-
-        // then.
-        assertThat(body.getStatusCode()).isEqualTo(HttpStatus.OK);
-    }
-
-    @Test
     void shouldSetLoggingLevelByLoggerNameAcrossInstances() {
         // given.
         LogLevelLoggerBulkChangeRequest requestBody = new LogLevelLoggerBulkChangeRequest(
@@ -310,25 +291,6 @@ public class LoggersApiManagementLoggingLevelTest {
     }
 
     @Test
-    void shouldReturnBadRequestForUnregisteredInstance_OnResetLoggingLevelByLoggerName() {
-        String instanceId = "unregistered-logger-instance";
-        String loggerName = "reset.logger.name";
-
-        // when.
-        ResponseEntity<String> response = restTemplate
-                .asViewer()
-                .postForEntity(
-                        "/api/external/loggers/{instanceId}/logger/{loggerName}/reset",
-                        null,
-                        String.class,
-                        instanceId,
-                        loggerName);
-
-        // then.
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-    }
-
-    @Test
     void shouldReturnBadRequest_WhenInstanceIdsAreEmpty() {
         // given.
         LogLevelLoggerBulkChangeRequest requestBody =
@@ -391,6 +353,6 @@ public class LoggersApiManagementLoggingLevelTest {
 
     @ProtectedEndpointTests(
             method = HttpMethod.POST,
-            path = "/api/external/loggers/00000000-0000-0000-0000-000000000001/logger/clear.logger.name/clear")
-    void negativeAuthTestsOnClearLoggingLevelByLoggerName() {}
+            path = "/api/external/loggers/00000000-0000-0000-0000-000000000001/logger/reset.logger.name/reset")
+    void negativeAuthTestsOnResetLoggingLevelByLoggerName() {}
 }

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiManagementLoggingLevelTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiManagementLoggingLevelTest.java
@@ -18,7 +18,10 @@
 package com.axelixlabs.axelix.master.api.external.endpoint;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
@@ -31,6 +34,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -39,6 +44,7 @@ import org.springframework.http.ResponseEntity;
 
 import com.axelixlabs.axelix.common.api.loggers.LogLevelChangeRequest;
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.master.api.external.request.loggers.LogLevelLoggerBulkChangeRequest;
 import com.axelixlabs.axelix.master.domain.InstanceId;
 import com.axelixlabs.axelix.master.service.state.InstanceRegistry;
 import com.axelixlabs.axelix.master.utils.TestObjectFactory;
@@ -58,11 +64,15 @@ public class LoggersApiManagementLoggingLevelTest {
 
     private static final String LOG_LEVEL_GROUP_AUTH_JSON = "{\"configuredLevel\":\"INFO\"}";
 
-    private static final String LOG_LEVEL_LOGGER_AUTH_JSON = "{\"configuredLevel\":\"DEBUG\"}";
-
     private static final String activeInstanceId = UUID.randomUUID().toString();
+    private static final String siblingInstanceId = UUID.randomUUID().toString();
+    private static final String failingInstanceId = UUID.randomUUID().toString();
 
     private static MockWebServer mockWebServer;
+
+    private List<String> invokedPaths;
+
+    private AtomicInteger failingLoggerUpdateStatusCode;
 
     @Autowired
     private TestRestTemplateBuilder restTemplate;
@@ -83,31 +93,46 @@ public class LoggersApiManagementLoggingLevelTest {
 
     @BeforeEach
     void prepare() {
+        invokedPaths = new CopyOnWriteArrayList<>();
+        failingLoggerUpdateStatusCode = new AtomicInteger(500);
         mockWebServer.setDispatcher(new Dispatcher() {
             @Override
             public @NotNull MockResponse dispatch(@NotNull RecordedRequest request) {
                 String path = request.getPath();
                 assert path != null;
+                invokedPaths.add(path);
 
+                if (path.equals("/" + failingInstanceId + "/axelix-loggers/logger/logger.name/change-level")) {
+                    return new MockResponse().setResponseCode(failingLoggerUpdateStatusCode.get());
+                }
                 if (path.equals("/" + activeInstanceId + "/axelix-loggers/group/groupName/change-level")) {
                     return new MockResponse();
-                } else if (path.equals("/" + activeInstanceId + "/axelix-loggers/logger/logger.name/change-level")) {
-                    return new MockResponse();
-                } else if (path.equals("/" + activeInstanceId + "/axelix-loggers/logger/reset.logger.name/reset")) {
-                    return new MockResponse();
-                } else {
-                    return new MockResponse().setResponseCode(404);
                 }
+                if (path.equals("/" + activeInstanceId + "/axelix-loggers/logger/reset.logger.name/reset")) {
+                    return new MockResponse();
+                }
+                if (path.equals("/" + activeInstanceId + "/axelix-loggers/logger/logger.name/change-level")
+                        || path.equals("/" + siblingInstanceId + "/axelix-loggers/logger/logger.name/change-level")) {
+                    return new MockResponse();
+                }
+
+                return new MockResponse().setResponseCode(404);
             }
         });
 
         registry.reload(TestObjectFactory.withUrl(
                 activeInstanceId, mockWebServer.url(activeInstanceId).toString()));
+        registry.register(TestObjectFactory.withUrl(
+                siblingInstanceId, mockWebServer.url(siblingInstanceId).toString()));
+        registry.register(TestObjectFactory.withUrl(
+                failingInstanceId, mockWebServer.url(failingInstanceId).toString()));
     }
 
     @AfterEach
     void cleanup() {
         registry.deRegister(InstanceId.of(activeInstanceId));
+        registry.deRegister(InstanceId.of(siblingInstanceId));
+        registry.deRegister(InstanceId.of(failingInstanceId));
     }
 
     @Test
@@ -130,22 +155,21 @@ public class LoggersApiManagementLoggingLevelTest {
     }
 
     @Test
-    void shouldSetLoggingLevelByLoggerName() {
-        String loggerName = "logger.name";
-        LogLevelChangeRequest requestBody = new LogLevelChangeRequest("DEBUG", null);
+    void shouldSetLoggingLevelByLoggerNameAcrossInstances() {
+        // given.
+        LogLevelLoggerBulkChangeRequest requestBody = new LogLevelLoggerBulkChangeRequest(
+                List.of(activeInstanceId, siblingInstanceId), "logger.name", null, "DEBUG");
 
         // when.
-        ResponseEntity<String> body = restTemplate
-                .asViewer()
-                .postForEntity(
-                        "/api/external/loggers/{instanceId}/logger/{loggerName}",
-                        requestBody,
-                        String.class,
-                        activeInstanceId,
-                        loggerName);
+        ResponseEntity<String> response =
+                restTemplate.asViewer().postForEntity("/api/external/loggers/logger", requestBody, String.class);
 
         // then.
-        assertThat(body.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(invokedPaths)
+                .containsExactlyInAnyOrder(
+                        "/" + activeInstanceId + "/axelix-loggers/logger/logger.name/change-level",
+                        "/" + siblingInstanceId + "/axelix-loggers/logger/logger.name/change-level");
     }
 
     @Test
@@ -164,6 +188,27 @@ public class LoggersApiManagementLoggingLevelTest {
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {400, 500})
+    void shouldReturnBadRequestAndInvokeAllInstances_WhenLoggerUpdatePartiallyFails(int failureStatusCode) {
+        // given.
+        failingLoggerUpdateStatusCode.set(failureStatusCode);
+        LogLevelLoggerBulkChangeRequest requestBody = new LogLevelLoggerBulkChangeRequest(
+                List.of(activeInstanceId, failingInstanceId), "logger.name", null, "DEBUG");
+
+        // when.
+        ResponseEntity<String> response =
+                restTemplate.asViewer().postForEntity("/api/external/loggers/logger", requestBody, String.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).contains("PARTIALLY_UPDATED");
+        assertThat(invokedPaths)
+                .containsExactlyInAnyOrder(
+                        "/" + activeInstanceId + "/axelix-loggers/logger/logger.name/change-level",
+                        "/" + failingInstanceId + "/axelix-loggers/logger/logger.name/change-level");
     }
 
     @Test
@@ -197,17 +242,14 @@ public class LoggersApiManagementLoggingLevelTest {
         registry.reload(createInstance(instanceId));
 
         // when.
-        ResponseEntity<?> response = restTemplate
-                .asViewer()
-                .postForEntity(
-                        "/api/external/loggers/{instanceId}/logger/{loggerName}",
-                        requestBody,
-                        Void.class,
-                        instanceId,
-                        loggerName);
+        ResponseEntity<String> response =
+                restTemplate.asViewer().postForEntity("/api/external/loggers/logger", requestBody, String.class);
 
         // then.
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNull();
+        assertThat(invokedPaths)
+                .containsExactly("/" + failingInstanceId + "/axelix-loggers/logger/logger.name/change-level");
     }
 
     @Test
@@ -252,23 +294,19 @@ public class LoggersApiManagementLoggingLevelTest {
     }
 
     @Test
-    void shouldReturnBadRequestForUnregisteredInstance_OnLoggerName() {
-        String instanceId = "unregistered-loggers-instance";
-        String loggerName = "logger.name";
-        LogLevelChangeRequest requestBody = new LogLevelChangeRequest("DEBUG", null);
+    void shouldReturnBadRequestForUnregisteredInstance_OnLoggerBulkChange() {
+        // given.
+        String instanceId = "unregistered-loggers-logger-instance";
+        LogLevelLoggerBulkChangeRequest requestBody =
+                new LogLevelLoggerBulkChangeRequest(List.of(instanceId), "logger.name", null, "DEBUG");
 
         // when.
-        ResponseEntity<String> response = restTemplate
-                .asViewer()
-                .postForEntity(
-                        "/api/external/loggers/{instanceId}/logger/{loggerName}",
-                        requestBody,
-                        String.class,
-                        instanceId,
-                        loggerName);
+        ResponseEntity<String> response =
+                restTemplate.asViewer().postForEntity("/api/external/loggers/logger", requestBody, String.class);
 
         // then.
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(invokedPaths).isEmpty();
     }
 
     @Test
@@ -290,16 +328,65 @@ public class LoggersApiManagementLoggingLevelTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
 
+    @Test
+    void shouldReturnBadRequest_WhenInstanceIdsAreEmpty() {
+        // given.
+        LogLevelLoggerBulkChangeRequest requestBody =
+                new LogLevelLoggerBulkChangeRequest(List.of(), "logger.name", null, "DEBUG");
+
+        // when.
+        ResponseEntity<String> response =
+                restTemplate.asViewer().postForEntity("/api/external/loggers/logger", requestBody, String.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(invokedPaths).isEmpty();
+    }
+
+    @Test
+    void shouldDeduplicateInstanceIds() {
+        // given.
+        LogLevelLoggerBulkChangeRequest requestBody = new LogLevelLoggerBulkChangeRequest(
+                List.of(activeInstanceId, activeInstanceId), "logger.name", null, "DEBUG");
+
+        // when.
+        ResponseEntity<String> response =
+                restTemplate.asViewer().postForEntity("/api/external/loggers/logger", requestBody, String.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(invokedPaths)
+                .containsExactly("/" + activeInstanceId + "/axelix-loggers/logger/logger.name/change-level");
+    }
+
+    @Test
+    void shouldReturnBadRequest_WhenConfiguredLevelIsBlank() {
+        // given.
+        LogLevelLoggerBulkChangeRequest requestBody =
+                new LogLevelLoggerBulkChangeRequest(List.of(activeInstanceId), "logger.name", null, " ");
+
+        // when.
+        ResponseEntity<String> response =
+                restTemplate.asViewer().postForEntity("/api/external/loggers/logger", requestBody, String.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(invokedPaths).isEmpty();
+    }
+
     @ProtectedEndpointTests(
             method = HttpMethod.POST,
             path = "/api/external/loggers/00000000-0000-0000-0000-000000000001/group/groupName",
             jsonBody = LOG_LEVEL_GROUP_AUTH_JSON)
     void negativeAuthTestsOnGroupName() {}
 
-    @ProtectedEndpointTests(
-            method = HttpMethod.POST,
-            path = "/api/external/loggers/00000000-0000-0000-0000-000000000001/logger/logger.name",
-            jsonBody = LOG_LEVEL_LOGGER_AUTH_JSON)
+    @ProtectedEndpointTests(method = HttpMethod.POST, path = "/api/external/loggers/logger", jsonBody = """
+                    {
+                      "instanceIds": ["00000000-0000-0000-0000-000000000001"],
+                      "loggerName": "logger.name",
+                      "configuredLevel": "DEBUG"
+                    }
+                    """)
     void negativeAuthTestsOnLoggerName() {}
 
     @ProtectedEndpointTests(

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiManagementLoggingLevelTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/LoggersApiManagementLoggingLevelTest.java
@@ -102,14 +102,14 @@ public class LoggersApiManagementLoggingLevelTest {
                 assert path != null;
                 invokedPaths.add(path);
 
-                if (path.equals("/" + failingInstanceId + "/axelix-loggers/logger/logger.name/change-level")) {
-                    return new MockResponse().setResponseCode(failingLoggerUpdateStatusCode.get());
-                }
                 if (path.equals("/" + activeInstanceId + "/axelix-loggers/group/groupName/change-level")) {
                     return new MockResponse();
                 }
                 if (path.equals("/" + activeInstanceId + "/axelix-loggers/logger/reset.logger.name/reset")) {
                     return new MockResponse();
+                }
+                if (path.equals("/" + failingInstanceId + "/axelix-loggers/logger/logger.name/change-level")) {
+                    return new MockResponse().setResponseCode(failingLoggerUpdateStatusCode.get());
                 }
                 if (path.equals("/" + activeInstanceId + "/axelix-loggers/logger/logger.name/change-level")
                         || path.equals("/" + siblingInstanceId + "/axelix-loggers/logger/logger.name/change-level")) {
@@ -120,11 +120,11 @@ public class LoggersApiManagementLoggingLevelTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(
+        registry.reload(TestObjectFactory.createTestInstance(
                 activeInstanceId, mockWebServer.url(activeInstanceId).toString()));
-        registry.reload(TestObjectFactory.withUrl(
+        registry.reload(TestObjectFactory.createTestInstance(
                 siblingInstanceId, mockWebServer.url(siblingInstanceId).toString()));
-        registry.reload(TestObjectFactory.withUrl(
+        registry.reload(TestObjectFactory.createTestInstance(
                 failingInstanceId, mockWebServer.url(failingInstanceId).toString()));
     }
 
@@ -213,7 +213,7 @@ public class LoggersApiManagementLoggingLevelTest {
 
     @Test
     @DisplayName("Should return 500 on EndpointInvocationError")
-    void shouldReturnInternalServerError_OnGroupName() {
+    void shouldReturnInternalServerError_WhenInvokedOnUnknownInstance() {
         String instanceId = UUID.randomUUID().toString();
         String groupName = "groupName";
         LogLevelChangeRequest requestBody = new LogLevelChangeRequest("INFO", null);
@@ -234,26 +234,8 @@ public class LoggersApiManagementLoggingLevelTest {
     }
 
     @Test
-    @DisplayName("Should return 400 on EndpointInvocationError")
-    void shouldReturnBadRequest_OnLoggerBulkChangeEndpointInvocationError() {
-        // given.
-        LogLevelLoggerBulkChangeRequest requestBody =
-                new LogLevelLoggerBulkChangeRequest(List.of(failingInstanceId), "logger.name", null, "DEBUG");
-
-        // when.
-        ResponseEntity<String> response =
-                restTemplate.asViewer().postForEntity("/api/external/loggers/logger", requestBody, String.class);
-
-        // then.
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(response.getBody()).isNull();
-        assertThat(invokedPaths)
-                .containsExactly("/" + failingInstanceId + "/axelix-loggers/logger/logger.name/change-level");
-    }
-
-    @Test
     @DisplayName("Should return 500 on EndpointInvocationError")
-    void shouldReturnInternalServerError_OnResetLoggingLevelByLoggerName() {
+    void shouldReturnInternalServerError_WhenResettingOnUnknonInstance() {
         String instanceId = UUID.randomUUID().toString();
         String loggerName = "reset.logger.name";
         registry.reload(createInstance(instanceId));
@@ -309,7 +291,7 @@ public class LoggersApiManagementLoggingLevelTest {
     }
 
     @Test
-    void shouldReturnBadRequest_WhenInstanceIdsAreEmpty() {
+    void givenInstanceIdsAreEmpty_shouldReturnBadRequest_WhenUpdatingLoggingLevelBulk() {
         // given.
         LogLevelLoggerBulkChangeRequest requestBody =
                 new LogLevelLoggerBulkChangeRequest(List.of(), "logger.name", null, "DEBUG");
@@ -324,7 +306,7 @@ public class LoggersApiManagementLoggingLevelTest {
     }
 
     @Test
-    void shouldDeduplicateInstanceIds() {
+    void shouldDeduplicateInstanceIds_WhenUpdatingLoggingLevelBulk() {
         // given.
         LogLevelLoggerBulkChangeRequest requestBody = new LogLevelLoggerBulkChangeRequest(
                 List.of(activeInstanceId, activeInstanceId), "logger.name", null, "DEBUG");
@@ -340,7 +322,7 @@ public class LoggersApiManagementLoggingLevelTest {
     }
 
     @Test
-    void shouldReturnBadRequest_WhenConfiguredLevelIsBlank() {
+    void givenConfiguredLevelIsEmpty_shouldReturnBadRequest__WhenUpdatingLoggingLevelBulk() {
         // given.
         LogLevelLoggerBulkChangeRequest requestBody =
                 new LogLevelLoggerBulkChangeRequest(List.of(activeInstanceId), "logger.name", null, " ");

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/MetricsApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/MetricsApiTest.java
@@ -208,7 +208,8 @@ public class MetricsApiTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @AfterEach

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/ScheduledTasksApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/ScheduledTasksApiTest.java
@@ -322,7 +322,8 @@ public class ScheduledTasksApiTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @AfterEach

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/StateExportApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/StateExportApiTest.java
@@ -414,7 +414,8 @@ class StateExportApiTest {
 
     @Test
     void shouldReturnZipArchiveWithJsonFiles() throws IOException {
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
 
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/ThreadDumpApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/ThreadDumpApiTest.java
@@ -280,7 +280,8 @@ class ThreadDumpApiTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @AfterEach

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/TransactionMonitoringApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/TransactionMonitoringApiTest.java
@@ -162,7 +162,8 @@ class TransactionMonitoringApiTest {
                 }
             }
         });
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @AfterEach

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/caches/CachesClearApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/caches/CachesClearApiTest.java
@@ -92,7 +92,8 @@ public class CachesClearApiTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @AfterEach

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/caches/CachesManagementApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/caches/CachesManagementApiTest.java
@@ -107,7 +107,8 @@ class CachesManagementApiTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @AfterEach

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/caches/CachesReadApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/caches/CachesReadApiTest.java
@@ -209,8 +209,9 @@ public class CachesReadApiTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
-        registry.reload(TestObjectFactory.withUrl(
+        registry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        registry.reload(TestObjectFactory.createTestInstance(
                 activeInstanceIdEmptyCaches, mockWebServer.url(activeInstanceIdEmptyCaches) + "/actuator"));
     }
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/filter/auth/AbstractMcpAuthorizationFilterTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/filter/auth/AbstractMcpAuthorizationFilterTest.java
@@ -148,8 +148,8 @@ abstract class AbstractMcpAuthorizationFilterTest {
             }
         });
 
-        instanceRegistry.reload(
-                TestObjectFactory.withUrl(activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
+        instanceRegistry.reload(TestObjectFactory.createTestInstance(
+                activeInstanceId, mockWebServer.url(activeInstanceId) + "/actuator"));
     }
 
     @TestPropertySource(

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/transport/DefaultEndpointInvokerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/transport/DefaultEndpointInvokerTest.java
@@ -275,7 +275,8 @@ public class DefaultEndpointInvokerTest {
     @Test
     void invokeForInstances_shouldThrowPartiallyUpdatedException_WhenSomeInstancesFail() {
         // given.
-        RecordingEndpointProber prober = new RecordingEndpointProber(METHOD_INVOKE_NO_VALUE, List.of("failed-instance"));
+        RecordingEndpointProber prober =
+                new RecordingEndpointProber(METHOD_INVOKE_NO_VALUE, List.of("failed-instance"));
         DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
 
         // when.
@@ -290,8 +291,8 @@ public class DefaultEndpointInvokerTest {
     @Test
     void invokeForInstances_shouldThrowBadRequestException_WhenAllInstancesFail() {
         // given.
-        RecordingEndpointProber prober = new RecordingEndpointProber(
-                METHOD_INVOKE_NO_VALUE, List.of("first-instance", "second-instance"));
+        RecordingEndpointProber prober =
+                new RecordingEndpointProber(METHOD_INVOKE_NO_VALUE, List.of("first-instance", "second-instance"));
         DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
 
         // when.
@@ -310,8 +311,8 @@ public class DefaultEndpointInvokerTest {
         DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
 
         // when.
-        ThrowableAssert.ThrowingCallable callable = () -> subject.invokeForInstances(
-                List.of("first-instance"), METHOD_INVOKE, NoHttpPayload.INSTANCE);
+        ThrowableAssert.ThrowingCallable callable =
+                () -> subject.invokeForInstances(List.of("first-instance"), METHOD_INVOKE, NoHttpPayload.INSTANCE);
 
         // then.
         assertThatThrownBy(callable).isInstanceOf(EndpointInvocationException.class);

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/transport/DefaultEndpointInvokerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/transport/DefaultEndpointInvokerTest.java
@@ -147,7 +147,7 @@ public class DefaultEndpointInvokerTest {
             }
         });
 
-        registry.reload(TestObjectFactory.withUrl(
+        registry.reload(TestObjectFactory.createTestInstance(
                 activeInstanceId, mockWebServer.url("/actuator").toString()));
     }
 
@@ -241,14 +241,14 @@ public class DefaultEndpointInvokerTest {
     }
 
     @Test
-    void invokeForInstances_shouldInvokeEndpointForAllInstances() {
+    void invokeNoValueForInstances_shouldInvokeEndpointNoValueForAllInstances() {
         // given.
         RecordingEndpointProber prober = new RecordingEndpointProber(METHOD_INVOKE_NO_VALUE, List.of());
         DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
 
         // when.
         assertThatNoException()
-                .isThrownBy(() -> subject.invokeForInstances(
+                .isThrownBy(() -> subject.invokeNoValueForInstances(
                         List.of("first-instance", "second-instance"), METHOD_INVOKE_NO_VALUE, NoHttpPayload.INSTANCE));
 
         // then.
@@ -256,14 +256,14 @@ public class DefaultEndpointInvokerTest {
     }
 
     @Test
-    void invokeForInstances_shouldIgnoreBlankAndDuplicatedInstanceIds() {
+    void invokeNoValueForInstances_shouldIgnoreBlankAndDuplicatedInstanceIds() {
         // given.
         RecordingEndpointProber prober = new RecordingEndpointProber(METHOD_INVOKE_NO_VALUE, List.of());
         DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
 
         // when.
         assertThatNoException()
-                .isThrownBy(() -> subject.invokeForInstances(
+                .isThrownBy(() -> subject.invokeNoValueForInstances(
                         List.of("first-instance", "", " ", "first-instance", "second-instance", "second-instance"),
                         METHOD_INVOKE_NO_VALUE,
                         NoHttpPayload.INSTANCE));
@@ -273,14 +273,14 @@ public class DefaultEndpointInvokerTest {
     }
 
     @Test
-    void invokeForInstances_shouldThrowPartiallyUpdatedException_WhenSomeInstancesFail() {
+    void invokeNoValueForInstances_shouldThrowPartiallyUpdatedException_WhenSomeInstancesFail() {
         // given.
         RecordingEndpointProber prober =
                 new RecordingEndpointProber(METHOD_INVOKE_NO_VALUE, List.of("failed-instance"));
         DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
 
         // when.
-        ThrowableAssert.ThrowingCallable callable = () -> subject.invokeForInstances(
+        ThrowableAssert.ThrowingCallable callable = () -> subject.invokeNoValueForInstances(
                 List.of("successful-instance", "failed-instance"), METHOD_INVOKE_NO_VALUE, NoHttpPayload.INSTANCE);
 
         // then.
@@ -289,30 +289,30 @@ public class DefaultEndpointInvokerTest {
     }
 
     @Test
-    void invokeForInstances_shouldThrowBadRequestException_WhenAllInstancesFail() {
+    void invokeNoValueForInstances_shouldThrowBadRequestException_WhenAllInstancesFail() {
         // given.
         RecordingEndpointProber prober =
                 new RecordingEndpointProber(METHOD_INVOKE_NO_VALUE, List.of("first-instance", "second-instance"));
         DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
 
         // when.
-        ThrowableAssert.ThrowingCallable callable = () -> subject.invokeForInstances(
+        ThrowableAssert.ThrowingCallable callable = () -> subject.invokeNoValueForInstances(
                 List.of("first-instance", "second-instance"), METHOD_INVOKE_NO_VALUE, NoHttpPayload.INSTANCE);
 
         // then.
-        assertThatThrownBy(callable).isInstanceOf(BadRequestException.class);
+        assertThatThrownBy(callable).isInstanceOf(PartiallyUpdatedException.class);
         assertThat(prober.invokedInstanceIds()).containsExactly("first-instance", "second-instance");
     }
 
     @Test
-    void invokeForInstances_shouldThrowEndpointInvocationException_OnUnknownActuatorEndpoint() {
+    void invokeNoValueForInstances_shouldThrowEndpointInvocationException_OnUnknownActuatorEndpoint() {
         // given.
         RecordingEndpointProber prober = new RecordingEndpointProber(METHOD_INVOKE_NO_VALUE, List.of());
         DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
 
         // when.
-        ThrowableAssert.ThrowingCallable callable =
-                () -> subject.invokeForInstances(List.of("first-instance"), METHOD_INVOKE, NoHttpPayload.INSTANCE);
+        ThrowableAssert.ThrowingCallable callable = () ->
+                subject.invokeNoValueForInstances(List.of("first-instance"), METHOD_INVOKE, NoHttpPayload.INSTANCE);
 
         // then.
         assertThatThrownBy(callable).isInstanceOf(EndpointInvocationException.class);

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/transport/DefaultEndpointInvokerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/transport/DefaultEndpointInvokerTest.java
@@ -18,6 +18,8 @@
 package com.axelixlabs.axelix.master.service.transport;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import okhttp3.mockwebserver.Dispatcher;
@@ -46,6 +48,7 @@ import org.springframework.stereotype.Component;
 import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
 import com.axelixlabs.axelix.common.domain.ActuatorEndpoint;
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.common.domain.http.HttpPayload;
 import com.axelixlabs.axelix.common.domain.http.NoHttpPayload;
 import com.axelixlabs.axelix.master.domain.InstanceId;
 import com.axelixlabs.axelix.master.exception.InstanceNotFoundException;
@@ -237,6 +240,84 @@ public class DefaultEndpointInvokerTest {
                 .isInstanceOf(BadRequestException.class);
     }
 
+    @Test
+    void invokeForInstances_shouldInvokeEndpointForAllInstances() {
+        // given.
+        RecordingEndpointProber prober = new RecordingEndpointProber(METHOD_INVOKE_NO_VALUE, List.of());
+        DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
+
+        // when.
+        assertThatNoException()
+                .isThrownBy(() -> subject.invokeForInstances(
+                        List.of("first-instance", "second-instance"), METHOD_INVOKE_NO_VALUE, NoHttpPayload.INSTANCE));
+
+        // then.
+        assertThat(prober.invokedInstanceIds()).containsExactly("first-instance", "second-instance");
+    }
+
+    @Test
+    void invokeForInstances_shouldIgnoreBlankAndDuplicatedInstanceIds() {
+        // given.
+        RecordingEndpointProber prober = new RecordingEndpointProber(METHOD_INVOKE_NO_VALUE, List.of());
+        DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
+
+        // when.
+        assertThatNoException()
+                .isThrownBy(() -> subject.invokeForInstances(
+                        List.of("first-instance", "", " ", "first-instance", "second-instance", "second-instance"),
+                        METHOD_INVOKE_NO_VALUE,
+                        NoHttpPayload.INSTANCE));
+
+        // then.
+        assertThat(prober.invokedInstanceIds()).containsExactly("first-instance", "second-instance");
+    }
+
+    @Test
+    void invokeForInstances_shouldThrowPartiallyUpdatedException_WhenSomeInstancesFail() {
+        // given.
+        RecordingEndpointProber prober = new RecordingEndpointProber(METHOD_INVOKE_NO_VALUE, List.of("failed-instance"));
+        DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
+
+        // when.
+        ThrowableAssert.ThrowingCallable callable = () -> subject.invokeForInstances(
+                List.of("successful-instance", "failed-instance"), METHOD_INVOKE_NO_VALUE, NoHttpPayload.INSTANCE);
+
+        // then.
+        assertThatThrownBy(callable).isInstanceOf(PartiallyUpdatedException.class);
+        assertThat(prober.invokedInstanceIds()).containsExactly("successful-instance", "failed-instance");
+    }
+
+    @Test
+    void invokeForInstances_shouldThrowBadRequestException_WhenAllInstancesFail() {
+        // given.
+        RecordingEndpointProber prober = new RecordingEndpointProber(
+                METHOD_INVOKE_NO_VALUE, List.of("first-instance", "second-instance"));
+        DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
+
+        // when.
+        ThrowableAssert.ThrowingCallable callable = () -> subject.invokeForInstances(
+                List.of("first-instance", "second-instance"), METHOD_INVOKE_NO_VALUE, NoHttpPayload.INSTANCE);
+
+        // then.
+        assertThatThrownBy(callable).isInstanceOf(BadRequestException.class);
+        assertThat(prober.invokedInstanceIds()).containsExactly("first-instance", "second-instance");
+    }
+
+    @Test
+    void invokeForInstances_shouldThrowEndpointInvocationException_OnUnknownActuatorEndpoint() {
+        // given.
+        RecordingEndpointProber prober = new RecordingEndpointProber(METHOD_INVOKE_NO_VALUE, List.of());
+        DefaultEndpointInvoker subject = new DefaultEndpointInvoker(List.of(prober));
+
+        // when.
+        ThrowableAssert.ThrowingCallable callable = () -> subject.invokeForInstances(
+                List.of("first-instance"), METHOD_INVOKE, NoHttpPayload.INSTANCE);
+
+        // then.
+        assertThatThrownBy(callable).isInstanceOf(EndpointInvocationException.class);
+        assertThat(prober.invokedInstanceIds()).isEmpty();
+    }
+
     @TestConfiguration
     static class DefaultEndpointInvokerTestConfiguration {
 
@@ -289,6 +370,45 @@ public class DefaultEndpointInvokerTest {
             public @NonNull Class<JsonNode> supported() {
                 return JsonNode.class;
             }
+        }
+    }
+
+    private static class RecordingEndpointProber implements EndpointProber<Object> {
+
+        private final ActuatorEndpoint endpoint;
+        private final List<String> failingInstanceIds;
+        private final List<String> invokedInstanceIds = new ArrayList<>();
+
+        RecordingEndpointProber(ActuatorEndpoint endpoint, List<String> failingInstanceIds) {
+            this.endpoint = endpoint;
+            this.failingInstanceIds = failingInstanceIds;
+        }
+
+        @Override
+        public @NonNull Object invoke(@NonNull InstanceId instanceId, HttpPayload httpPayload)
+                throws EndpointInvocationException, BadRequestException, InstanceNotFoundException {
+            invokedInstanceIds.add(instanceId.instanceId());
+
+            if (failingInstanceIds.contains(instanceId.instanceId())) {
+                throw new InstanceNotFoundException(instanceId);
+            }
+
+            return new Object();
+        }
+
+        @Override
+        public @NonNull Object invoke(@NonNull String baseUrl, HttpPayload httpPayload)
+                throws EndpointInvocationException, BadRequestException {
+            return new Object();
+        }
+
+        @Override
+        public @NonNull ActuatorEndpoint supports() {
+            return endpoint;
+        }
+
+        List<String> invokedInstanceIds() {
+            return invokedInstanceIds;
         }
     }
 }

--- a/master/src/test/java/com/axelixlabs/axelix/master/utils/TestObjectFactory.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/utils/TestObjectFactory.java
@@ -45,7 +45,7 @@ public final class TestObjectFactory {
     private TestObjectFactory() {}
 
     public static Instance createInstance(String id) {
-        return withUrl(id, DEFAULT_URL);
+        return createTestInstance(id, DEFAULT_URL);
     }
 
     public static Instance createInstance(String id, @Nullable Instant instant) {
@@ -56,12 +56,12 @@ public final class TestObjectFactory {
         return createInstance(id, DEFAULT_URL, name, DEFAULT_STATUS, "25", "3.5.2", "6.0.2", "BellSoft", null);
     }
 
-    public static Instance withUrl(String id, String url) {
+    public static Instance createTestInstance(String id, String url) {
         return createInstance(id, url, DEFAULT_STATUS);
     }
 
     public static Instance createInstance(String id, String url) {
-        return withUrl(id, url);
+        return createTestInstance(id, url);
     }
 
     public static Instance withStatus(String id, Instance.InstanceStatus status) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk logger management support across multiple instances, including changing logger levels, changing logger groups, and resetting loggers.
  * Introduced clearer API responses for partial updates.

* **Bug Fixes**
  * Bulk requests now ignore blank or duplicate instance IDs and validate required fields more strictly.
  * Partial failures now return a client-facing error instead of failing silently.

* **Tests**
  * Expanded coverage for multi-instance success, partial failure, invalid input, and endpoint invocation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->