### PR TITLE
Share the beans cached context with the endpoint test

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AbstractBeansSharedContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AbstractBeansSharedContextTest.java
@@ -22,6 +22,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.function.Supplier;
 
 import javax.sql.DataSource;
 
@@ -40,7 +41,11 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.boot.actuate.autoconfigure.condition.ConditionsReportEndpoint;
+import org.springframework.boot.actuate.beans.BeansEndpoint;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -59,36 +64,100 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.axelixlabs.axelix.sbs.spring.core.Main;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRefBuilder;
 
 /**
  * Shared base test that defines a single Spring {@link org.springframework.context.ApplicationContext}
- * reused by the non-endpoint "beans" tests so they hit the Spring TestContext cache instead of each
- * building its own context.
+ * reused by the "beans" tests so they hit the Spring TestContext cache instead of each building its
+ * own context.
  *
  * <p>{@link Main} is pinned via the {@code classes} attribute (rather than left to Spring Boot's
  * auto-detection) so all subclasses resolve an identical, deterministic configuration — this is
  * what makes the cached context shareable, and it also keeps auto-configuration (e.g. the embedded
  * {@code DataSource}) active.
  *
- * <p>All test configurations consumed by these tests live here, in the parent, as nested classes —
- * so the parent owns the entire shared configuration and never has to reference its subclasses.
+ * <p>The context runs with a {@link SpringBootTest.WebEnvironment#RANDOM_PORT} web server and pulls
+ * in the actuator beans endpoints. <strong>All</strong> test configurations consumed by the "beans"
+ * tests live here, in the parent, as nested classes — so the parent owns the entire shared
+ * configuration and never has to reference its subclasses.
  *
  * @author Artemiy Degtyarev
  */
-@SpringBootTest(classes = Main.class)
+@SpringBootTest(classes = Main.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"axelix.prop.test.name=axelix-beans"})
 @Import({
     AbstractBeansSharedContextTest.DefaultBeanAnalyzerTestConfig.class,
     AbstractBeansSharedContextTest.BeanMethodDeclarations.class,
     AbstractBeansSharedContextTest.ComponentMethodDeclarations.class,
-    AbstractBeansSharedContextTest.ConfigurationClassesDeclarations.class
+    AbstractBeansSharedContextTest.ConfigurationClassesDeclarations.class,
+    AbstractBeansSharedContextTest.CurrentConfiguration.class,
+    BeansEndpoint.class,
+    AxelixBeansEndpoint.class,
+    ConditionsReportEndpoint.class,
+    JwtAuthTestConfiguration.class
 })
 abstract class AbstractBeansSharedContextTest {
+
+    // --- Endpoint integration configuration (AxelixBeansEndpointTest) ---
+
+    @TestConfiguration(value = "testCurrentConfiguration")
+    @EnableConfigurationProperties(AxelixPropTest.class)
+    static class CurrentConfiguration {
+
+        static final String QUALIFIERS_PERSISTENCE_POST_PROCESSOR = "qualifiersPersistencePostProcessor";
+        static final String BEAN_META_INFO_EXTRACTOR = "beanMetaInfoExtractor";
+        static final String CUSTOM_SUPPLIER = "customSupplier";
+
+        @Bean
+        public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
+            return new DefaultConditionalBeanRefBuilder();
+        }
+
+        @Bean
+        public BeansFeedBuilder testBeansFeedBuilder(
+                BeanMetaInfoExtractor beanMetaInfoExtractor,
+                ConfigurableApplicationContext configurableApplicationContext) {
+            return new DefaultBeansFeedBuilder(beanMetaInfoExtractor, configurableApplicationContext);
+        }
+
+        @Bean(BEAN_META_INFO_EXTRACTOR)
+        public BeanMetaInfoExtractor beanMetaInfoExtractor(
+                ConfigurableApplicationContext configurableApplicationContext,
+                ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
+            return new DefaultBeanMetaInfoExtractor(configurableApplicationContext, conditionalBeanRefBuilder);
+        }
+
+        @Bean(QUALIFIERS_PERSISTENCE_POST_PROCESSOR)
+        public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
+            return new QualifiersPersistencePostProcessor();
+        }
+
+        @Bean(CUSTOM_SUPPLIER)
+        public Supplier<String> customSupplier() {
+            return () -> "value";
+        }
+    }
+
+    @ConfigurationProperties(prefix = "axelix.prop.test")
+    static class AxelixPropTest {
+
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
 
     // --- Bean meta-info extraction fixtures (DefaultBeanMetaInfoExtractorTest) ---
 
@@ -159,11 +228,6 @@ abstract class AbstractBeansSharedContextTest {
         }
 
         @Bean
-        public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
-            return new QualifiersPersistencePostProcessor();
-        }
-
-        @Bean
         public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
             LocalContainerEntityManagerFactoryBean emf = new LocalContainerEntityManagerFactoryBean();
             emf.setDataSource(dataSource);
@@ -179,18 +243,6 @@ abstract class AbstractBeansSharedContextTest {
         @Bean
         public PlatformTransactionManager transactionManager(EntityManagerFactory emf) {
             return new JpaTransactionManager(emf);
-        }
-
-        @Bean
-        public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
-            return new DefaultConditionalBeanRefBuilder();
-        }
-
-        @Bean
-        public BeanMetaInfoExtractor beanMetaInfoExtractor(
-                ConfigurableApplicationContext configurableApplicationContext,
-                ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
-            return new DefaultBeanMetaInfoExtractor(configurableApplicationContext, conditionalBeanRefBuilder);
         }
 
         @Entity

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpointTest.java
@@ -22,23 +22,10 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.autoconfigure.condition.ConditionsReportEndpoint;
-import org.springframework.boot.actuate.beans.BeansEndpoint;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.TestPropertySource;
 
 import com.axelixlabs.axelix.common.api.BeansFeed;
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
-import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRefBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
 
@@ -50,68 +37,10 @@ import static org.assertj.core.api.InstanceOfAssertFactories.type;
  *
  * @author Mikhail Polivakha
  */
-@SpringBootTest(
-        classes = AxelixBeansEndpointTest.CurrentConfiguration.class,
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties = {"axelix.prop.test.name=axelix-beans"})
-@Import({BeansEndpoint.class, AxelixBeansEndpoint.class, ConditionsReportEndpoint.class, JwtAuthTestConfiguration.class
-})
-class AxelixBeansEndpointTest {
+class AxelixBeansEndpointTest extends AbstractBeansSharedContextTest {
 
     @Autowired
     private TestRestTemplateBuilder testRestTemplate;
-
-    @TestConfiguration(value = "testCurrentConfiguration")
-    @EnableConfigurationProperties(AxelixPropTest.class)
-    static class CurrentConfiguration {
-
-        static final String QUALIFIERS_PERSISTENCE_POST_PROCESSOR = "qualifiersPersistencePostProcessor";
-        static final String BEAN_META_INFO_EXTRACTOR = "beanMetaInfoExtractor";
-        static final String CUSTOM_SUPPLIER = "customSupplier";
-
-        @Bean
-        public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
-            return new DefaultConditionalBeanRefBuilder();
-        }
-
-        @Bean
-        public BeansFeedBuilder testBeansFeedBuilder(
-                BeanMetaInfoExtractor beanMetaInfoExtractor,
-                ConfigurableApplicationContext configurableApplicationContext) {
-            return new DefaultBeansFeedBuilder(beanMetaInfoExtractor, configurableApplicationContext);
-        }
-
-        @Bean(BEAN_META_INFO_EXTRACTOR)
-        public BeanMetaInfoExtractor beanMetaInfoExtractor(
-                ConfigurableApplicationContext configurableApplicationContext,
-                ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
-            return new DefaultBeanMetaInfoExtractor(configurableApplicationContext, conditionalBeanRefBuilder);
-        }
-
-        @Bean(QUALIFIERS_PERSISTENCE_POST_PROCESSOR)
-        public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
-            return new QualifiersPersistencePostProcessor();
-        }
-
-        @Bean(CUSTOM_SUPPLIER)
-        public Supplier<String> customSupplier() {
-            return () -> "value";
-        }
-    }
-
-    @ConfigurationProperties(prefix = "axelix.prop.test")
-    static class AxelixPropTest {
-
-        private String name;
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-    }
 
     @Test
     void shouldReturnEnrichedBeansFeed() {


### PR DESCRIPTION
## What

Folds `AxelixBeansEndpointTest` into the shared `AbstractBeansSharedContextTest` cached context, so the entire `beans` test package uses a **single** Spring `ApplicationContext` instead of two.

- The endpoint configuration (`CurrentConfiguration`, `AxelixPropTest`, the `RANDOM_PORT` web environment, the actuator endpoint imports and the test property source) is moved into the parent — which keeps owning the shared configuration directly and never references its subclasses.
- `AxelixBeansEndpointTest` becomes a thin subclass with only its test methods.
- The duplicate `conditionalBeanRefBuilder` / `beanMetaInfoExtractor` / `qualifiersPersistencePostProcessor` beans are removed from `DefaultBeanAnalyzerTestConfig`, since they would otherwise collide with `CurrentConfiguration`'s beans now that both live in the same context (bean overriding is disabled).

## Why

One cached context for the whole package → fewer context loads / faster test runs.

## Stacked on #1263

This PR builds on #1263 (configuration centralization) and should be merged **after** it. Until #1263 merges, the diff here also contains that commit — review the second commit, *"Share the beans cached context with the endpoint test"*, for the net change.

## Verification

- `spring-test-profiler` report shows all three beans test classes (`DefaultBeanMetaInfoExtractorTest`, `AxelixBeansEndpointTest`, `QualifiersPersistencePostProcessorTest`) sharing one context.
- Full `:sbs:axelix-spring-boot-3-starter:build` (tests + Spotless + PMD + NullAway) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)