### PR TITLE
test(sb3): run AxelixMetadataEndpointTest in shared master context

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/AbstractMasterSharedContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/AbstractMasterSharedContextTest.java
@@ -29,22 +29,26 @@ import org.springframework.context.annotation.Import;
 
 import com.axelixlabs.axelix.common.api.registration.BasicDiscoveryMetadata;
 import com.axelixlabs.axelix.common.domain.version.AxelixVersionDiscoverer;
+import com.axelixlabs.axelix.sbs.spring.core.Main;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
 
 /**
- * Shared base for the {@code master} integration tests that do not require a running web server. By defining a single,
- * unioned context here and having every subclass inherit it unchanged, the Spring TestContext framework resolves the
- * same context cache key for all of them, so they share one cached {@link org.springframework.context.ApplicationContext}.
+ * Shared base for the {@code master} integration tests. By defining a single, unioned context here and having every
+ * subclass inherit it unchanged, the Spring TestContext framework resolves the same context cache key for all of them,
+ * so they share one cached {@link org.springframework.context.ApplicationContext}.
  *
  *
  * @author Mikhail Polivakha
  * @author Artemiy Degtyarev
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(classes = Main.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import({
     CommitIdPluginGitInformationProvider.class,
     CommitIdPluginShortBuildInfoProvider.class,
     ProjectInfoAutoConfiguration.class,
     DefaultServiceMetadataAssembler.class,
+    AxelixMetadataEndpoint.class,
+    JwtAuthTestConfiguration.class,
     AbstractMasterSharedContextTest.SharedConfig.class
 })
 abstract class AbstractMasterSharedContextTest {

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/AxelixMetadataEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/AxelixMetadataEndpointTest.java
@@ -17,22 +17,13 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.master;
 
-import java.lang.management.ManagementFactory;
-
 import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
 
-import com.axelixlabs.axelix.common.api.registration.BasicDiscoveryMetadata;
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
-import com.axelixlabs.axelix.common.domain.version.AxelixVersionDiscoverer;
-import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
 
@@ -42,45 +33,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for {@link AxelixMetadataEndpoint}.
  *
  * @author Mikhail Polivakha
+ * @author Artemiy Degtyarev
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import({
-    AxelixMetadataEndpoint.class,
-    AxelixMetadataEndpointTest.CurrentConfig.class,
-    DefaultServiceMetadataAssembler.class,
-    CommitIdPluginGitInformationProvider.class,
-    CommitIdPluginShortBuildInfoProvider.class,
-    JwtAuthTestConfiguration.class
-})
-class AxelixMetadataEndpointTest {
+class AxelixMetadataEndpointTest extends AbstractMasterSharedContextTest {
 
     @Autowired
     private TestRestTemplateBuilder testRestTemplate;
-
-    @TestConfiguration
-    static class CurrentConfig {
-
-        @Bean
-        VMFeaturesProvider vmFeaturesProvider() {
-            return new OptionsParsingVMFeaturesProvider(
-                    ManagementFactory.getRuntimeMXBean().getInputArguments());
-        }
-
-        @Bean
-        HealthDetectionFunction healthDetectionFunction() {
-            return () -> BasicDiscoveryMetadata.HealthStatus.UP;
-        }
-
-        @Bean
-        AxelixVersionDiscoverer axelixVersionDiscoverer() {
-            return () -> "1.1.3";
-        }
-
-        @Bean
-        public LibraryInformationProvider libraryInformationProvider() {
-            return new DefaultLibraryInformationProvider();
-        }
-    }
 
     @Test
     void shouldReceiveServiceMetadata() {


### PR DESCRIPTION
## What

`AxelixMetadataEndpointTest` now runs inside the shared `master`-group context instead of spinning up its own dedicated `ApplicationContext`.

- Promote `AbstractMasterSharedContextTest` to `@SpringBootTest(classes = Main.class, webEnvironment = RANDOM_PORT)` and add `AxelixMetadataEndpoint` + `JwtAuthTestConfiguration` to its `@Import`.
- Reduce `AxelixMetadataEndpointTest` to a clean `extends AbstractMasterSharedContextTest` subclass — its own `@SpringBootTest`, `@Import`, and nested `CurrentConfig` (byte-for-byte identical to the parent's `SharedConfig`) are removed.

The parent references only production / shared-test classes, never its children, matching the pattern already applied to the `configprops` (#1256), `beans` (#1263/#1264), and `details` groups.

## Verification

- `./gradlew :sbs:axelix-spring-boot-3-starter:test --tests "com.axelixlabs.axelix.sbs.spring.core.master.*"` → all four classes pass.
- The spring-test-profiler report confirms the master group now resolves to a **single cached context** (Cache Size: 1, Test Classes: 4, 4 hits / 1 miss) — previously this group required two contexts (one `NONE`, one `RANDOM_PORT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test environment configuration to support more comprehensive integration testing with active web services.

* **Refactor**
  * Consolidated test setup across multiple classes to reduce duplication and improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->