### PR TITLE
test(sb3): Run AxelixEnvironmentEndpointTest in the shared env context

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/AbstractEnvSharedContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/AbstractEnvSharedContextTest.java
@@ -20,10 +20,15 @@ package com.axelixlabs.axelix.sbs.spring.core.env;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
+import com.axelixlabs.axelix.sbs.spring.core.Main;
+import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
+
 /**
- * Base class for the {@code env} integration tests (the endpoint test is intentionally excluded). Every subclass
+ * Base class for the {@code env} integration tests, including {@link AxelixEnvironmentEndpoint}. Every subclass
  * inherits the same merged test configuration, so Spring's TestContext cache builds the context once and reuses it
  * across all of them. The {@link TestPropertySource} below is the union of the properties each test needs; the keys
  * do not collide and {@code args} is harmless to tests that do not read it.
@@ -32,7 +37,14 @@ import org.springframework.test.context.TestPropertySource;
  * @author Mikhail Polivakha
  * @author Artemiy Degtyarev
  */
-@SpringBootTest(args = "--fooBar=fromArgs")
+@SpringBootTest(
+        classes = Main.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        args = {"--fooBar=fromArgs", "--axelix.env.test.prop3=fromCommandLine"},
+        properties = {
+            "axelix.env.test.prop2=systemValue2",
+            "management.endpoint.env.show-values=always",
+        })
 @TestPropertySource(
         properties = {
             // DefaultPropertyMetadataExtractorTest
@@ -50,8 +62,31 @@ import org.springframework.test.context.TestPropertySource;
             "test.method.timeout=4200",
             // DefaultEnvironmentServiceTest (explicit sanitization scenario)
             "axelix.prop.test.tags.forSanitization=toBeSanitized",
-            "axelix.prop.test.tags.FOR_SANITIZATION=toBeSanitized"
+            "axelix.prop.test.tags.FOR_SANITIZATION=toBeSanitized",
+            // AxelixEnvironmentEndpointTest
+            "axelix.env.test.prop1=fromTestSource",
+            "axelix.env.test.toBeSanitized=shouldBeSanitized",
+            "axelix.prop.test.tags.environment=test",
+            "axelix.prop.test.tags.version=1.0.0",
+            "axelix.prop.test.enabled-contexts=user-service,payment-service",
+            "axelix.prop.test.http-client.requests[0].name=user-api",
+            "axelix.prop.test.http-client.requests[0].base-url=https://api.users.example.com/v1",
+            "axelix.prop.test.http-client.requests[0].methods[0].type=GET",
+            "axelix.prop.test.http-client.requests[0].methods[0].retries[0].count=3",
+            "axelix.prop.test.http-client.requests[0].methods[0].retries[0].parameters.timeout=5000",
+            "axelix.prop.test.http-client.requests[0].methods[1].type=POST",
+            "axelix.prop.test.http-client.requests[1].name=payment-api",
+            "axelix.prop.test.http-client.requests[1].base-url=https://api.payments.example.com/v2",
+            "axelix.prop.test.http-client.requests[1].methods[0].type=PUT",
+            "axelix.prop.test.http-client.requests[1].methods[0].retries[0].count=2",
+            "axelix.prop.test.http-client.requests[1].methods[0].retries[0].parameters.log-level=DEBUG",
         })
 @EnableConfigurationProperties(EnvSharedTestConfig.AxelixConfigurationProperties.class)
-@Import(EnvSharedTestConfig.class)
-abstract class AbstractEnvSharedContextTest {}
+@Import({EnvSharedTestConfig.class, JwtAuthTestConfiguration.class})
+abstract class AbstractEnvSharedContextTest {
+
+    @DynamicPropertySource
+    static void registerDynamic(DynamicPropertyRegistry registry) {
+        registry.add("axelix.env.test.prop2", () -> "dynamicValue");
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/AxelixEnvironmentEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/AxelixEnvironmentEndpointTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -67,6 +68,14 @@ class AxelixEnvironmentEndpointTest extends AbstractEnvSharedContextTest {
         environment.getSystemProperties().put("axelix.env.test.prop2", "systemValue");
         environment.getSystemProperties().put("axelix.env.test.prop3", "systemValue");
         environment.getSystemProperties().put("AXELIX_FOR_SANITIZATION", "shouldBeSanitized");
+    }
+
+    @AfterEach
+    void tearDown() {
+        environment.getSystemProperties().remove("axelix.env.test.prop1", "systemValue");
+        environment.getSystemProperties().remove("axelix.env.test.prop2", "systemValue");
+        environment.getSystemProperties().remove("axelix.env.test.prop3", "systemValue");
+        environment.getSystemProperties().remove("AXELIX_FOR_SANITIZATION", "shouldBeSanitized");
     }
 
     @ParameterizedTest(name = "Property ''{0}'' should resolve from highest-precedence source")

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/AxelixEnvironmentEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/AxelixEnvironmentEndpointTest.java
@@ -29,27 +29,15 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.test.context.TestPropertySource;
 
 import com.axelixlabs.axelix.common.api.env.EnvironmentFeed;
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
-import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
-import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
-import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
 
@@ -63,39 +51,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
  * @author Mikhail Polivakha
+ * @author Artemiy Degtyarev
  */
-@SpringBootTest(
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-        args = {"--axelix.env.test.prop3=fromCommandLine"},
-        properties = {
-            "axelix.env.test.prop2=systemValue2",
-            "management.endpoint.env.show-values=always",
-        })
-@TestPropertySource(
-        properties = {
-            // properties -> shouldSelectPrimaryPropertyFromHighestPrecedenceSource
-            "axelix.env.test.prop1=fromTestSource",
-            "axelix.env.test.toBeSanitized=shouldBeSanitized",
-
-            // properties -> shouldReturnTheBeanNameThatMatchesTheConfigProps
-            "axelix.prop.test.tags.environment=test",
-            "axelix.prop.test.tags.version=1.0.0",
-            "axelix.prop.test.enabled-contexts=user-service,payment-service",
-            "axelix.prop.test.http-client.requests[0].name=user-api",
-            "axelix.prop.test.http-client.requests[0].base-url=https://api.users.example.com/v1",
-            "axelix.prop.test.http-client.requests[0].methods[0].type=GET",
-            "axelix.prop.test.http-client.requests[0].methods[0].retries[0].count=3",
-            "axelix.prop.test.http-client.requests[0].methods[0].retries[0].parameters.timeout=5000",
-            "axelix.prop.test.http-client.requests[0].methods[1].type=POST",
-            "axelix.prop.test.http-client.requests[1].name=payment-api",
-            "axelix.prop.test.http-client.requests[1].base-url=https://api.payments.example.com/v2",
-            "axelix.prop.test.http-client.requests[1].methods[0].type=PUT",
-            "axelix.prop.test.http-client.requests[1].methods[0].retries[0].count=2",
-            "axelix.prop.test.http-client.requests[1].methods[0].retries[0].parameters.log-level=DEBUG",
-        })
-@EnableConfigurationProperties(AxelixEnvironmentEndpointTest.AxelixPropTest.class)
-@Import({EnvironmentTestConfig.class, JwtAuthTestConfiguration.class})
-class AxelixEnvironmentEndpointTest {
+class AxelixEnvironmentEndpointTest extends AbstractEnvSharedContextTest {
 
     @Autowired
     private TestRestTemplateBuilder restTemplate;
@@ -109,11 +67,6 @@ class AxelixEnvironmentEndpointTest {
         environment.getSystemProperties().put("axelix.env.test.prop2", "systemValue");
         environment.getSystemProperties().put("axelix.env.test.prop3", "systemValue");
         environment.getSystemProperties().put("AXELIX_FOR_SANITIZATION", "shouldBeSanitized");
-    }
-
-    @DynamicPropertySource
-    static void registerDynamic(DynamicPropertyRegistry registry) {
-        registry.add("axelix.env.test.prop2", () -> "dynamicValue");
     }
 
     @ParameterizedTest(name = "Property ''{0}'' should resolve from highest-precedence source")
@@ -203,7 +156,7 @@ class AxelixEnvironmentEndpointTest {
 
         assertThat(propertyAppearances)
                 .extracting(e -> e.getValue().getConfigPropsBeanName())
-                .containsOnly(AxelixPropTest.class.getName());
+                .containsOnly(EnvSharedTestConfig.AxelixConfigurationProperties.class.getName());
     }
 
     @ParameterizedTest
@@ -274,38 +227,5 @@ class AxelixEnvironmentEndpointTest {
                         .filter(p -> p.getName().equals(propertyName))
                         .map(p -> Map.entry(src.getName(), p)))
                 .toList();
-    }
-
-    @ConfigurationProperties(prefix = "axelix.prop.test")
-    public record AxelixPropTest(Map<String, String> tags, List<String> enabledContexts, HttpClient httpClient) {
-
-        public record HttpClient(List<Request> requests) {}
-
-        public record Request(String name, String baseUrl, List<Method> methods) {}
-
-        public record Method(String type, List<Retry> retries) {}
-
-        public record Retry(Integer count, Map<String, Object> parameters) {}
-    }
-
-    @TestConfiguration
-    static class AxelixEnvironmentEndpointTestConfiguration {
-
-        @Bean
-        @ConfigurationProperties(prefix = "axelix.sbs.endpoints.config")
-        public EndpointsConfigurationProperties endpointsConfigurationProperties() {
-            return new EndpointsConfigurationProperties();
-        }
-
-        @Bean
-        public AxelixEnvironmentEndpoint axelixEnvironmentEndpoint(EnvironmentService environmentService) {
-            return new AxelixEnvironmentEndpoint(environmentService);
-        }
-
-        @Bean
-        public SmartSanitizingFunction smartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
-            return new SmartSanitizingFunction(
-                    List.of("axelix.env.test.toBeSanitized", "AXELIX_FOR_SANITIZATION"), propertyNameNormalizer);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvironmentServiceTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvironmentServiceTest.java
@@ -106,9 +106,6 @@ class DefaultEnvironmentServiceTest extends AbstractEnvSharedContextTest {
                     () -> environmentService.getEnvironmentFeed(null), securityContext);
 
             // then.
-            // The explicit sanitizer also covers the endpoint's keys; "axelix.env.test.toBeSanitized" is a static
-            // test property (always present), while "AXELIX_FOR_SANITIZATION" is only set as a system property by the
-            // endpoint test, so its presence is order-dependent — asserted via isSubsetOf rather than an exact set.
             Set<String> sanitizedPropertyNames = environmentFeed.getPropertySources().stream()
                     .flatMap(propertySource -> propertySource.getProperties().stream())
                     .filter(property -> "******".equals(property.getValue()))

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvironmentServiceTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/DefaultEnvironmentServiceTest.java
@@ -17,7 +17,6 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.env;
 
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -53,7 +52,7 @@ class DefaultEnvironmentServiceTest extends AbstractEnvSharedContextTest {
     class WithoutExplicitSanitizationProperties {
 
         @Autowired
-        @Qualifier("sanitizeAllEnvironmentService")
+        @Qualifier(EnvSharedTestConfig.SANITIZE_ALL_ENVIRONMENT_SERVICE)
         private EnvironmentService environmentService;
 
         @Test
@@ -95,7 +94,7 @@ class DefaultEnvironmentServiceTest extends AbstractEnvSharedContextTest {
     class WithExplicitSanitizationProperties {
 
         @Autowired
-        @Qualifier("explicitSanitizeEnvironmentService")
+        @Qualifier(EnvSharedTestConfig.EXPLICIT_SANITIZE_ENVIRONMENT_SERVICE)
         private EnvironmentService environmentService;
 
         @Test
@@ -107,14 +106,25 @@ class DefaultEnvironmentServiceTest extends AbstractEnvSharedContextTest {
                     () -> environmentService.getEnvironmentFeed(null), securityContext);
 
             // then.
-            Map<String, String> sanitizedProperties = environmentFeed.getPropertySources().stream()
+            // The explicit sanitizer also covers the endpoint's keys; "axelix.env.test.toBeSanitized" is a static
+            // test property (always present), while "AXELIX_FOR_SANITIZATION" is only set as a system property by the
+            // endpoint test, so its presence is order-dependent — asserted via isSubsetOf rather than an exact set.
+            Set<String> sanitizedPropertyNames = environmentFeed.getPropertySources().stream()
                     .flatMap(propertySource -> propertySource.getProperties().stream())
                     .filter(property -> "******".equals(property.getValue()))
-                    .collect(Collectors.toMap(Property::getName, Property::getValue));
+                    .map(Property::getName)
+                    .collect(Collectors.toSet());
 
-            assertThat(sanitizedProperties)
-                    .containsOnlyKeys("axelix.prop.test.tags.forSanitization", "axelix.prop.test.tags.FOR_SANITIZATION")
-                    .containsValues("******", "******");
+            assertThat(sanitizedPropertyNames)
+                    .contains(
+                            "axelix.prop.test.tags.forSanitization",
+                            "axelix.prop.test.tags.FOR_SANITIZATION",
+                            "axelix.env.test.toBeSanitized")
+                    .isSubsetOf(
+                            "axelix.prop.test.tags.forSanitization",
+                            "axelix.prop.test.tags.FOR_SANITIZATION",
+                            "axelix.env.test.toBeSanitized",
+                            "AXELIX_FOR_SANITIZATION");
         }
 
         @Test

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/EnvSharedTestConfig.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/EnvSharedTestConfig.java
@@ -48,11 +48,7 @@ import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPro
 import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
 
 /**
- * Shared test configuration backing a single, cached Spring context for all {@code env} integration tests,
- * including {@link AxelixEnvironmentEndpoint}. The two distinct sanitization behaviours required by these
- * tests are exposed as two separately-named {@link SmartSanitizingFunction} beans (and two matching
- * {@link EnvironmentService} beans), so a single context can satisfy every scenario. The endpoint is wired
- * to the explicitly-sanitizing {@link EnvironmentService}.
+ * Shared test configuration backing a single, cached Spring context for all {@code env} integration tests.
  *
  * @author Nikita Kirillov
  * @author Mikhail Polivakha

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/EnvSharedTestConfig.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/env/EnvSharedTestConfig.java
@@ -48,10 +48,11 @@ import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPro
 import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
 
 /**
- * Shared test configuration backing a single, cached Spring context for all non-endpoint {@code env}
- * integration tests. The two distinct sanitization behaviours required by these tests are exposed as two
- * separately-named {@link SmartSanitizingFunction} beans (and two matching {@link EnvironmentService} beans),
- * so a single context can satisfy every scenario.
+ * Shared test configuration backing a single, cached Spring context for all {@code env} integration tests,
+ * including {@link AxelixEnvironmentEndpoint}. The two distinct sanitization behaviours required by these
+ * tests are exposed as two separately-named {@link SmartSanitizingFunction} beans (and two matching
+ * {@link EnvironmentService} beans), so a single context can satisfy every scenario. The endpoint is wired
+ * to the explicitly-sanitizing {@link EnvironmentService}.
  *
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
@@ -61,6 +62,9 @@ import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction
 public class EnvSharedTestConfig {
 
     public static final String SAMPLE_BEAN_NAME = "testBeanWithCustomAnnotations";
+
+    public static final String SANITIZE_ALL_ENVIRONMENT_SERVICE = "sanitizeAllEnvironmentService";
+    public static final String EXPLICIT_SANITIZE_ENVIRONMENT_SERVICE = "explicitSanitizeEnvironmentService";
 
     private static final String SANITIZE_ALL_SMART_SANITIZATION_FUNCTION = "sanitizeAllSmartSanitizingFunction";
     private static final String EXPLICITLY_CONFIGURED_SMART_SANITIZATION_FUNCTION = "explicitSmartSanitizingFunction";
@@ -119,10 +123,14 @@ public class EnvSharedTestConfig {
         return new SmartSanitizingFunction(EndpointsConfigurationProperties.SANITIZE_ALL, propertyNameNormalizer);
     }
 
-    @Bean
+    @Bean(EXPLICITLY_CONFIGURED_SMART_SANITIZATION_FUNCTION)
     public SmartSanitizingFunction explicitSmartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
         return new SmartSanitizingFunction(
-                List.of("axelix.prop.test.tags.forSanitization", "axelix.prop.test.tags.FOR_SANITIZATION"),
+                List.of(
+                        "axelix.prop.test.tags.forSanitization",
+                        "axelix.prop.test.tags.FOR_SANITIZATION",
+                        "axelix.env.test.toBeSanitized",
+                        "AXELIX_FOR_SANITIZATION"),
                 propertyNameNormalizer);
     }
 
@@ -155,7 +163,7 @@ public class EnvSharedTestConfig {
                 valueInjectionTrackerBeanPostProcessor);
     }
 
-    @Bean
+    @Bean(SANITIZE_ALL_ENVIRONMENT_SERVICE)
     public EnvironmentService sanitizeAllEnvironmentService(
             Environment environment,
             @Qualifier(SANITIZE_ALL_SMART_SANITIZATION_FUNCTION) SmartSanitizingFunction smartSanitizingFunction,
@@ -165,7 +173,7 @@ public class EnvSharedTestConfig {
                 environment, smartSanitizingFunction, envPropertyEnricher, requiredAuthorityCheckService);
     }
 
-    @Bean
+    @Bean(EXPLICIT_SANITIZE_ENVIRONMENT_SERVICE)
     public EnvironmentService explicitSanitizeEnvironmentService(
             Environment environment,
             @Qualifier(EXPLICITLY_CONFIGURED_SMART_SANITIZATION_FUNCTION)
@@ -174,6 +182,12 @@ public class EnvSharedTestConfig {
             RequiredAuthorityCheckService requiredAuthorityCheckService) {
         return new DefaultEnvironmentService(
                 environment, smartSanitizingFunction, envPropertyEnricher, requiredAuthorityCheckService);
+    }
+
+    @Bean
+    public AxelixEnvironmentEndpoint axelixEnvironmentEndpoint(
+            @Qualifier(EXPLICIT_SANITIZE_ENVIRONMENT_SERVICE) EnvironmentService environmentService) {
+        return new AxelixEnvironmentEndpoint(environmentService);
     }
 
     @Bean(SAMPLE_BEAN_NAME)
@@ -187,7 +201,17 @@ public class EnvSharedTestConfig {
     }
 
     @ConfigurationProperties(prefix = "axelix.prop.test")
-    public record AxelixConfigurationProperties(Map<String, String> tags) {}
+    public record AxelixConfigurationProperties(
+            Map<String, String> tags, List<String> enabledContexts, HttpClient httpClient) {
+
+        public record HttpClient(List<Request> requests) {}
+
+        public record Request(String name, String baseUrl, List<Method> methods) {}
+
+        public record Method(String type, List<Retry> retries) {}
+
+        public record Retry(Integer count, Map<String, Object> parameters) {}
+    }
 
     @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
     @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
## What

Folds `AxelixEnvironmentEndpointTest` into `AbstractEnvSharedContextTest` so the whole `env` package (sb3 starter) builds a **single** cached Spring `ApplicationContext` instead of a separate one for the endpoint test.

Mirrors the pattern already established for the `beans` (#1263/#1264) and `configprops` (#1256) endpoint tests.

## Changes

- **`AbstractEnvSharedContextTest`** — now `@SpringBootTest(classes = Main.class, RANDOM_PORT, …)`; the endpoint's args/properties are merged into the shared union, the `@DynamicPropertySource` (`prop2 → dynamicValue`) is moved up so every subclass shares one cache key, and `JwtAuthTestConfiguration` is imported. The parent stays unaware of its children.
- **`EnvSharedTestConfig`** — config-props record merged to `AxelixConfigurationProperties(tags, enabledContexts, httpClient)`; the existing `explicitSmartSanitizingFunction` is widened to also cover the endpoint's keys (no new sanitizer bean added); the `AxelixEnvironmentEndpoint` bean is added, wired via `@Qualifier` to the existing `explicitSanitizeEnvironmentService`. Bean names extracted into constants.
- **`AxelixEnvironmentEndpointTest`** — stripped to a bare `extends AbstractEnvSharedContextTest`; nested config/record removed; config-props bean-name assertion repointed.
- **`DefaultEnvironmentServiceTest`** — explicit-sanitize assertion updated (`contains` + `isSubsetOf`) for the widened sanitizer, robust to the order-dependent `AXELIX_FOR_SANITIZATION` system property.

## Verification

- `./gradlew :sbs:axelix-spring-boot-3-starter:build` — BUILD SUCCESSFUL (tests + spotless + PMD).
- spring-test-profiler report: all `env` test classes — including `AxelixEnvironmentEndpointTest` — map to a single context (1 cache miss, 98.1% hit rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure to consolidate shared configuration across environment-related test classes.
  * Enhanced test setup with improved environment property management, dynamic property registration, and lifecycle cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->