### PR TITLE
test(sbs3): run metrics tests in shared context

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AbstractMetricsSharedContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AbstractMetricsSharedContextTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import org.springframework.boot.actuate.metrics.MetricsEndpoint;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+import com.axelixlabs.axelix.common.api.transform.BaseUnitParser;
+import com.axelixlabs.axelix.common.api.transform.BytesMemoryBaseUnitValueTransformer;
+import com.axelixlabs.axelix.common.api.transform.KilobytesMemoryBaseUnitValueTransformer;
+import com.axelixlabs.axelix.sbs.spring.core.Main;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+
+/**
+ * Shared base test that defines a single Spring {@link ApplicationContext} reused by the
+ * {@code metrics} integration tests so they hit the Spring TestContext cache instead of each
+ * building their own context.
+ *
+ * <p>{@link Main} is pinned via the {@code classes} attribute (rather than left to Spring Boot's
+ * auto-detection) so all subclasses resolve an identical, deterministic configuration — this is
+ * what makes the cached context shareable. The metrics beans, the actuator {@link MetricsEndpoint}
+ * and the {@link JwtAuthTestConfiguration} are imported here, and the shared metric fixtures live
+ * in the nested {@link MetricsTestSupportConfiguration} — so the parent owns the entire shared
+ * configuration and never has to reference its subclasses.
+ *
+ * @author Nikita Kirillov
+ * @author Sergey Cherkasov
+ * @author Artemiy Degtyarev
+ */
+@SpringBootTest(classes = Main.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import({
+    AxelixMetricsEndpoint.class,
+    MetricsEndpoint.class,
+    DefaultServiceMetricsGroupsAssembler.class,
+    BaseUnitParser.class,
+    KilobytesMemoryBaseUnitValueTransformer.class,
+    BytesMemoryBaseUnitValueTransformer.class,
+    JwtAuthTestConfiguration.class,
+    AbstractMetricsSharedContextTest.MetricsTestSupportConfiguration.class
+})
+abstract class AbstractMetricsSharedContextTest {
+
+    @TestConfiguration
+    static class MetricsTestSupportConfiguration {
+
+        @Bean
+        public MeterBinder groupingMetrics() {
+            return registry -> {
+                Counter.builder("axelixMetrics.test.metric1")
+                        .description("Test metric belonging to the `axelixMetrics` group with a description")
+                        .register(registry);
+
+                Counter.builder("axelixMetrics.test.metric2")
+                        .description("Test metric belonging to the `axelixMetrics` group with a description")
+                        .register(registry);
+
+                Counter.builder("axelixMetrics.test.metric3").register(registry);
+
+                Counter.builder("testMetrics.axelix.metric1")
+                        .description("Test metric belonging to the `testMetrics` group with a description")
+                        .register(registry);
+
+                Counter.builder("testMetrics.axelix.metric2").register(registry);
+
+                Counter.builder("standalone")
+                        .description(
+                                "Test metric belonging to the 'Others' group without a prefix and with a description")
+                        .register(registry);
+
+                Gauge.builder(
+                                "for.value.transformations", () -> 5480079 // ~ 5.22 MB
+                                )
+                        .baseUnit("bytes")
+                        .register(registry);
+            };
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsEndpointTest.java
@@ -21,9 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.binder.MeterBinder;
 import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,22 +28,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.actuate.metrics.MetricsEndpoint;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
 
 import com.axelixlabs.axelix.common.api.metrics.MetricProfile;
 import com.axelixlabs.axelix.common.api.metrics.MetricsGroupsFeed;
 import com.axelixlabs.axelix.common.api.metrics.MetricsGroupsFeed.MetricsGroup.MetricDescription;
-import com.axelixlabs.axelix.common.api.transform.BaseUnitParser;
-import com.axelixlabs.axelix.common.api.transform.BytesMemoryBaseUnitValueTransformer;
-import com.axelixlabs.axelix.common.api.transform.KilobytesMemoryBaseUnitValueTransformer;
 import com.axelixlabs.axelix.common.api.transform.units.MegabytesMemoryBaseUnit;
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
-import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
 
@@ -57,18 +45,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
+ * @author Artemiy Degtyarev
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Import({
-    AxelixMetricsEndpoint.class,
-    MetricsEndpoint.class,
-    DefaultServiceMetricsGroupsAssembler.class,
-    BaseUnitParser.class,
-    KilobytesMemoryBaseUnitValueTransformer.class,
-    BytesMemoryBaseUnitValueTransformer.class,
-    JwtAuthTestConfiguration.class
-})
-class AxelixMetricsEndpointTest {
+class AxelixMetricsEndpointTest extends AbstractMetricsSharedContextTest {
 
     @Autowired
     private TestRestTemplateBuilder testRestTemplate;
@@ -201,40 +180,4 @@ class AxelixMetricsEndpointTest {
 
     @ProtectedEndpointTests(method = HttpMethod.GET, path = "/actuator/axelix-metrics")
     void negativeAuthTests() {}
-
-    @TestConfiguration
-    static class AxelixMetricsEndpointTestConfiguration {
-
-        @Bean
-        public MeterBinder groupingMetrics() {
-            return registry -> {
-                Counter.builder("axelixMetrics.test.metric1")
-                        .description("Test metric belonging to the `axelixMetrics` group with a description")
-                        .register(registry);
-
-                Counter.builder("axelixMetrics.test.metric2")
-                        .description("Test metric belonging to the `axelixMetrics` group with a description")
-                        .register(registry);
-
-                Counter.builder("axelixMetrics.test.metric3").register(registry);
-
-                Counter.builder("testMetrics.axelix.metric1")
-                        .description("Test metric belonging to the `testMetrics` group with a description")
-                        .register(registry);
-
-                Counter.builder("testMetrics.axelix.metric2").register(registry);
-
-                Counter.builder("standalone")
-                        .description(
-                                "Test metric belonging to the 'Others' group without a prefix and with a description")
-                        .register(registry);
-
-                Gauge.builder(
-                                "for.value.transformations", () -> 5480079 // ~ 5.22 MB
-                                )
-                        .baseUnit("bytes")
-                        .register(registry);
-            };
-        }
-    }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultServiceMetricsGroupsFeedAssemblerTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultServiceMetricsGroupsFeedAssemblerTest.java
@@ -17,15 +17,9 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.metrics;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.MeterBinder;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.common.api.metrics.MetricsGroupsFeed;
 import com.axelixlabs.axelix.common.api.metrics.MetricsGroupsFeed.MetricsGroup;
@@ -37,9 +31,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration tests for {@link DefaultServiceMetricsGroupsAssembler}.
  *
  * @author Sergey Cherkasov
+ * @author Artemiy Degtyarev
  */
-@SpringBootTest
-public class DefaultServiceMetricsGroupsFeedAssemblerTest {
+class DefaultServiceMetricsGroupsFeedAssemblerTest extends AbstractMetricsSharedContextTest {
 
     @Autowired
     ServiceMetricsGroupsAssembler assembler;
@@ -82,40 +76,5 @@ public class DefaultServiceMetricsGroupsFeedAssemblerTest {
                 .filter(group -> group.getGroupName().equals(groupName))
                 .findFirst()
                 .get();
-    }
-
-    @TestConfiguration
-    static class DefaultServiceMetricsGroupsAssemblerTestConfiguration {
-
-        @Bean
-        public ServiceMetricsGroupsAssembler defaultMetricsGroupsAssembler(MeterRegistry registry) {
-            return new DefaultServiceMetricsGroupsAssembler(registry);
-        }
-
-        @Bean
-        public MeterBinder groupingMetrics() {
-            return registry -> {
-                Counter.builder("axelixMetrics.test.metric1")
-                        .description("Test metric belonging to the `axelixMetrics` group with a description")
-                        .register(registry);
-
-                Counter.builder("axelixMetrics.test.metric2")
-                        .description("Test metric belonging to the `axelixMetrics` group with a description")
-                        .register(registry);
-
-                Counter.builder("axelixMetrics.test.metric3").register(registry);
-
-                Counter.builder("testMetrics.axelix.metric1")
-                        .description("Test metric belonging to the `testMetrics` group with a description")
-                        .register(registry);
-
-                Counter.builder("testMetrics.axelix.metric2").register(registry);
-
-                Counter.builder("standalone")
-                        .description(
-                                "Test metric belonging to the 'Others' group without a prefix and with a description")
-                        .register(registry);
-            };
-        }
     }
 }


### PR DESCRIPTION
Fold the two `metrics` integration tests into one shared, cached Spring context, so the `axelix-spring-boot-3-starter` module loads a single metrics context instead of two. Continues the shared-context migration already done for `configprops`, `beans`, `details`, `env`, `master`, and `transactions`.

## Changes
- **New `AbstractMetricsSharedContextTest`** — pins `Main.class` with `RANDOM_PORT`, imports the metrics beans, the actuator `MetricsEndpoint` and `JwtAuthTestConfiguration`, and owns the shared metric fixtures in a nested `MetricsTestSupportConfiguration` (the superset `MeterBinder`: six counters plus the `for.value.transformations` gauge). The parent never references its subclasses.
- **`AxelixMetricsEndpointTest` / `DefaultServiceMetricsGroupsFeedAssemblerTest`** — extend the shared base and drop their own `@SpringBootTest`/`@Import` and inner `@TestConfiguration`.

## Verification
- `./gradlew :sbs:axelix-spring-boot-3-starter:test --tests "*.metrics.*"` → BUILD SUCCESSFUL (spotless + pmd clean), 11 tests, 0 failures/errors.
- spring-test-profiler reports both metrics test classes on a **single** cached context entry (one cache miss, the second class is a cache hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)