### PR TITLE
test(sb3): Share the transaction-monitoring cached context with the endpoint test

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/AbstractTransactionMonitoringSharedContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/AbstractTransactionMonitoringSharedContextTest.java
@@ -17,27 +17,42 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.transactions;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
 
@@ -47,19 +62,41 @@ import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublish
  * so that all subclasses resolve to an identical merged context configuration and therefore share a
  * single cached {@link org.springframework.context.ApplicationContext}.
  *
+ * <p>The context runs with a {@link SpringBootTest.WebEnvironment#RANDOM_PORT} web server and exposes the
+ * transaction-monitoring actuator endpoint, so the endpoint integration test shares the very same cached
+ * context as the non-web bean-post-processor tests. <strong>All</strong> test configurations and fixtures
+ * consumed by the transaction-monitoring tests live here, in the parent, as nested classes — so the parent
+ * owns the entire shared configuration and never has to reference its subclasses.
+ *
  * @author Sergey Cherkasov
  * @author Nikita Kirillov
  * @author Artemiy Degtyarev
  * @author Mikhail Polivakha
  */
-@SpringBootTest
-@Import(AbstractTransactionMonitoringSharedContextTest.SharedTransactionTestConfiguration.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {"management.endpoints.web.exposure.include=axelix-transactions-monitoring"})
+@Import({
+    AbstractTransactionMonitoringSharedContextTest.SharedTransactionTestConfiguration.class,
+    JwtAuthTestConfiguration.class
+})
 abstract class AbstractTransactionMonitoringSharedContextTest {
 
     @TestConfiguration
     @EnableJpaRepositories(basePackageClasses = OwnerRepository.class, considerNestedRepositories = true)
-    @EntityScan(basePackageClasses = Owner.class)
+    @EntityScan(basePackageClasses = {Owner.class, Pet.class})
     static class SharedTransactionTestConfiguration {
+
+        @Bean
+        public TransactionMonitoringEndpoint transactionMonitoringEndpoint(
+                TransactionMonitoringService transactionMonitoringService) {
+            return new TransactionMonitoringEndpoint(transactionMonitoringService);
+        }
+
+        @Bean
+        public TransactionMonitoringService transactionMonitoringService(
+                TransactionStatsCollector transactionStatsCollector) {
+            return new DefaultTransactionMonitoringService(transactionStatsCollector);
+        }
 
         @Bean
         public TransactionStatsCollector transactionStatsCollector() {
@@ -102,9 +139,15 @@ abstract class AbstractTransactionMonitoringSharedContextTest {
         public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
             return new DefaultAxelixMetricsPublisher(meterRegistry);
         }
+
+        @EventListener(ApplicationReadyEvent.class)
+        public void registerAppender() {
+            new LogbackInMemoryPaginationAppenderRegistrar().register();
+        }
     }
 
     @Entity
+    @Table(name = "owner")
     static class Owner {
 
         @Id
@@ -113,6 +156,13 @@ abstract class AbstractTransactionMonitoringSharedContextTest {
 
         private String lastName;
 
+        @OneToMany(mappedBy = "owner", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+        private List<Pet> pets = new ArrayList<>();
+
+        public List<Pet> getPets() {
+            return pets;
+        }
+
         public Long getId() {
             return id;
         }
@@ -120,19 +170,55 @@ abstract class AbstractTransactionMonitoringSharedContextTest {
         public String getLastName() {
             return lastName;
         }
+
+        public Owner setLastName(String lastName) {
+            this.lastName = lastName;
+            return this;
+        }
+
+        public Owner addPet(Pet pet) {
+            this.pets.add(pet);
+            return this;
+        }
+    }
+
+    @Entity
+    @Table(name = "pet")
+    static class Pet {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+
+        private String name;
+
+        @ManyToOne
+        @JoinColumn(name = "owner_id")
+        private Owner owner;
+
+        public Pet() {}
+
+        public Pet(String name, Owner owner) {
+            this.name = name;
+            this.owner = owner;
+        }
     }
 
     interface OwnerRepository extends JpaRepository<Owner, Long> {
 
         @Transactional
-        default Owner findByLastName(String lastName) {
-            return new Owner();
-        }
+        Owner findByLastName(String lastName);
 
         @Transactional(propagation = Propagation.SUPPORTS)
         default List<Owner> findAll() {
             return List.of(new Owner());
         }
+
+        @Transactional
+        @Query(
+                value = "SELECT o FROM AbstractTransactionMonitoringSharedContextTest$Owner o JOIN FETCH o.pets",
+                countQuery = "SELECT COUNT(o) FROM AbstractTransactionMonitoringSharedContextTest$Owner o")
+        Page<Owner> findAllWithPets(Pageable pageable);
     }
 
     static class PropagationTestHelper {
@@ -143,6 +229,62 @@ abstract class AbstractTransactionMonitoringSharedContextTest {
         public PropagationTestHelper(OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
             this.ownerRepository = ownerRepository;
             this.self = self;
+        }
+
+        // IMPORTANT: Calling via 'self' proxy is required to properly test the REQUIRED -> REQUIRES_NEW stack behavior.
+        @Transactional(propagation = Propagation.REQUIRED)
+        public void outerRequiredMethod(String outerName) {
+            ownerRepository.save(new Owner().setLastName(outerName));
+
+            self.saveRequiresNew("SomeName");
+
+            ownerRepository.save(new Owner().setLastName(outerName));
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void saveRequiresNew(String lastName) {
+            ownerRepository.save(new Owner().setLastName(lastName));
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void testSaveMultipleOwners() {
+            ownerRepository.saveAll(List.of(new Owner(), new Owner(), new Owner()));
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void updateOwner(Owner owner) {
+            // will cause entityManager.merge --> new SELECT, since Owner has an id
+            ownerRepository.save(owner);
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void findOwnerById(Long id) {
+            Owner owner = ownerRepository.findById(id).orElseThrow();
+            owner.getPets().size(); // will cause n + 1
+        }
+
+        @Transactional(propagation = Propagation.NESTED)
+        public void testNested() {
+            ownerRepository.findByLastName("Schroeder");
+        }
+
+        @Transactional(propagation = Propagation.SUPPORTS)
+        public void testSupports(String lastName) {
+            ownerRepository.findByLastName(lastName);
+        }
+
+        @Transactional(propagation = Propagation.SUPPORTS)
+        public void testSupportsWithoutTransaction() {}
+
+        @Transactional
+        public void testRollbackScenario(String lastName) {
+            ownerRepository.findByLastName(lastName);
+            throw new RuntimeException("Test rollback");
+        }
+
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        public void findAllWithPetsPageable() {
+            ownerRepository.findAllWithPets(PageRequest.of(0, 5));
         }
 
         @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/TransactionMonitoringEndpointTest.java
@@ -17,21 +17,9 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.transactions;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
 
 import com.jayway.jsonpath.JsonPath;
 import io.micrometer.core.instrument.Counter;
@@ -40,32 +28,11 @@ import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.Lazy;
-import org.springframework.context.event.EventListener;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
-import com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest.TransactionMonitoringEndpointTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
 
@@ -83,11 +50,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
  * @author Mikhail Polivakha
+ * @author Artemiy Degtyarev
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource(properties = {"management.endpoints.web.exposure.include=axelix-transactions-monitoring"})
-@Import({TransactionMonitoringEndpointTestConfiguration.class, JwtAuthTestConfiguration.class})
-class TransactionMonitoringEndpointTest {
+class TransactionMonitoringEndpointTest extends AbstractTransactionMonitoringSharedContextTest {
 
     private final String expectedClassName = PropagationTestHelper.class.getSimpleName();
 
@@ -124,7 +89,7 @@ class TransactionMonitoringEndpointTest {
                         """
                 {
                   "entrypoints" : [ {
-                    "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+                    "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.AbstractTransactionMonitoringSharedContextTest$PropagationTestHelper",
                     "methodName" : "saveRequiresNew",
                     "executions" : [ {
                       "startTimestampMs" : "#{json-unit.ignore}",
@@ -182,7 +147,7 @@ class TransactionMonitoringEndpointTest {
                         """
             {
               "entrypoints" : [ {
-                "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+                "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.AbstractTransactionMonitoringSharedContextTest$PropagationTestHelper",
                 "methodName" : "testSaveMultipleOwners",
                 "executions" : [ {
                   "startTimestampMs" : "#{json-unit.ignore}",
@@ -251,7 +216,7 @@ class TransactionMonitoringEndpointTest {
                         """
                 {
                   "entrypoints" : [ {
-                    "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+                    "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.AbstractTransactionMonitoringSharedContextTest$PropagationTestHelper",
                     "methodName" : "findOwnerById",
                     "executions" : [ {
                       "startTimestampMs" : "#{json-unit.ignore}",
@@ -314,7 +279,7 @@ class TransactionMonitoringEndpointTest {
                         """
             {
               "entrypoints" : [ {
-                "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+                "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.AbstractTransactionMonitoringSharedContextTest$PropagationTestHelper",
                 "methodName" : "updateOwner",
                 "executions" : [ {
                   "startTimestampMs" : "#{json-unit.ignore}",
@@ -375,7 +340,7 @@ class TransactionMonitoringEndpointTest {
                         """
                 {
                   "entrypoints" : [ {
-                    "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+                    "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.AbstractTransactionMonitoringSharedContextTest$PropagationTestHelper",
                     "methodName" : "testRollbackScenario",
                     "executions" : [ {
                       "startTimestampMs" : "#{json-unit.ignore}",
@@ -416,7 +381,7 @@ class TransactionMonitoringEndpointTest {
         {
           "entrypoints" : [
             {
-              "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+              "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.AbstractTransactionMonitoringSharedContextTest$PropagationTestHelper",
               "methodName" : "saveRequiresNew",
               "executions" : [ {
                 "startTimestampMs" : "#{json-unit.ignore}",
@@ -436,7 +401,7 @@ class TransactionMonitoringEndpointTest {
               }
             },
             {
-              "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+              "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.AbstractTransactionMonitoringSharedContextTest$PropagationTestHelper",
               "methodName" : "outerRequiredMethod",
               "executions" : [ {
                 "startTimestampMs" : "#{json-unit.ignore}",
@@ -480,7 +445,7 @@ class TransactionMonitoringEndpointTest {
                         """
         {
           "entrypoints" : [ {
-            "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringEndpointTest$PropagationTestHelper",
+            "className" : "com.axelixlabs.axelix.sbs.spring.core.transactions.AbstractTransactionMonitoringSharedContextTest$PropagationTestHelper",
             "methodName" : "testNested",
             "executions" : [ {
               "startTimestampMs" : "#{json-unit.ignore}",
@@ -587,206 +552,5 @@ class TransactionMonitoringEndpointTest {
                 restTemplate.asViewer().getForEntity("/actuator/axelix-transactions-monitoring", String.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         return response.getBody();
-    }
-
-    @TestConfiguration
-    @EnableJpaRepositories(basePackageClasses = OwnerRepository.class, considerNestedRepositories = true)
-    @EntityScan(basePackageClasses = {Owner.class, Pet.class})
-    static class TransactionMonitoringEndpointTestConfiguration {
-
-        @Bean
-        public TransactionMonitoringEndpoint transactionMonitoringEndpoint(
-                TransactionMonitoringService transactionMonitoringService) {
-            return new TransactionMonitoringEndpoint(transactionMonitoringService);
-        }
-
-        @Bean
-        public TransactionMonitoringService transactionMonitoringService(
-                TransactionStatsCollector transactionStatsCollector) {
-            return new DefaultTransactionMonitoringService(transactionStatsCollector);
-        }
-
-        @Bean
-        public TransactionStatsCollector transactionStatsCollector() {
-            return new DefaultTransactionStatsCollector(30);
-        }
-
-        @Bean
-        public TransactionMonitoringBeanPostProcessor transactionMonitoringBeanPostProcessor(
-                TransactionStatsCollector transactionStatsCollector,
-                QueriesRecorder queriesCollector,
-                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
-            return new TransactionMonitoringBeanPostProcessor(
-                    transactionStatsCollector, queriesCollector, axelixMetricsPublisherObjectProvider);
-        }
-
-        @Bean
-        public QueriesRecorder queriesStatsCollector() {
-            return new DefaultQueriesRecorder();
-        }
-
-        @Bean
-        public ProxyingDataSourceBeanPostProcessor transactionMonitoringDataSourceBeanPostProcessor(
-                QueriesRecorder queriesCollector) {
-            return new ProxyingDataSourceBeanPostProcessor(queriesCollector);
-        }
-
-        @Bean
-        public PropagationTestHelper propagationTestHelper(
-                OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
-            return new PropagationTestHelper(ownerRepository, self);
-        }
-
-        @Bean
-        public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
-            return new DefaultAxelixMetricsPublisher(meterRegistry);
-        }
-
-        @EventListener(ApplicationReadyEvent.class)
-        public void registerAppender() {
-            new LogbackInMemoryPaginationAppenderRegistrar().register();
-        }
-    }
-
-    @Entity
-    @Table(name = "owner")
-    static class Owner {
-
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        private Long id;
-
-        private String lastName;
-
-        @OneToMany(mappedBy = "owner", cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-        private List<Pet> pets = new ArrayList<>();
-
-        public List<Pet> getPets() {
-            return pets;
-        }
-
-        public Long getId() {
-            return id;
-        }
-
-        public String getLastName() {
-            return lastName;
-        }
-
-        public Owner setLastName(String lastName) {
-            this.lastName = lastName;
-            return this;
-        }
-
-        public Owner addPet(Pet pet) {
-            this.pets.add(pet);
-            return this;
-        }
-    }
-
-    @Entity
-    @Table(name = "pet")
-    static class Pet {
-
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        private Long id;
-
-        private String name;
-
-        @ManyToOne
-        @JoinColumn(name = "owner_id")
-        private Owner owner;
-
-        public Pet() {}
-
-        public Pet(String name, Owner owner) {
-            this.name = name;
-            this.owner = owner;
-        }
-    }
-
-    interface OwnerRepository extends JpaRepository<Owner, Long> {
-
-        @Transactional
-        Owner findByLastName(String lastName);
-
-        @Transactional(propagation = Propagation.SUPPORTS)
-        default List<Owner> findAll() {
-            return List.of(new Owner());
-        }
-
-        @Transactional
-        @Query(
-                value = "SELECT o FROM TransactionMonitoringEndpointTest$Owner o JOIN FETCH o.pets",
-                countQuery = "SELECT COUNT(o) FROM TransactionMonitoringEndpointTest$Owner o")
-        Page<Owner> findAllWithPets(Pageable pageable);
-    }
-
-    static class PropagationTestHelper {
-
-        private final OwnerRepository ownerRepository;
-        private final PropagationTestHelper self;
-
-        public PropagationTestHelper(OwnerRepository ownerRepository, @Lazy PropagationTestHelper self) {
-            this.ownerRepository = ownerRepository;
-            this.self = self;
-        }
-
-        // IMPORTANT: Calling via 'self' proxy is required to properly test the REQUIRED -> REQUIRES_NEW stack behavior.
-        @Transactional(propagation = Propagation.REQUIRED)
-        public void outerRequiredMethod(String outerName) {
-            ownerRepository.save(new Owner().setLastName(outerName));
-
-            self.saveRequiresNew("SomeName");
-
-            ownerRepository.save(new Owner().setLastName(outerName));
-        }
-
-        @Transactional(propagation = Propagation.REQUIRES_NEW)
-        public void saveRequiresNew(String lastName) {
-            ownerRepository.save(new Owner().setLastName(lastName));
-        }
-
-        @Transactional(propagation = Propagation.REQUIRES_NEW)
-        public void testSaveMultipleOwners() {
-            ownerRepository.saveAll(List.of(new Owner(), new Owner(), new Owner()));
-        }
-
-        @Transactional(propagation = Propagation.REQUIRES_NEW)
-        public void updateOwner(Owner owner) {
-            // will cause entityManager.merge --> new SELECT, since Owner has an id
-            ownerRepository.save(owner);
-        }
-
-        @Transactional(propagation = Propagation.REQUIRES_NEW)
-        public void findOwnerById(Long id) {
-            Owner owner = ownerRepository.findById(id).orElseThrow();
-            owner.getPets().size(); // will cause n + 1
-        }
-
-        @Transactional(propagation = Propagation.NESTED)
-        public void testNested() {
-            ownerRepository.findByLastName("Schroeder");
-        }
-
-        @Transactional(propagation = Propagation.SUPPORTS)
-        public void testSupports(String lastName) {
-            ownerRepository.findByLastName(lastName);
-        }
-
-        @Transactional(propagation = Propagation.SUPPORTS)
-        public void testSupportsWithoutTransaction() {}
-
-        @Transactional
-        public void testRollbackScenario(String lastName) {
-            ownerRepository.findByLastName(lastName);
-            throw new RuntimeException("Test rollback");
-        }
-
-        @Transactional(propagation = Propagation.REQUIRES_NEW)
-        public void findAllWithPetsPageable() {
-            ownerRepository.findAllWithPets(PageRequest.of(0, 5));
-        }
     }
 }


### PR DESCRIPTION
## What

Folds `TransactionMonitoringEndpointTest` into the shared
`AbstractTransactionMonitoringSharedContextTest` context so the endpoint test hits the Spring
TestContext cache instead of building its own separate `ApplicationContext`.

This mirrors the recent "beans" merge (#1264) and the details/config-props merges (#1257, #1256).

## How

- The parent `AbstractTransactionMonitoringSharedContextTest` now owns the **union** of all
  configuration and fixtures: `RANDOM_PORT` web environment, the
  `management.endpoints.web.exposure.include=axelix-transactions-monitoring` property source,
  `JwtAuthTestConfiguration`, the endpoint/service/appender beans, and the richer
  `Owner`/`Pet`/`OwnerRepository`/`PropagationTestHelper` fixtures. The parent never references its
  subclasses.
- `TransactionMonitoringEndpointTest` is reduced to `extends AbstractTransactionMonitoringSharedContextTest`,
  keeping only its `@Autowired` fields and `@Test` methods. The hardcoded `className` JSON assertions were
  updated to the parent's enclosing class, and the `findAllWithPets` JPQL entity name was updated accordingly.

## Verification

- `./gradlew :sbs:axelix-spring-boot-3-starter:test --tests '*transactions*'` — all four transaction
  test classes pass.
- The `spring-test-profiler` report confirms all three transaction test classes
  (`TransactionMonitoringBeanPostProcessorTest`, `ProxyingDataSourceBeanPostProcessorTest`,
  `TransactionMonitoringEndpointTest`) now resolve to a **single** cached `ApplicationContext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)