### PR TITLE
Centralize beans test configurations in the shared parent

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AbstractBeansSharedContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AbstractBeansSharedContextTest.java
@@ -17,10 +17,54 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.beans;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.sql.DataSource;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.axelixlabs.axelix.sbs.spring.core.Main;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRefBuilder;
 
 /**
  * Shared base test that defines a single Spring {@link org.springframework.context.ApplicationContext}
@@ -28,17 +72,278 @@ import com.axelixlabs.axelix.sbs.spring.core.Main;
  * building its own context.
  *
  * <p>{@link Main} is pinned via the {@code classes} attribute (rather than left to Spring Boot's
- * auto-detection) so both subclasses resolve an identical, deterministic configuration — this is
+ * auto-detection) so all subclasses resolve an identical, deterministic configuration — this is
  * what makes the cached context shareable, and it also keeps auto-configuration (e.g. the embedded
  * {@code DataSource}) active.
+ *
+ * <p>All test configurations consumed by these tests live here, in the parent, as nested classes —
+ * so the parent owns the entire shared configuration and never has to reference its subclasses.
  *
  * @author Artemiy Degtyarev
  */
 @SpringBootTest(classes = Main.class)
 @Import({
-    DefaultBeanMetaInfoExtractorTest.DefaultBeanAnalyzerTestConfig.class,
-    QualifiersPersistencePostProcessorTest.BeanMethodDeclarations.class,
-    QualifiersPersistencePostProcessorTest.ComponentMethodDeclarations.class,
-    QualifiersPersistencePostProcessorTest.ConfigurationClassesDeclarations.class
+    AbstractBeansSharedContextTest.DefaultBeanAnalyzerTestConfig.class,
+    AbstractBeansSharedContextTest.BeanMethodDeclarations.class,
+    AbstractBeansSharedContextTest.ComponentMethodDeclarations.class,
+    AbstractBeansSharedContextTest.ConfigurationClassesDeclarations.class
 })
-abstract class AbstractBeansSharedContextTest {}
+abstract class AbstractBeansSharedContextTest {
+
+    // --- Bean meta-info extraction fixtures (DefaultBeanMetaInfoExtractorTest) ---
+
+    @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Qualifier(DefaultBeanAnalyzerTestConfig.CUSTOM_DATABASE_QUALIFIER_BEAN)
+    public @interface CustomDatabaseQualifier {}
+
+    /**
+     * Static nested configuration that declares the various bean shapes exercised by the bean
+     * meta-info extraction tests.
+     */
+    @TestConfiguration
+    @EnableJpaRepositories(
+            basePackageClasses = DefaultBeanAnalyzerTestConfig.MyRepository.class,
+            considerNestedRepositories = true)
+    @EntityScan(basePackageClasses = DefaultBeanAnalyzerTestConfig.MyEntity.class)
+    public static class DefaultBeanAnalyzerTestConfig {
+
+        static final String PRIMARY_COMPONENT = "primaryComponent";
+
+        static final String LAZY_COMPONENT = "lazyComponentAnnotation";
+
+        static final String REGULAR_COMPONENT = "fromServiceAnnotation";
+
+        static final String QUALIFIED_COMPONENT = "qualifiedService";
+
+        static final String LAZY_PRIMARY_BEAN_METHOD = "lazyPrimaryBeanMethod";
+
+        static final String QUALIFIED_BEAN_METHOD = "qualifiedBeanMethod";
+
+        static final String CONFIGURATION_BEAN = "configurationBean";
+
+        static final String TRANSACTIONAL_BEAN = "transactionalBean";
+
+        static final String SPRING_DATA_REPOSITORY = "MyRepository";
+
+        static final String CUSTOM_DATABASE_QUALIFIER_BEAN = "CustomDatabaseQualifierBean";
+
+        static final String ANONYMOUS_BEAN = "anonymousBean";
+
+        static final String STATIC_BFPP_BEAN = "staticBFPPBean";
+
+        static final String BEAN_DEFINITION_REGISTRY_BEAN = "BEAN_DEFINITION_REGISTRY_BEAN";
+
+        static final String SYNTHETIC_BEAN_DEFINITION = "SYNTHETIC_BEAN_DEFINITION";
+
+        @Service(REGULAR_COMPONENT)
+        static class FromServiceAnnotation {}
+
+        @Component(LAZY_COMPONENT)
+        @Lazy
+        static class LazyComponentAnnotation {}
+
+        @Component(PRIMARY_COMPONENT)
+        @Primary
+        static class PrimaryComponent {}
+
+        @Service(QUALIFIED_COMPONENT)
+        @Qualifier(QUALIFIED_COMPONENT)
+        static class QualifiedService {}
+
+        @Bean(LAZY_PRIMARY_BEAN_METHOD)
+        @Lazy
+        @Primary
+        public String lazyPrimaryBean() {
+            return LAZY_PRIMARY_BEAN_METHOD;
+        }
+
+        @Bean
+        public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
+            return new QualifiersPersistencePostProcessor();
+        }
+
+        @Bean
+        public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
+            LocalContainerEntityManagerFactoryBean emf = new LocalContainerEntityManagerFactoryBean();
+            emf.setDataSource(dataSource);
+            emf.setPackagesToScan(MyEntity.class.getPackageName());
+
+            JpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+            emf.setJpaVendorAdapter(vendorAdapter);
+
+            emf.getJpaPropertyMap().put("hibernate.hbm2ddl.auto", "create-drop");
+            return emf;
+        }
+
+        @Bean
+        public PlatformTransactionManager transactionManager(EntityManagerFactory emf) {
+            return new JpaTransactionManager(emf);
+        }
+
+        @Bean
+        public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
+            return new DefaultConditionalBeanRefBuilder();
+        }
+
+        @Bean
+        public BeanMetaInfoExtractor beanMetaInfoExtractor(
+                ConfigurableApplicationContext configurableApplicationContext,
+                ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
+            return new DefaultBeanMetaInfoExtractor(configurableApplicationContext, conditionalBeanRefBuilder);
+        }
+
+        @Entity
+        @Table(name = "my_entity")
+        public static class MyEntity {
+            @Id
+            @GeneratedValue(strategy = GenerationType.AUTO)
+            private Long id;
+        }
+
+        @Repository(SPRING_DATA_REPOSITORY)
+        public interface MyRepository extends JpaRepository<MyEntity, Long> {}
+
+        @Bean
+        @Qualifier(QUALIFIED_BEAN_METHOD)
+        public String qualifiedBeanMethod() {
+            return QUALIFIED_BEAN_METHOD;
+        }
+
+        @Configuration(CONFIGURATION_BEAN)
+        public static class ConfigurationBean {}
+
+        @Service(TRANSACTIONAL_BEAN)
+        public static class TransactionalClass {
+
+            @Autowired
+            private JdbcTemplate jdbcTemplate;
+
+            @Transactional
+            public void execute() {
+                // code
+            }
+        }
+
+        @Service(CUSTOM_DATABASE_QUALIFIER_BEAN)
+        @CustomDatabaseQualifier
+        static class CustomDatabaseQualifierBean {}
+
+        // IMPORTANT! Intentionally using explicit anonymous class `new Runnable()`
+        // instead of lambda to ensure Class.isAnonymousClass() returns true.
+        @Bean(ANONYMOUS_BEAN)
+        public Runnable anonymousBean() {
+            return new Runnable() {
+                @Override
+                public void run() {}
+            };
+        }
+
+        @Bean(STATIC_BFPP_BEAN)
+        public static BeanFactoryPostProcessor staticBFPPBean() {
+            return beanFactory -> {};
+        }
+
+        @Bean(BEAN_DEFINITION_REGISTRY_BEAN)
+        public static BeanDefinitionRegistryPostProcessor beanDefinitionRegistryPostProcessor() {
+
+            return new BeanDefinitionRegistryPostProcessor() {
+
+                @Override
+                public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+                    RootBeanDefinition beanDefinition = new RootBeanDefinition();
+                    beanDefinition.setSynthetic(true);
+                    beanDefinition.setBeanClass(Object.class);
+                    registry.registerBeanDefinition(SYNTHETIC_BEAN_DEFINITION, beanDefinition);
+                }
+
+                @Override
+                public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {}
+            };
+        }
+    }
+
+    // --- Qualifier persistence fixtures (QualifiersPersistencePostProcessorTest) ---
+
+    @Documented
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Qualifier("customQualifier")
+    @interface CustomQualifier {}
+
+    @TestConfiguration
+    static class ComponentMethodDeclarations {
+
+        @Component("noQualifiersBeanName")
+        static class NoQualifiers {}
+
+        @Service("builtInTypeQualifierBeanName")
+        @Qualifier("builtInTypeQualifier")
+        static class BuiltInTypeQualifier {}
+
+        @Service("customTypeQualifierBeanName")
+        @CustomQualifier
+        static class CustomTypeQualifier {}
+
+        @Service("mixedTypeQualifierBeanName")
+        @CustomQualifier
+        @Qualifier("builtInTypeQualifier")
+        static class MixedTypeQualifier {}
+    }
+
+    @TestConfiguration
+    static class BeanMethodDeclarations {
+
+        static class BeanMethodNoQualifiers {}
+
+        static class BeanMethodBuiltInTypeQualifier {}
+
+        static class BeanMethodCustomTypeQualifier {}
+
+        static class BeanMethodMixedTypeQualifier {}
+
+        @Bean("beanMethodNoQualifiersBeanName")
+        public BeanMethodNoQualifiers beanMethodNoQualifiers() {
+            return new BeanMethodNoQualifiers();
+        }
+
+        @Bean("beanMethodBuiltInTypeQualifierBeanName")
+        @Qualifier("builtInTypeQualifier")
+        public BeanMethodBuiltInTypeQualifier builtInTypeQualifier() {
+            return new BeanMethodBuiltInTypeQualifier();
+        }
+
+        @Bean("beanMethodCustomTypeQualifierBeanName")
+        @CustomQualifier
+        public BeanMethodCustomTypeQualifier customTypeQualifier() {
+            return new BeanMethodCustomTypeQualifier();
+        }
+
+        @Bean("beanMethodMixedTypeQualifierBeanName")
+        @CustomQualifier
+        @Qualifier("builtInTypeQualifier")
+        public BeanMethodMixedTypeQualifier mixedTypeQualifier() {
+            return new BeanMethodMixedTypeQualifier();
+        }
+    }
+
+    @Configuration
+    static class ConfigurationClassesDeclarations {
+
+        @Configuration("noQualifiersConfigBeanName")
+        static class NoQualifiers {}
+
+        @Configuration("builtInTypeQualifierConfigBeanName")
+        @Qualifier("builtInTypeQualifier")
+        static class BuiltInTypeQualifier {}
+
+        @Configuration("customTypeQualifierConfigBeanName")
+        @CustomQualifier
+        static class CustomTypeQualifier {}
+
+        @Configuration("mixedTypeQualifierConfigBeanName")
+        @CustomQualifier
+        @Qualifier("builtInTypeQualifier")
+        static class MixedTypeQualifier {}
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeanMetaInfoExtractorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeanMetaInfoExtractorTest.java
@@ -17,61 +17,23 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.beans;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-import javax.sql.DataSource;
-
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityManagerFactory;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
-import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.context.annotation.Primary;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.orm.jpa.JpaTransactionManager;
-import org.springframework.orm.jpa.JpaVendorAdapter;
-import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
-import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
-import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Repository;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.axelixlabs.axelix.common.api.BeansFeed;
 import com.axelixlabs.axelix.common.api.BeansFeed.ComponentVariant;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRefBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Integration test for {@link DefaultBeanMetaInfoExtractor}.
+ *
+ * <p>The bean fixtures it exercises are declared by
+ * {@link AbstractBeansSharedContextTest.DefaultBeanAnalyzerTestConfig} on the shared parent context.
  *
  * @since 07.07.2025
  * @author Nikita Kirillov
@@ -328,175 +290,5 @@ class DefaultBeanMetaInfoExtractorTest extends AbstractBeansSharedContextTest {
             assertThat(it.getBeanSource()).isInstanceOf(BeansFeed.SyntheticBean.class);
             assertThat(it.getAutoConfigurationRef()).isNull();
         });
-    }
-
-    @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
-    @Retention(RetentionPolicy.RUNTIME)
-    @Qualifier(DefaultBeanAnalyzerTestConfig.CUSTOM_DATABASE_QUALIFIER_BEAN)
-    public @interface CustomDatabaseQualifier {}
-
-    /**
-     * Static nested configuration class for {@link DefaultBeanMetaInfoExtractorTest}.
-     */
-    @TestConfiguration
-    @EnableJpaRepositories(
-            basePackageClasses = DefaultBeanAnalyzerTestConfig.MyRepository.class,
-            considerNestedRepositories = true)
-    @EntityScan(basePackageClasses = DefaultBeanAnalyzerTestConfig.MyEntity.class)
-    public static class DefaultBeanAnalyzerTestConfig {
-
-        static final String PRIMARY_COMPONENT = "primaryComponent";
-
-        static final String LAZY_COMPONENT = "lazyComponentAnnotation";
-
-        static final String REGULAR_COMPONENT = "fromServiceAnnotation";
-
-        static final String QUALIFIED_COMPONENT = "qualifiedService";
-
-        static final String LAZY_PRIMARY_BEAN_METHOD = "lazyPrimaryBeanMethod";
-
-        static final String QUALIFIED_BEAN_METHOD = "qualifiedBeanMethod";
-
-        static final String CONFIGURATION_BEAN = "configurationBean";
-
-        static final String TRANSACTIONAL_BEAN = "transactionalBean";
-
-        static final String SPRING_DATA_REPOSITORY = "MyRepository";
-
-        static final String CUSTOM_DATABASE_QUALIFIER_BEAN = "CustomDatabaseQualifierBean";
-
-        static final String ANONYMOUS_BEAN = "anonymousBean";
-
-        static final String STATIC_BFPP_BEAN = "staticBFPPBean";
-
-        static final String BEAN_DEFINITION_REGISTRY_BEAN = "BEAN_DEFINITION_REGISTRY_BEAN";
-
-        static final String SYNTHETIC_BEAN_DEFINITION = "SYNTHETIC_BEAN_DEFINITION";
-
-        @Service(REGULAR_COMPONENT)
-        static class FromServiceAnnotation {}
-
-        @Component(LAZY_COMPONENT)
-        @Lazy
-        static class LazyComponentAnnotation {}
-
-        @Component(PRIMARY_COMPONENT)
-        @Primary
-        static class PrimaryComponent {}
-
-        @Service(QUALIFIED_COMPONENT)
-        @Qualifier(QUALIFIED_COMPONENT)
-        static class QualifiedService {}
-
-        @Bean(LAZY_PRIMARY_BEAN_METHOD)
-        @Lazy
-        @Primary
-        public String lazyPrimaryBean() {
-            return LAZY_PRIMARY_BEAN_METHOD;
-        }
-
-        @Bean
-        public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
-            return new QualifiersPersistencePostProcessor();
-        }
-
-        @Bean
-        public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
-            LocalContainerEntityManagerFactoryBean emf = new LocalContainerEntityManagerFactoryBean();
-            emf.setDataSource(dataSource);
-            emf.setPackagesToScan(MyEntity.class.getPackageName());
-
-            JpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
-            emf.setJpaVendorAdapter(vendorAdapter);
-
-            emf.getJpaPropertyMap().put("hibernate.hbm2ddl.auto", "create-drop");
-            return emf;
-        }
-
-        @Bean
-        public PlatformTransactionManager transactionManager(EntityManagerFactory emf) {
-            return new JpaTransactionManager(emf);
-        }
-
-        @Bean
-        public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
-            return new DefaultConditionalBeanRefBuilder();
-        }
-
-        @Bean
-        public BeanMetaInfoExtractor beanMetaInfoExtractor(
-                ConfigurableApplicationContext configurableApplicationContext,
-                ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
-            return new DefaultBeanMetaInfoExtractor(configurableApplicationContext, conditionalBeanRefBuilder);
-        }
-
-        @Entity
-        @Table(name = "my_entity")
-        public static class MyEntity {
-            @Id
-            @GeneratedValue(strategy = GenerationType.AUTO)
-            private Long id;
-        }
-
-        @Repository(SPRING_DATA_REPOSITORY)
-        public interface MyRepository extends JpaRepository<MyEntity, Long> {}
-
-        @Bean
-        @Qualifier(QUALIFIED_BEAN_METHOD)
-        public String qualifiedBeanMethod() {
-            return QUALIFIED_BEAN_METHOD;
-        }
-
-        @Configuration(CONFIGURATION_BEAN)
-        public static class ConfigurationBean {}
-
-        @Service(TRANSACTIONAL_BEAN)
-        public static class TransactionalClass {
-
-            @Autowired
-            private JdbcTemplate jdbcTemplate;
-
-            @Transactional
-            public void execute() {
-                // code
-            }
-        }
-
-        @Service(CUSTOM_DATABASE_QUALIFIER_BEAN)
-        @CustomDatabaseQualifier
-        static class CustomDatabaseQualifierBean {}
-
-        // IMPORTANT! Intentionally using explicit anonymous class `new Runnable()`
-        // instead of lambda to ensure Class.isAnonymousClass() returns true.
-        @Bean(ANONYMOUS_BEAN)
-        public Runnable anonymousBean() {
-            return new Runnable() {
-                @Override
-                public void run() {}
-            };
-        }
-
-        @Bean(STATIC_BFPP_BEAN)
-        public static BeanFactoryPostProcessor staticBFPPBean() {
-            return beanFactory -> {};
-        }
-
-        @Bean(BEAN_DEFINITION_REGISTRY_BEAN)
-        public static BeanDefinitionRegistryPostProcessor beanDefinitionRegistryPostProcessor() {
-
-            return new BeanDefinitionRegistryPostProcessor() {
-
-                @Override
-                public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
-                    RootBeanDefinition beanDefinition = new RootBeanDefinition();
-                    beanDefinition.setSynthetic(true);
-                    beanDefinition.setBeanClass(Object.class);
-                    registry.registerBeanDefinition(SYNTHETIC_BEAN_DEFINITION, beanDefinition);
-                }
-
-                @Override
-                public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {}
-            };
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/QualifiersPersistencePostProcessorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/QualifiersPersistencePostProcessorTest.java
@@ -17,24 +17,14 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.beans;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Service;
-
 /**
  * Integration test for {@link QualifiersPersistencePostProcessor}.
+ *
+ * <p>The qualifier-bearing beans it asserts on are declared by the {@code *Declarations} test
+ * configurations on the shared parent context ({@link AbstractBeansSharedContextTest}).
  *
  * @author Mikhail Polivakha
  */
@@ -73,87 +63,5 @@ class QualifiersPersistencePostProcessorTest extends AbstractBeansSharedContextT
             sa.assertThat(registry.getQualifiers("mixedTypeQualifierConfigBeanName"))
                     .containsOnly("builtInTypeQualifier", "customQualifier");
         });
-    }
-
-    @Documented
-    @Target({ElementType.TYPE, ElementType.METHOD})
-    @Retention(RetentionPolicy.RUNTIME)
-    @Qualifier("customQualifier")
-    @interface CustomQualifier {}
-
-    @TestConfiguration
-    static class ComponentMethodDeclarations {
-
-        @Component("noQualifiersBeanName")
-        static class NoQualifiers {}
-
-        @Service("builtInTypeQualifierBeanName")
-        @Qualifier("builtInTypeQualifier")
-        static class BuiltInTypeQualifier {}
-
-        @Service("customTypeQualifierBeanName")
-        @CustomQualifier
-        static class CustomTypeQualifier {}
-
-        @Service("mixedTypeQualifierBeanName")
-        @CustomQualifier
-        @Qualifier("builtInTypeQualifier")
-        static class MixedTypeQualifier {}
-    }
-
-    @TestConfiguration
-    static class BeanMethodDeclarations {
-
-        static class BeanMethodNoQualifiers {}
-
-        static class BeanMethodBuiltInTypeQualifier {}
-
-        static class BeanMethodCustomTypeQualifier {}
-
-        static class BeanMethodMixedTypeQualifier {}
-
-        @Bean("beanMethodNoQualifiersBeanName")
-        public BeanMethodNoQualifiers beanMethodNoQualifiers() {
-            return new BeanMethodNoQualifiers();
-        }
-
-        @Bean("beanMethodBuiltInTypeQualifierBeanName")
-        @Qualifier("builtInTypeQualifier")
-        public BeanMethodBuiltInTypeQualifier builtInTypeQualifier() {
-            return new BeanMethodBuiltInTypeQualifier();
-        }
-
-        @Bean("beanMethodCustomTypeQualifierBeanName")
-        @CustomQualifier
-        public BeanMethodCustomTypeQualifier customTypeQualifier() {
-            return new BeanMethodCustomTypeQualifier();
-        }
-
-        @Bean("beanMethodMixedTypeQualifierBeanName")
-        @CustomQualifier
-        @Qualifier("builtInTypeQualifier")
-        public BeanMethodMixedTypeQualifier mixedTypeQualifier() {
-            return new BeanMethodMixedTypeQualifier();
-        }
-    }
-
-    @Configuration
-    static class ConfigurationClassesDeclarations {
-
-        @Configuration("noQualifiersConfigBeanName")
-        static class NoQualifiers {}
-
-        @Configuration("builtInTypeQualifierConfigBeanName")
-        @Qualifier("builtInTypeQualifier")
-        static class BuiltInTypeQualifier {}
-
-        @Configuration("customTypeQualifierConfigBeanName")
-        @CustomQualifier
-        static class CustomTypeQualifier {}
-
-        @Configuration("mixedTypeQualifierConfigBeanName")
-        @CustomQualifier
-        @Qualifier("builtInTypeQualifier")
-        static class MixedTypeQualifier {}
     }
 }


### PR DESCRIPTION
## What

Centralizes all test configurations used by the `beans` test package into the shared `AbstractBeansSharedContextTest` parent.

Previously the parent `@Import`ed nested config classes that lived **inside its own subclasses** (`DefaultBeanMetaInfoExtractorTest`, `QualifiersPersistencePostProcessorTest`) — i.e. the parent referenced its children. This moves those configurations into the parent as nested classes:

- `DefaultBeanAnalyzerTestConfig` (+ the `CustomDatabaseQualifier` annotation)
- the qualifier `*Declarations` configurations (+ the `CustomQualifier` annotation)

The parent now imports only its own nested types; the subclasses are reduced to their `@Test` methods and resolve the fixtures through inheritance.

## Why

So the shared parent owns the entire shared configuration and never depends on its subclasses.

## Notes

Pure refactor — the cached context composition is unchanged. The full `:sbs:axelix-spring-boot-3-starter:build` (tests + Spotless + PMD + NullAway) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)