### PR TITLE
GH-1261: Add SemanticVersion value object to common/utils

### DIFF
--- a/common/utils/src/main/java/com/axelixlabs/axelix/common/utils/SemanticVersion.java
+++ b/common/utils/src/main/java/com/axelixlabs/axelix/common/utils/SemanticVersion.java
@@ -19,6 +19,7 @@ package com.axelixlabs.axelix.common.utils;
 
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.Set;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -32,9 +33,13 @@ import org.jspecify.annotations.Nullable;
  * separator. So postfixes such as {@code .RELEASE}, {@code .Final} or {@code -SNAPSHOT} are
  * recognised and stripped from the numeric accessors (e.g. {@code 3.0.15.RELEASE} yields major
  * {@code 3}, minor {@code 0}, patch {@code 15} and qualifier {@code RELEASE}).
+ * <p>
+ * Note, that according to SemVer specification, the semantic version MUST have the major, minor and
+ * the patch. Missing any of those will result in parsing error.
  *
- * @author Nikita Kirillov
  * @author Artemiy Degtyarev
+ * @author Nikita Kirillov
+ * @author Mikhail Polivakha
  */
 public class SemanticVersion implements Comparable<SemanticVersion> {
 
@@ -74,85 +79,65 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      *
      * @param version the version string to parse, may be {@code null}
      * @return the parsed {@link SemanticVersion}, or {@link Optional#empty()} if the version is
-     *         {@code null}, blank or does not start with a numeric major segment
+     *         {@code null}, blank or the provided {@link String} does not represent a valid Semantic Version.
      */
     public static Optional<SemanticVersion> tryParse(@Nullable String version) {
         if (version == null || version.isBlank()) {
             return Optional.empty();
         }
 
-        String trimmed = version.trim();
+        version = version.trim();
 
-        NumericParsingState result = parseNumeric(trimmed);
-        if (result == null) {
-            return Optional.empty();
-        }
-
-        String qualifier;
-
-        try {
-            qualifier = parseQualifier(trimmed, result.getPos());
-        } catch (IllegalArgumentException ex) {
-            return Optional.empty();
-        }
-
-        return Optional.of(new SemanticVersion(result.getMajor(), result.getMinor(), result.getPatch(), qualifier));
-    }
-
-    /**
-     * Parses numeric part from given version string
-     * @param version version string
-     *
-     * @return {@link NumericParsingState} or {@code null} when invalid version format
-     */
-    private static @Nullable NumericParsingState parseNumeric(String version) {
         int majorEnd = version.indexOf('.');
         int minorEnd = majorEnd == -1 ? -1 : version.indexOf('.', majorEnd + 1);
         int patchEnd = minorEnd == -1 ? -1 : getLastDigitIdx(version, minorEnd + 1, version.length());
 
         if (majorEnd == -1 || minorEnd == -1 || patchEnd == -1) {
-            return null;
+            return Optional.empty();
         }
 
         Integer major = parseNumber(version, 0, majorEnd);
         Integer minor = parseNumber(version, majorEnd + 1, minorEnd);
         Integer patch = parseNumber(version, minorEnd + 1, patchEnd);
 
-        if (major == null || minor == null || patch == null) {
-            return null;
+        String qualifier;
+
+        try {
+            qualifier = parseQualifier(version, patchEnd);
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
         }
 
-        return new NumericParsingState(major, minor, patch, patchEnd);
+        if (major == null || minor == null || patch == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new SemanticVersion(major, minor, patch, qualifier));
     }
 
     /**
-     * Parses qualifier from given version string
-     * @param version version string
-     * @param pos position of last patch digit
+     * Parses qualifier from given version string.
      *
-     * @return qualifier string
+     * @param version version string.
+     * @param pos position where the separator of the qualifier is supposed to start.
      *
-     * @throws IllegalArgumentException when version haven't separator between patch and qualifier
-     * @throws IllegalArgumentException when version haven't content after separator
+     * @return parsed qualifier or {@code null} if there is no.
+     * @throws IllegalArgumentException if the qualifier cannot be parsed.
      */
-    private static @Nullable String parseQualifier(String version, int pos) {
-        String qualifier = null;
-
-        if (pos < version.length()) {
-            if (pos + 2 > version.length()) {
-                throw new IllegalArgumentException("qualifier should have content after separator");
-            }
-
-            char separator = version.charAt(pos);
-
-            if (separator == '#' || Character.isLetter(separator)) {
-                throw new IllegalArgumentException("version must have separator between patch and qualifier");
-            }
-
-            qualifier = version.substring(pos + 1);
+    private static @Nullable String parseQualifier(String version, int pos) throws IllegalArgumentException {
+        if (pos == version.length()) {
+            return null;
         }
 
-        return qualifier;
+        if (pos + 1 >= version.length()) {
+            throw new IllegalArgumentException("Invalid version qualifier - no content"); // like 1.0.0- or 1.0.0.
+        }
+
+        if (!Set.of('-', '.').contains(version.charAt(pos))) {
+            throw new IllegalArgumentException("Invalid version qualifier - invalid separator"); // like 1.0.0#alpha or 1.0.0+beta1
+        }
+
+        return version.substring(pos + 1);
     }
 
     /**
@@ -252,36 +237,4 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
         return ORDER.compare(this, other);
     }
 
-    /**
-     * State of numeric version parsing process
-     */
-    private static class NumericParsingState {
-        private final int major;
-        private final int minor;
-        private final int patch;
-        private final int pos;
-
-        NumericParsingState(int major, int minor, int patch, int pos) {
-            this.major = major;
-            this.minor = minor;
-            this.patch = patch;
-            this.pos = pos;
-        }
-
-        public int getMajor() {
-            return major;
-        }
-
-        public int getMinor() {
-            return minor;
-        }
-
-        public int getPatch() {
-            return patch;
-        }
-
-        public int getPos() {
-            return pos;
-        }
-    }
 }

--- a/common/utils/src/main/java/com/axelixlabs/axelix/common/utils/SemanticVersion.java
+++ b/common/utils/src/main/java/com/axelixlabs/axelix/common/utils/SemanticVersion.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.common.utils;
+
+import java.util.Optional;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Immutable semantic version value object.
+ * <p>
+ * Parses a version string into its leading numeric {@code major.minor.patch} segments and an
+ * optional trailing qualifier. At most three numeric segments are consumed; everything after
+ * {@code patch} is the qualifier, which may be introduced by either a {@code .} or a {@code -}
+ * separator. So postfixes such as {@code .RELEASE}, {@code .Final} or {@code -SNAPSHOT} are
+ * recognised and stripped from the numeric accessors (e.g. {@code 3.0.15.RELEASE} yields major
+ * {@code 3}, minor {@code 0}, patch {@code 15} and qualifier {@code RELEASE}).
+ *
+ * @author Nikita Kirillov
+ * @author Artemiy Degtyarev
+ */
+public class SemanticVersion {
+
+    private final int major;
+    private final int minor;
+    private final int patch;
+    private final boolean hasMinor;
+    private final boolean hasPatch;
+    private final @Nullable String qualifier;
+
+    private SemanticVersion(
+            int major, int minor, int patch, boolean hasMinor, boolean hasPatch, @Nullable String qualifier) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+        this.hasMinor = hasMinor;
+        this.hasPatch = hasPatch;
+        this.qualifier = qualifier;
+    }
+
+    /**
+     * Parses the given version string.
+     *
+     * @param version the version string to parse
+     * @return the parsed {@link SemanticVersion}
+     * @throws IllegalArgumentException if the version is {@code null}, blank or does not start with
+     *                                  a numeric major segment
+     */
+    public static SemanticVersion parse(String version) {
+        return tryParse(version)
+                .orElseThrow(() -> new IllegalArgumentException("Not a valid semantic version: " + version));
+    }
+
+    /**
+     * Leniently parses the given version string.
+     *
+     * @param version the version string to parse, may be {@code null}
+     * @return the parsed {@link SemanticVersion}, or {@link Optional#empty()} if the version is
+     *         {@code null}, blank or does not start with a numeric major segment
+     */
+    public static Optional<SemanticVersion> tryParse(@Nullable String version) {
+        if (version == null || version.isBlank()) {
+            return Optional.empty();
+        }
+
+        String trimmed = version.trim();
+
+        // Substring the leading major.minor.patch numeric run; everything after it is the qualifier.
+        int[] numbers = {0, 0, 0};
+        int[] scan = scanNumericSegments(trimmed, numbers);
+        int numericCount = scan[0];
+        int qualifierStart = scan[1];
+
+        if (numericCount == 0) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new SemanticVersion(
+                numbers[0],
+                numbers[1],
+                numbers[2],
+                numericCount >= 2,
+                numericCount >= 3,
+                qualifierFrom(trimmed, qualifierStart)));
+    }
+
+    /**
+     * Reads the leading {@code major.minor.patch} numeric segments into {@code numbers}, splitting on
+     * {@code .} like {@link String#indexOf(int)}.
+     *
+     * @return a two-element array of {@code [number of segments read, index where the qualifier starts]}
+     */
+    private static int[] scanNumericSegments(String version, int[] numbers) {
+        int length = version.length();
+        int count = 0;
+        int pos = 0;
+        while (count < numbers.length && pos < length) {
+            int dot = version.indexOf('.', pos);
+            int segmentEnd = dot == -1 ? length : dot;
+            int digits = leadingDigitCount(version, pos, segmentEnd);
+            if (digits == 0) {
+                break;
+            }
+            numbers[count++] = Integer.parseInt(version.substring(pos, pos + digits));
+            if (pos + digits < segmentEnd) {
+                // A qualifier is glued to this segment without a separator, e.g. "19u" or "0-SNAPSHOT".
+                pos += digits;
+                break;
+            }
+            pos = dot == -1 ? length : dot + 1;
+        }
+        return new int[] {count, pos};
+    }
+
+    private static int leadingDigitCount(String version, int start, int end) {
+        int pos = start;
+        while (pos < end && Character.isDigit(version.charAt(pos))) {
+            pos++;
+        }
+        return pos - start;
+    }
+
+    private static @Nullable String qualifierFrom(String version, int pos) {
+        if (pos >= version.length()) {
+            return null;
+        }
+        char separator = version.charAt(pos);
+        int start = separator == '.' || separator == '-' ? pos + 1 : pos;
+        return start < version.length() ? version.substring(start) : null;
+    }
+
+    /**
+     * @return the major version segment, e.g. {@code 3}
+     */
+    public int major() {
+        return major;
+    }
+
+    /**
+     * @return the minor version segment, or {@code 0} when none was present
+     */
+    public int minor() {
+        return minor;
+    }
+
+    /**
+     * @return the {@code major.minor} segments, or just the major when no minor was present
+     *         (e.g. {@code "3.0"}, but {@code "11"} for the input {@code "11"})
+     */
+    public String majorMinor() {
+        return hasMinor ? major + "." + minor : Integer.toString(major);
+    }
+
+    /**
+     * @return the numeric {@code major.minor.patch} version with the qualifier stripped; only the
+     *         segments that were present are included (e.g. {@code "3.0.15"}, {@code "2.0"},
+     *         {@code "11"})
+     */
+    public String versionNumber() {
+        StringBuilder builder = new StringBuilder(Integer.toString(major));
+        if (hasMinor) {
+            builder.append('.').append(minor);
+        }
+        if (hasPatch) {
+            builder.append('.').append(patch);
+        }
+        return builder.toString();
+    }
+
+    /**
+     * @return the patch version segment, or {@code 0} when none was present
+     */
+    public int patch() {
+        return patch;
+    }
+
+    /**
+     * @return the trailing qualifier (e.g. {@code "RELEASE"}, {@code "Final"}, {@code "SNAPSHOT"}),
+     *         or {@code null} when none was present
+     */
+    public @Nullable String qualifier() {
+        return qualifier;
+    }
+}

--- a/common/utils/src/main/java/com/axelixlabs/axelix/common/utils/SemanticVersion.java
+++ b/common/utils/src/main/java/com/axelixlabs/axelix/common/utils/SemanticVersion.java
@@ -82,7 +82,15 @@ public class SemanticVersion {
 
         // Substring the leading major.minor.patch numeric run; everything after it is the qualifier.
         int[] numbers = {0, 0, 0};
-        int[] scan = scanNumericSegments(trimmed, numbers);
+
+        int[] scan;
+
+        try {
+            scan = scanNumericSegments(trimmed, numbers);
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
+
         int numericCount = scan[0];
         int qualifierStart = scan[1];
 

--- a/common/utils/src/main/java/com/axelixlabs/axelix/common/utils/SemanticVersion.java
+++ b/common/utils/src/main/java/com/axelixlabs/axelix/common/utils/SemanticVersion.java
@@ -203,31 +203,28 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
     }
 
     /**
-     * @return the minor version segment, or {@code 0} when none was present
+     * @return the minor version segment
      */
     public int minor() {
         return minor;
     }
 
     /**
-     * @return the {@code major.minor} segments, or just the major when no minor was present
-     *         (e.g. {@code "3.0"}, but {@code "11"} for the input {@code "11"})
+     * @return the {@code major.minor} segments
      */
     public String majorMinor() {
         return major + "." + minor;
     }
 
     /**
-     * @return the numeric {@code major.minor.patch} version with the qualifier stripped; only the
-     *         segments that were present are included (e.g. {@code "3.0.15"}, {@code "2.0"},
-     *         {@code "11"})
+     * @return the numeric {@code major.minor.patch} version with the qualifier stripped
      */
     public String versionNumber() {
         return major + "." + minor + "." + patch;
     }
 
     /**
-     * @return the patch version segment, or {@code 0} when none was present
+     * @return the patch version segment
      */
     public int patch() {
         return patch;

--- a/common/utils/src/main/java/com/axelixlabs/axelix/common/utils/SemanticVersion.java
+++ b/common/utils/src/main/java/com/axelixlabs/axelix/common/utils/SemanticVersion.java
@@ -20,6 +20,7 @@ package com.axelixlabs.axelix.common.utils;
 import java.util.Comparator;
 import java.util.Optional;
 
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -46,17 +47,12 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
     private final int major;
     private final int minor;
     private final int patch;
-    private final boolean hasMinor;
-    private final boolean hasPatch;
     private final @Nullable String qualifier;
 
-    private SemanticVersion(
-            int major, int minor, int patch, boolean hasMinor, boolean hasPatch, @Nullable String qualifier) {
+    SemanticVersion(int major, int minor, int patch, @Nullable String qualifier) {
         this.major = major;
         this.minor = minor;
         this.patch = patch;
-        this.hasMinor = hasMinor;
-        this.hasPatch = hasPatch;
         this.qualifier = qualifier;
     }
 
@@ -87,76 +83,116 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
 
         String trimmed = version.trim();
 
-        // Substring the leading major.minor.patch numeric run; everything after it is the qualifier.
-        int[] numbers = {0, 0, 0};
+        NumericParsingState result = parseNumeric(trimmed);
+        if (result == null) {
+            return Optional.empty();
+        }
 
-        int[] scan;
+        String qualifier;
 
         try {
-            scan = scanNumericSegments(trimmed, numbers);
-        } catch (NumberFormatException ex) {
+            qualifier = parseQualifier(trimmed, result.getPos());
+        } catch (IllegalArgumentException ex) {
             return Optional.empty();
         }
 
-        int numericCount = scan[0];
-        int qualifierStart = scan[1];
-
-        if (numericCount == 0) {
-            return Optional.empty();
-        }
-
-        return Optional.of(new SemanticVersion(
-                numbers[0],
-                numbers[1],
-                numbers[2],
-                numericCount >= 2,
-                numericCount >= 3,
-                qualifierFrom(trimmed, qualifierStart)));
+        return Optional.of(new SemanticVersion(result.getMajor(), result.getMinor(), result.getPatch(), qualifier));
     }
 
     /**
-     * Reads the leading {@code major.minor.patch} numeric segments into {@code numbers}, splitting on
-     * {@code .} like {@link String#indexOf(int)}.
+     * Parses numeric part from given version string
+     * @param version version string
      *
-     * @return a two-element array of {@code [number of segments read, index where the qualifier starts]}
+     * @return {@link NumericParsingState} or {@code null} when invalid version format
      */
-    private static int[] scanNumericSegments(String version, int[] numbers) {
-        int length = version.length();
-        int count = 0;
-        int pos = 0;
-        while (count < numbers.length && pos < length) {
-            int dot = version.indexOf('.', pos);
-            int segmentEnd = dot == -1 ? length : dot;
-            int digits = leadingDigitCount(version, pos, segmentEnd);
-            if (digits == 0) {
-                break;
-            }
-            numbers[count++] = Integer.parseInt(version.substring(pos, pos + digits));
-            if (pos + digits < segmentEnd) {
-                // A qualifier is glued to this segment without a separator, e.g. "19u" or "0-SNAPSHOT".
-                pos += digits;
-                break;
-            }
-            pos = dot == -1 ? length : dot + 1;
-        }
-        return new int[] {count, pos};
-    }
+    private static @Nullable NumericParsingState parseNumeric(String version) {
+        int majorEnd = version.indexOf('.');
+        int minorEnd = majorEnd == -1 ? -1 : version.indexOf('.', majorEnd + 1);
+        int patchEnd = minorEnd == -1 ? -1 : getLastDigitIdx(version, minorEnd + 1, version.length());
 
-    private static int leadingDigitCount(String version, int start, int end) {
-        int pos = start;
-        while (pos < end && Character.isDigit(version.charAt(pos))) {
-            pos++;
-        }
-        return pos - start;
-    }
-
-    private static @Nullable String qualifierFrom(String version, int pos) {
-        if (pos >= version.length()) {
+        if (majorEnd == -1 || minorEnd == -1 || patchEnd == -1) {
             return null;
         }
-        char separator = version.charAt(pos);
-        int start = separator == '.' || separator == '-' ? pos + 1 : pos;
-        return start < version.length() ? version.substring(start) : null;
+
+        Integer major = parseNumber(version, 0, majorEnd);
+        Integer minor = parseNumber(version, majorEnd + 1, minorEnd);
+        Integer patch = parseNumber(version, minorEnd + 1, patchEnd);
+
+        if (major == null || minor == null || patch == null) {
+            return null;
+        }
+
+        return new NumericParsingState(major, minor, patch, patchEnd);
+    }
+
+    /**
+     * Parses qualifier from given version string
+     * @param version version string
+     * @param pos position of last patch digit
+     *
+     * @return qualifier string
+     *
+     * @throws IllegalArgumentException when version haven't separator between patch and qualifier
+     * @throws IllegalArgumentException when version haven't content after separator
+     */
+    private static @Nullable String parseQualifier(String version, int pos) {
+        String qualifier = null;
+
+        if (pos < version.length()) {
+            if (pos + 2 > version.length()) {
+                throw new IllegalArgumentException("qualifier should have content after separator");
+            }
+
+            char separator = version.charAt(pos);
+
+            if (separator == '#' || Character.isLetter(separator)) {
+                throw new IllegalArgumentException("version must have separator between patch and qualifier");
+            }
+
+            qualifier = version.substring(pos + 1);
+        }
+
+        return qualifier;
+    }
+
+    /**
+     * Parses number from version string
+     *
+     * @param version version string
+     * @param start idx of first digit
+     * @param end idx of last digit
+     *
+     * @return number from version string or {@code null} when invalid number
+     */
+    private static @Nullable Integer parseNumber(String version, int start, int end) {
+        String substr = version.substring(start, end);
+
+        try {
+            return Integer.parseInt(substr);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param version string
+     * @param start first char idx
+     * @param end last char idx
+     * @return idx of last digit in selected range in version string
+     */
+    private static int getLastDigitIdx(@NonNull String version, int start, int end) {
+        int result = start;
+
+        while (result < end) {
+            char c = version.charAt(result);
+
+            if (!Character.isDigit(c)) {
+                break;
+            }
+
+            result++;
+        }
+        return result;
     }
 
     /**
@@ -178,7 +214,7 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      *         (e.g. {@code "3.0"}, but {@code "11"} for the input {@code "11"})
      */
     public String majorMinor() {
-        return hasMinor ? major + "." + minor : Integer.toString(major);
+        return major + "." + minor;
     }
 
     /**
@@ -187,14 +223,7 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      *         {@code "11"})
      */
     public String versionNumber() {
-        StringBuilder builder = new StringBuilder(Integer.toString(major));
-        if (hasMinor) {
-            builder.append('.').append(minor);
-        }
-        if (hasPatch) {
-            builder.append('.').append(patch);
-        }
-        return builder.toString();
+        return major + "." + minor + "." + patch;
     }
 
     /**
@@ -222,7 +251,40 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      *         or greater than {@code other}
      */
     @Override
-    public int compareTo(SemanticVersion other) {
+    public int compareTo(@NonNull SemanticVersion other) {
         return ORDER.compare(this, other);
+    }
+
+    /**
+     * State of numeric version parsing process
+     */
+    private static class NumericParsingState {
+        private final int major;
+        private final int minor;
+        private final int patch;
+        private final int pos;
+
+        NumericParsingState(int major, int minor, int patch, int pos) {
+            this.major = major;
+            this.minor = minor;
+            this.patch = patch;
+            this.pos = pos;
+        }
+
+        public int getMajor() {
+            return major;
+        }
+
+        public int getMinor() {
+            return minor;
+        }
+
+        public int getPatch() {
+            return patch;
+        }
+
+        public int getPos() {
+            return pos;
+        }
     }
 }

--- a/common/utils/src/main/java/com/axelixlabs/axelix/common/utils/SemanticVersion.java
+++ b/common/utils/src/main/java/com/axelixlabs/axelix/common/utils/SemanticVersion.java
@@ -17,6 +17,7 @@
  */
 package com.axelixlabs.axelix.common.utils;
 
+import java.util.Comparator;
 import java.util.Optional;
 
 import org.jspecify.annotations.Nullable;
@@ -34,7 +35,13 @@ import org.jspecify.annotations.Nullable;
  * @author Nikita Kirillov
  * @author Artemiy Degtyarev
  */
-public class SemanticVersion {
+public class SemanticVersion implements Comparable<SemanticVersion> {
+
+    private static final Comparator<SemanticVersion> ORDER = Comparator.comparingInt(SemanticVersion::major)
+            .thenComparingInt(SemanticVersion::minor)
+            .thenComparingInt(SemanticVersion::patch)
+            // A qualifier (e.g. a pre-release like -SNAPSHOT) sorts below the same version without one.
+            .thenComparing(version -> version.qualifier == null);
 
     private final int major;
     private final int minor;
@@ -203,5 +210,19 @@ public class SemanticVersion {
      */
     public @Nullable String qualifier() {
         return qualifier;
+    }
+
+    /**
+     * Orders by numeric {@code major.minor.patch}; when those are equal, a version that carries a
+     * qualifier (e.g. a pre-release like {@code -SNAPSHOT}) sorts below the same version without one.
+     * The qualifier text itself is not ordered, so two qualified versions compare as equal — e.g.
+     * {@code 1.0.0-SNAPSHOT} and {@code 1.0.0.RELEASE} are equal, but both are less than {@code 1.0.0}.
+     *
+     * @return a negative integer, zero, or a positive integer as this version is less than, equal to,
+     *         or greater than {@code other}
+     */
+    @Override
+    public int compareTo(SemanticVersion other) {
+        return ORDER.compare(this, other);
     }
 }

--- a/common/utils/src/test/java/com/axelixlabs/axelix/common/utils/SemanticVersionTest.java
+++ b/common/utils/src/test/java/com/axelixlabs/axelix/common/utils/SemanticVersionTest.java
@@ -17,6 +17,7 @@
  */
 package com.axelixlabs.axelix.common.utils;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Nested;
@@ -43,16 +44,16 @@ class SemanticVersionTest {
         @ParameterizedTest
         @MethodSource("invalidVersions")
         void tryParseReturnsEmpty(String input) {
-            // when.
-            // then.
-            assertThat(SemanticVersion.tryParse(input)).isEmpty();
+            // when
+            Optional<SemanticVersion> actual = SemanticVersion.tryParse(input);
+
+            // then
+            assertThat(actual).isEmpty();
         }
 
         @ParameterizedTest
         @MethodSource("invalidVersions")
         void parseThrows(String input) {
-            // when.
-            // then.
             assertThatThrownBy(() -> SemanticVersion.parse(input)).isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -73,10 +74,10 @@ class SemanticVersionTest {
         @ParameterizedTest
         @MethodSource("majorCases")
         void major(String input, int expected) {
-            // when.
+            // when
             int actual = SemanticVersion.parse(input).major();
 
-            // then.
+            // then
             assertThat(actual).isEqualTo(expected);
         }
 
@@ -99,10 +100,10 @@ class SemanticVersionTest {
         @ParameterizedTest
         @MethodSource("minorCases")
         void minor(String input, int expected) {
-            // when.
+            // when
             int actual = SemanticVersion.parse(input).minor();
 
-            // then.
+            // then
             assertThat(actual).isEqualTo(expected);
         }
 
@@ -124,10 +125,10 @@ class SemanticVersionTest {
         @ParameterizedTest
         @MethodSource("majorMinorCases")
         void majorMinor(String input, String expected) {
-            // when.
+            // when
             String actual = SemanticVersion.parse(input).majorMinor();
 
-            // then.
+            // then
             assertThat(actual).isEqualTo(expected);
         }
 
@@ -150,10 +151,10 @@ class SemanticVersionTest {
         @ParameterizedTest
         @MethodSource("versionNumberCases")
         void versionNumber(String input, String expected) {
-            // when.
+            // when
             String actual = SemanticVersion.parse(input).versionNumber();
 
-            // then.
+            // then
             assertThat(actual).isEqualTo(expected);
         }
 
@@ -176,10 +177,10 @@ class SemanticVersionTest {
         @ParameterizedTest
         @MethodSource("patchCases")
         void patch(String input, int expected) {
-            // when.
+            // when
             int actual = SemanticVersion.parse(input).patch();
 
-            // then.
+            // then
             assertThat(actual).isEqualTo(expected);
         }
 
@@ -200,10 +201,10 @@ class SemanticVersionTest {
         @ParameterizedTest
         @MethodSource("qualifierCases")
         void qualifier(String input, String expected) {
-            // when.
+            // when
             String actual = SemanticVersion.parse(input).qualifier();
 
-            // then.
+            // then
             assertThat(actual).isEqualTo(expected);
         }
 

--- a/common/utils/src/test/java/com/axelixlabs/axelix/common/utils/SemanticVersionTest.java
+++ b/common/utils/src/test/java/com/axelixlabs/axelix/common/utils/SemanticVersionTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.common.utils;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link SemanticVersion}.
+ *
+ * @author Nikita Kirillov
+ * @author Artemiy Degtyarev
+ */
+class SemanticVersionTest {
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class Parse {
+
+        @ParameterizedTest
+        @MethodSource("invalidVersions")
+        void tryParseReturnsEmpty(String input) {
+            // when.
+            // then.
+            assertThat(SemanticVersion.tryParse(input)).isEmpty();
+        }
+
+        @ParameterizedTest
+        @MethodSource("invalidVersions")
+        void parseThrows(String input) {
+            // when.
+            // then.
+            assertThatThrownBy(() -> SemanticVersion.parse(input)).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        Stream<Arguments> invalidVersions() {
+            return Stream.of(
+                    Arguments.of((String) null),
+                    Arguments.of(""),
+                    Arguments.of("   "),
+                    Arguments.of("abc"),
+                    Arguments.of("v1"));
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class Major {
+
+        @ParameterizedTest
+        @MethodSource("majorCases")
+        void major(String input, int expected) {
+            // when.
+            int actual = SemanticVersion.parse(input).major();
+
+            // then.
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        Stream<Arguments> majorCases() {
+            return Stream.of(
+                    Arguments.of("17.0.19u", 17),
+                    Arguments.of("3.5.2", 3),
+                    Arguments.of("11", 11),
+                    Arguments.of("2.0", 2),
+                    Arguments.of("1.2.3.4", 1),
+                    Arguments.of("2.5.0-SNAPSHOT", 2),
+                    Arguments.of("3.0.0-RELEASE", 3));
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class Minor {
+
+        @ParameterizedTest
+        @MethodSource("minorCases")
+        void minor(String input, int expected) {
+            // when.
+            int actual = SemanticVersion.parse(input).minor();
+
+            // then.
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        Stream<Arguments> minorCases() {
+            return Stream.of(
+                    Arguments.of("17.0.19u", 0),
+                    Arguments.of("3.5.2", 5),
+                    Arguments.of("11", 0),
+                    Arguments.of("2.4", 4),
+                    Arguments.of("1.2.3.4", 2),
+                    Arguments.of("2.5.0-SNAPSHOT", 5));
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class MajorMinor {
+
+        @ParameterizedTest
+        @MethodSource("majorMinorCases")
+        void majorMinor(String input, String expected) {
+            // when.
+            String actual = SemanticVersion.parse(input).majorMinor();
+
+            // then.
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        Stream<Arguments> majorMinorCases() {
+            return Stream.of(
+                    Arguments.of("17.0.19u", "17.0"),
+                    Arguments.of("3.5.2", "3.5"),
+                    Arguments.of("1.2.3.4", "1.2"),
+                    Arguments.of("11.0", "11.0"),
+                    Arguments.of("11", "11"),
+                    Arguments.of("2.5.0-SNAPSHOT", "2.5"),
+                    Arguments.of("3.0.0-RELEASE", "3.0"));
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class VersionNumber {
+
+        @ParameterizedTest
+        @MethodSource("versionNumberCases")
+        void versionNumber(String input, String expected) {
+            // when.
+            String actual = SemanticVersion.parse(input).versionNumber();
+
+            // then.
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        Stream<Arguments> versionNumberCases() {
+            return Stream.of(
+                    Arguments.of("3.0.15.RELEASE", "3.0.15"),
+                    Arguments.of("1.2.0.Final", "1.2.0"),
+                    Arguments.of("2.5.0-SNAPSHOT", "2.5.0"),
+                    Arguments.of("17.0.19u", "17.0.19"),
+                    Arguments.of("1.2.3.4", "1.2.3"),
+                    Arguments.of("11", "11"),
+                    Arguments.of("2.0", "2.0"));
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class PatchSegment {
+
+        @ParameterizedTest
+        @MethodSource("patchCases")
+        void patch(String input, int expected) {
+            // when.
+            int actual = SemanticVersion.parse(input).patch();
+
+            // then.
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        Stream<Arguments> patchCases() {
+            return Stream.of(
+                    Arguments.of("3.0.15.RELEASE", 15),
+                    Arguments.of("1.2.3.4", 3),
+                    Arguments.of("17.0.19u", 19),
+                    Arguments.of("2.0", 0),
+                    Arguments.of("11", 0));
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class QualifierSuffix {
+
+        @ParameterizedTest
+        @MethodSource("qualifierCases")
+        void qualifier(String input, String expected) {
+            // when.
+            String actual = SemanticVersion.parse(input).qualifier();
+
+            // then.
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        Stream<Arguments> qualifierCases() {
+            return Stream.of(
+                    Arguments.of("3.0.15.RELEASE", "RELEASE"),
+                    Arguments.of("1.2.0.Final", "Final"),
+                    Arguments.of("2.5.0-SNAPSHOT", "SNAPSHOT"),
+                    Arguments.of("17.0.19u", "u"),
+                    Arguments.of("1.2.3.4", "4"),
+                    Arguments.of("11", null));
+        }
+    }
+}

--- a/common/utils/src/test/java/com/axelixlabs/axelix/common/utils/SemanticVersionTest.java
+++ b/common/utils/src/test/java/com/axelixlabs/axelix/common/utils/SemanticVersionTest.java
@@ -20,8 +20,6 @@ package com.axelixlabs.axelix.common.utils;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -37,218 +35,162 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class SemanticVersionTest {
 
-    @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class Parse {
+    @ParameterizedTest
+    @MethodSource("invalidVersions")
+    void tryParseReturnsEmpty(String input) {
+        // when
+        Optional<SemanticVersion> actual = SemanticVersion.tryParse(input);
 
-        @ParameterizedTest
-        @MethodSource("invalidVersions")
-        void tryParseReturnsEmpty(String input) {
-            // when
-            Optional<SemanticVersion> actual = SemanticVersion.tryParse(input);
-
-            // then
-            assertThat(actual).isEmpty();
-        }
-
-        @ParameterizedTest
-        @MethodSource("invalidVersions")
-        void parseThrows(String input) {
-            assertThatThrownBy(() -> SemanticVersion.parse(input)).isInstanceOf(IllegalArgumentException.class);
-        }
-
-        Stream<Arguments> invalidVersions() {
-            return Stream.of(
-                    Arguments.of((String) null),
-                    Arguments.of(""),
-                    Arguments.of("   "),
-                    Arguments.of("abc"),
-                    Arguments.of("v1"));
-        }
+        // then
+        assertThat(actual).isEmpty();
     }
 
-    @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class Major {
-
-        @ParameterizedTest
-        @MethodSource("majorCases")
-        void major(String input, int expected) {
-            // when
-            int actual = SemanticVersion.parse(input).major();
-
-            // then
-            assertThat(actual).isEqualTo(expected);
-        }
-
-        Stream<Arguments> majorCases() {
-            return Stream.of(
-                    Arguments.of("17.0.19u", 17),
-                    Arguments.of("3.5.2", 3),
-                    Arguments.of("11", 11),
-                    Arguments.of("2.0", 2),
-                    Arguments.of("1.2.3.4", 1),
-                    Arguments.of("2.5.0-SNAPSHOT", 2),
-                    Arguments.of("3.0.0-RELEASE", 3));
-        }
+    @ParameterizedTest
+    @MethodSource("invalidVersions")
+    void parseThrows(String input) {
+        assertThatThrownBy(() -> SemanticVersion.parse(input)).isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class Minor {
-
-        @ParameterizedTest
-        @MethodSource("minorCases")
-        void minor(String input, int expected) {
-            // when
-            int actual = SemanticVersion.parse(input).minor();
-
-            // then
-            assertThat(actual).isEqualTo(expected);
-        }
-
-        Stream<Arguments> minorCases() {
-            return Stream.of(
-                    Arguments.of("17.0.19u", 0),
-                    Arguments.of("3.5.2", 5),
-                    Arguments.of("11", 0),
-                    Arguments.of("2.4", 4),
-                    Arguments.of("1.2.3.4", 2),
-                    Arguments.of("2.5.0-SNAPSHOT", 5));
-        }
+    static Stream<Arguments> invalidVersions() {
+        return Stream.of(
+                Arguments.of((String) null),
+                Arguments.of(""),
+                Arguments.of("   "),
+                Arguments.of("abc"),
+                Arguments.of("v1"),
+                Arguments.of("1"),
+                Arguments.of("1.0"),
+                Arguments.of("1.0.0beta"),
+                Arguments.of("1x2x3"),
+                Arguments.of("1-2.3"),
+                Arguments.of("1.2.3-"));
     }
 
-    @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class MajorMinor {
+    @ParameterizedTest
+    @MethodSource("majorCases")
+    void major(String input, int expected) {
+        // when
+        int actual = SemanticVersion.parse(input).major();
 
-        @ParameterizedTest
-        @MethodSource("majorMinorCases")
-        void majorMinor(String input, String expected) {
-            // when
-            String actual = SemanticVersion.parse(input).majorMinor();
-
-            // then
-            assertThat(actual).isEqualTo(expected);
-        }
-
-        Stream<Arguments> majorMinorCases() {
-            return Stream.of(
-                    Arguments.of("17.0.19u", "17.0"),
-                    Arguments.of("3.5.2", "3.5"),
-                    Arguments.of("1.2.3.4", "1.2"),
-                    Arguments.of("11.0", "11.0"),
-                    Arguments.of("11", "11"),
-                    Arguments.of("2.5.0-SNAPSHOT", "2.5"),
-                    Arguments.of("3.0.0-RELEASE", "3.0"));
-        }
+        // then
+        assertThat(actual).isEqualTo(expected);
     }
 
-    @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class VersionNumber {
-
-        @ParameterizedTest
-        @MethodSource("versionNumberCases")
-        void versionNumber(String input, String expected) {
-            // when
-            String actual = SemanticVersion.parse(input).versionNumber();
-
-            // then
-            assertThat(actual).isEqualTo(expected);
-        }
-
-        Stream<Arguments> versionNumberCases() {
-            return Stream.of(
-                    Arguments.of("3.0.15.RELEASE", "3.0.15"),
-                    Arguments.of("1.2.0.Final", "1.2.0"),
-                    Arguments.of("2.5.0-SNAPSHOT", "2.5.0"),
-                    Arguments.of("17.0.19u", "17.0.19"),
-                    Arguments.of("1.2.3.4", "1.2.3"),
-                    Arguments.of("11", "11"),
-                    Arguments.of("2.0", "2.0"));
-        }
+    static Stream<Arguments> majorCases() {
+        return Stream.of(
+                Arguments.of("3.5.2", 3),
+                Arguments.of("1.2.3.4", 1),
+                Arguments.of("2.5.0-SNAPSHOT", 2),
+                Arguments.of("3.0.0-RELEASE", 3));
     }
 
-    @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class PatchSegment {
+    @ParameterizedTest
+    @MethodSource("minorCases")
+    void minor(String input, int expected) {
+        // when
+        int actual = SemanticVersion.parse(input).minor();
 
-        @ParameterizedTest
-        @MethodSource("patchCases")
-        void patch(String input, int expected) {
-            // when
-            int actual = SemanticVersion.parse(input).patch();
-
-            // then
-            assertThat(actual).isEqualTo(expected);
-        }
-
-        Stream<Arguments> patchCases() {
-            return Stream.of(
-                    Arguments.of("3.0.15.RELEASE", 15),
-                    Arguments.of("1.2.3.4", 3),
-                    Arguments.of("17.0.19u", 19),
-                    Arguments.of("2.0", 0),
-                    Arguments.of("11", 0));
-        }
+        // then
+        assertThat(actual).isEqualTo(expected);
     }
 
-    @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class QualifierSuffix {
-
-        @ParameterizedTest
-        @MethodSource("qualifierCases")
-        void qualifier(String input, String expected) {
-            // when
-            String actual = SemanticVersion.parse(input).qualifier();
-
-            // then
-            assertThat(actual).isEqualTo(expected);
-        }
-
-        Stream<Arguments> qualifierCases() {
-            return Stream.of(
-                    Arguments.of("3.0.15.RELEASE", "RELEASE"),
-                    Arguments.of("1.2.0.Final", "Final"),
-                    Arguments.of("2.5.0-SNAPSHOT", "SNAPSHOT"),
-                    Arguments.of("17.0.19u", "u"),
-                    Arguments.of("1.2.3.4", "4"),
-                    Arguments.of("11", null));
-        }
+    static Stream<Arguments> minorCases() {
+        return Stream.of(Arguments.of("3.5.2", 5), Arguments.of("1.2.3.4", 2), Arguments.of("2.5.0-SNAPSHOT", 5));
     }
 
-    @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class Compare {
+    @ParameterizedTest
+    @MethodSource("majorMinorCases")
+    void majorMinor(String input, String expected) {
+        // when
+        String actual = SemanticVersion.parse(input).majorMinor();
 
-        @ParameterizedTest
-        @MethodSource("comparisonCases")
-        void compareTo(String left, String right, int expectedSign) {
-            // given
-            SemanticVersion a = SemanticVersion.parse(left);
-            SemanticVersion b = SemanticVersion.parse(right);
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
 
-            // when
-            int result = a.compareTo(b);
+    static Stream<Arguments> majorMinorCases() {
+        return Stream.of(
+                Arguments.of("3.5.2", "3.5"),
+                Arguments.of("1.2.3.4", "1.2"),
+                Arguments.of("2.5.0-SNAPSHOT", "2.5"),
+                Arguments.of("3.0.0-RELEASE", "3.0"));
+    }
 
-            // then
-            assertThat(Integer.signum(result)).isEqualTo(expectedSign);
-        }
+    @ParameterizedTest
+    @MethodSource("versionNumberCases")
+    void versionNumber(String input, String expected) {
+        // when
+        String actual = SemanticVersion.parse(input).versionNumber();
 
-        Stream<Arguments> comparisonCases() {
-            return Stream.of(
-                    Arguments.of("2.5.0", "2.4.9", 1),
-                    Arguments.of("2.4.9", "2.5.0", -1),
-                    Arguments.of("3.0.0", "3.0.0", 0),
-                    Arguments.of("2.0.0", "1.9.9", 1),
-                    Arguments.of("1.2.3", "1.2.4", -1),
-                    Arguments.of("1.2", "1.2.0", 0),
-                    Arguments.of("11", "11.0.0", 0),
-                    Arguments.of("1.0.0-SNAPSHOT", "1.0.0.RELEASE", 0),
-                    Arguments.of("1.0.0-SNAPSHOT", "1.0.0", -1),
-                    Arguments.of("1.0.0", "1.0.0-SNAPSHOT", 1));
-        }
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> versionNumberCases() {
+        return Stream.of(
+                Arguments.of("3.0.15.RELEASE", "3.0.15"),
+                Arguments.of("1.2.0.Final", "1.2.0"),
+                Arguments.of("2.5.0-SNAPSHOT", "2.5.0"),
+                Arguments.of("1.2.3.4", "1.2.3"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("patchCases")
+    void patch(String input, int expected) {
+        // when
+        int actual = SemanticVersion.parse(input).patch();
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> patchCases() {
+        return Stream.of(Arguments.of("3.0.15.RELEASE", 15), Arguments.of("1.2.3.4", 3));
+    }
+
+    @ParameterizedTest
+    @MethodSource("qualifierCases")
+    void qualifier(String input, String expected) {
+        // when
+        String actual = SemanticVersion.parse(input).qualifier();
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> qualifierCases() {
+        return Stream.of(
+                Arguments.of("3.0.15.RELEASE", "RELEASE"),
+                Arguments.of("1.2.0.Final", "Final"),
+                Arguments.of("2.5.0-SNAPSHOT", "SNAPSHOT"),
+                Arguments.of("1.2.3.4", "4"),
+                Arguments.of("1.2.0", null),
+                Arguments.of("1.2.0-beta.1", "beta.1"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("comparisonCases")
+    void compareTo(String left, String right, int expectedSign) {
+        // given
+        SemanticVersion a = SemanticVersion.parse(left);
+        SemanticVersion b = SemanticVersion.parse(right);
+
+        // when
+        int result = a.compareTo(b);
+
+        // then
+        assertThat(Integer.signum(result)).isEqualTo(expectedSign);
+    }
+
+    static Stream<Arguments> comparisonCases() {
+        return Stream.of(
+                Arguments.of("2.5.0", "2.4.9", 1),
+                Arguments.of("2.4.9", "2.5.0", -1),
+                Arguments.of("3.0.0", "3.0.0", 0),
+                Arguments.of("2.0.0", "1.9.9", 1),
+                Arguments.of("1.2.3", "1.2.4", -1),
+                Arguments.of("1.0.0-SNAPSHOT", "1.0.0.RELEASE", 0),
+                Arguments.of("1.0.0-SNAPSHOT", "1.0.0", -1),
+                Arguments.of("1.0.0", "1.0.0-SNAPSHOT", 1));
     }
 }

--- a/common/utils/src/test/java/com/axelixlabs/axelix/common/utils/SemanticVersionTest.java
+++ b/common/utils/src/test/java/com/axelixlabs/axelix/common/utils/SemanticVersionTest.java
@@ -218,4 +218,37 @@ class SemanticVersionTest {
                     Arguments.of("11", null));
         }
     }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class Compare {
+
+        @ParameterizedTest
+        @MethodSource("comparisonCases")
+        void compareTo(String left, String right, int expectedSign) {
+            // given
+            SemanticVersion a = SemanticVersion.parse(left);
+            SemanticVersion b = SemanticVersion.parse(right);
+
+            // when
+            int result = a.compareTo(b);
+
+            // then
+            assertThat(Integer.signum(result)).isEqualTo(expectedSign);
+        }
+
+        Stream<Arguments> comparisonCases() {
+            return Stream.of(
+                    Arguments.of("2.5.0", "2.4.9", 1),
+                    Arguments.of("2.4.9", "2.5.0", -1),
+                    Arguments.of("3.0.0", "3.0.0", 0),
+                    Arguments.of("2.0.0", "1.9.9", 1),
+                    Arguments.of("1.2.3", "1.2.4", -1),
+                    Arguments.of("1.2", "1.2.0", 0),
+                    Arguments.of("11", "11.0.0", 0),
+                    Arguments.of("1.0.0-SNAPSHOT", "1.0.0.RELEASE", 0),
+                    Arguments.of("1.0.0-SNAPSHOT", "1.0.0", -1),
+                    Arguments.of("1.0.0", "1.0.0-SNAPSHOT", 1));
+        }
+    }
 }


### PR DESCRIPTION
Part of #1261.

## What

Adds an immutable `SemanticVersion` value object to `common/utils`, so version parsing can be shared across `master` and the starter modules (today the only helper, `VersionTrimmer`, lives in `master` and can't strip qualifier postfixes).

## API

- `SemanticVersion.parse(String)` — strict, throws `IllegalArgumentException` on null/blank/non-numeric input.
- `SemanticVersion.tryParse(String)` — lenient, returns `Optional<SemanticVersion>`.
- Numeric accessors: `int major()`, `int minor()`, `int patch()`.
- Formatted views: `String majorMinor()`, `String versionNumber()` (numeric `major.minor.patch`), `@Nullable String qualifier()`.

## Parsing

At most three numeric segments are consumed (`major.minor.patch`); everything after `patch` is the qualifier, introduced by either a `.` or a `-` separator. So postfixes such as `.RELEASE`, `.Final` and `-SNAPSHOT` are recognised and stripped from the numeric accessors — e.g. `3.0.15.RELEASE` → major `3`, minor `0`, patch `15`, qualifier `RELEASE`. A trailing numeric segment beyond patch becomes the qualifier too (`1.2.3.4` → qualifier `4`).

Segmentation uses `indexOf('.')` + `substring` (mirroring the existing `VersionTrimmer` style).

## Notes

This PR adds the new abstraction only. Migrating the existing `VersionTrimmer` call sites onto `SemanticVersion` (and deleting `VersionTrimmer`) is the follow-up that closes #1261.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new immutable `SemanticVersion` value object for parsing `major.minor.patch` versions with optional `.QUALIFIER` or `-QUALIFIER` suffixes.
  * Provides version component accessors and consistent ordering using numeric comparison, with deterministic handling of presence/absence of qualifiers.

* **Tests**
  * Added JUnit coverage for successful parsing, invalid input scenarios, component extraction (including qualifier formats), and `compareTo` ordering across numeric-only and qualified versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->