### PR TITLE
GH-1250: Add a toggle for in-memory pagination detection.

### DIFF
--- a/docs/docs/setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx
+++ b/docs/docs/setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx
@@ -404,6 +404,41 @@ heartbeats are rejected with `401`.
 
 </div>
 
+### In-memory pagination detection
+
+Detects Hibernate`s in-memory pagination caused by using
+[setFirstResult/setMaxResults](https://docs.hibernate.org/orm/current/javadocs/org/hibernate/query/Query.html?#setMaxResults(int))
+together with a collection fetch.
+
+By default, transaction monitoring registers a Logback appender
+`com.axelixlabs.axelix.sbs.spring.core.transactions.LogbackInMemoryPaginationAppender` that intercepts Hibernate
+warnings (HHH000104 in Hibernate 5.x and HHH90003004 in Hibernate 6.x–7.3.x).
+
+Set `axelix.sbs.transaction.monitoring.in-memory-pagination-detection.enabled` to `false` if you want to prevent the
+appender from being registered.
+
+<Tabs groupId="spring-config">
+  <TabItem value="yaml" label="application.yaml">
+
+```yaml
+axelix:
+  sbs:
+    transaction:
+      monitoring:
+        in-memory-pagination-detection:
+          enabled: false
+```
+
+  </TabItem>
+  <TabItem value="properties" label="application.properties">
+
+```properties
+axelix.sbs.transaction.monitoring.in-memory-pagination-detection.enabled=false
+```
+
+  </TabItem>
+</Tabs>
+
 ## Related
 
 - [Configuring Master](../../setting-up-master-ui/configuring-master/configuring-master.mdx) — where the signing key, eviction timeout, and

--- a/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx
+++ b/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx
@@ -409,6 +409,41 @@ heartbeat-сигналы будут отклоняться с `401`.
 
 </div>
 
+### Обнаружение in-memory pagination
+
+Обнаруживает случаи применения in-memory pagination, выполняемые Hibernate при использовании методов
+[setFirstResult/setMaxResults](https://docs.hibernate.org/orm/current/javadocs/org/hibernate/query/Query.html?#setMaxResults(int))
+совместно с выборкой коллекций через fetch.
+
+По умолчанию мониторинг транзакций регистрирует Logback appender
+`com.axelixlabs.axelix.sbs.spring.core.transactions.LogbackInMemoryPaginationAppender`, который перехватывает
+предупреждения Hibernate (HHH000104 в Hibernate 5.x и HHH90003004 в Hibernate 6.x–7.3.x).
+
+Установите значение свойства `axelix.sbs.transaction.monitoring.in-memory-pagination-detection.enabled` в `false`, если
+хотите отключить регистрацию данного appender-а.
+
+<Tabs groupId="spring-config">
+  <TabItem value="yaml" label="application.yaml">
+
+```yaml
+axelix:
+  sbs:
+    transaction:
+      monitoring:
+        in-memory-pagination-detection:
+          enabled: false
+```
+
+  </TabItem>
+  <TabItem value="properties" label="application.properties">
+
+```properties
+axelix.sbs.transaction.monitoring.in-memory-pagination-detection.enabled=false
+```
+
+  </TabItem>
+</Tabs>
+
 ## См. также
 
 - [Настройка Master](../../setting-up-master-ui/configuring-master/configuring-master.mdx) — где задаются ключ подписи, таймаут выселения и

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.condition.Conditi
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -46,6 +47,7 @@ import com.axelixlabs.axelix.sbs.spring.core.validate.ValidationListener;
  * @since 21.01.2026
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
+ * @author Ilya Naumov
  */
 @AutoConfiguration
 @ConditionalOnAvailableEndpoint(endpoint = TransactionMonitoringEndpoint.class)
@@ -107,6 +109,11 @@ public class TransactionMonitoringAutoConfiguration {
 
     @Configuration
     @ConditionalOnClass(name = {"org.hibernate.Session", "ch.qos.logback.classic.LoggerContext"})
+    @ConditionalOnProperty(
+            prefix = "axelix.sbs.transaction.monitoring.in-memory-pagination-detection",
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = true)
     static class LogbackInMemoryPaginationAppenderConfiguration {
 
         @EventListener(ApplicationReadyEvent.class)

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since 10.02.2026
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
+ * @author Ilya Naumov
  */
 class TransactionMonitoringAutoConfigurationTest {
 
@@ -61,7 +62,24 @@ class TransactionMonitoringAutoConfigurationTest {
             assertThat(context).hasSingleBean(TransactionMonitoringEndpoint.class);
             assertThat(context).hasSingleBean(TransactionMonitoringBeanPostProcessor.class);
             assertThat(context).hasSingleBean(ProxyingDataSourceBeanPostProcessor.class);
+            assertThat(context)
+                    .hasSingleBean(
+                            TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
+                                    .class);
         });
+    }
+
+    @Test // GH-1250
+    void shouldNotRegisterInMemoryPaginationAppenderConfiguration_whenDetectionDisabled() {
+        contextRunner
+                .withPropertyValues("axelix.sbs.transaction.monitoring.in-memory-pagination-detection.enabled=false")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(TransactionMonitoringAutoConfiguration.class);
+                    assertThat(context)
+                            .doesNotHaveBean(
+                                    TransactionMonitoringAutoConfiguration
+                                            .LogbackInMemoryPaginationAppenderConfiguration.class);
+                });
     }
 
     @Test
@@ -76,6 +94,10 @@ class TransactionMonitoringAutoConfigurationTest {
                     assertThat(context).doesNotHaveBean(TransactionMonitoringEndpoint.class);
                     assertThat(context).doesNotHaveBean(TransactionMonitoringBeanPostProcessor.class);
                     assertThat(context).doesNotHaveBean(ProxyingDataSourceBeanPostProcessor.class);
+                    assertThat(context)
+                            .doesNotHaveBean(
+                                    TransactionMonitoringAutoConfiguration
+                                            .LogbackInMemoryPaginationAppenderConfiguration.class);
                 });
     }
 
@@ -93,6 +115,10 @@ class TransactionMonitoringAutoConfigurationTest {
             assertThat(context).doesNotHaveBean(TransactionMonitoringEndpoint.class);
             assertThat(context).doesNotHaveBean(TransactionMonitoringBeanPostProcessor.class);
             assertThat(context).doesNotHaveBean(ProxyingDataSourceBeanPostProcessor.class);
+            assertThat(context)
+                    .doesNotHaveBean(
+                            TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
+                                    .class);
         });
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -53,6 +54,7 @@ import com.axelixlabs.axelix.sbs.spring.core.validate.ValidationListener;
  * @since 21.01.2026
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
+ * @author Ilya Naumov
  */
 @AutoConfiguration(after = CompositeMeterRegistryAutoConfiguration.class)
 @ConditionalOnAvailableEndpoint(endpoint = TransactionMonitoringEndpoint.class)
@@ -124,6 +126,11 @@ public class TransactionMonitoringAutoConfiguration {
 
     @Configuration
     @ConditionalOnClass(name = {"org.hibernate.Session", "ch.qos.logback.classic.LoggerContext"})
+    @ConditionalOnProperty(
+            prefix = "axelix.sbs.transaction.monitoring.in-memory-pagination-detection",
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = true)
     static class LogbackInMemoryPaginationAppenderConfiguration {
 
         @EventListener(ApplicationReadyEvent.class)

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since 10.02.2026
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
+ * @author Ilya Naumov
  */
 class TransactionMonitoringAutoConfigurationTest {
 
@@ -61,7 +62,24 @@ class TransactionMonitoringAutoConfigurationTest {
             assertThat(context).hasSingleBean(TransactionMonitoringEndpoint.class);
             assertThat(context).hasSingleBean(TransactionMonitoringBeanPostProcessor.class);
             assertThat(context).hasSingleBean(ProxyingDataSourceBeanPostProcessor.class);
+            assertThat(context)
+                    .hasSingleBean(
+                            TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
+                                    .class);
         });
+    }
+
+    @Test // GH-1250
+    void shouldNotRegisterInMemoryPaginationAppenderConfiguration_whenDetectionDisabled() {
+        contextRunner
+                .withPropertyValues("axelix.sbs.transaction.monitoring.in-memory-pagination-detection.enabled=false")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(TransactionMonitoringAutoConfiguration.class);
+                    assertThat(context)
+                            .doesNotHaveBean(
+                                    TransactionMonitoringAutoConfiguration
+                                            .LogbackInMemoryPaginationAppenderConfiguration.class);
+                });
     }
 
     @Test
@@ -76,6 +94,10 @@ class TransactionMonitoringAutoConfigurationTest {
                     assertThat(context).doesNotHaveBean(TransactionMonitoringEndpoint.class);
                     assertThat(context).doesNotHaveBean(TransactionMonitoringBeanPostProcessor.class);
                     assertThat(context).doesNotHaveBean(ProxyingDataSourceBeanPostProcessor.class);
+                    assertThat(context)
+                            .doesNotHaveBean(
+                                    TransactionMonitoringAutoConfiguration
+                                            .LogbackInMemoryPaginationAppenderConfiguration.class);
                 });
     }
 
@@ -93,6 +115,10 @@ class TransactionMonitoringAutoConfigurationTest {
             assertThat(context).doesNotHaveBean(TransactionMonitoringEndpoint.class);
             assertThat(context).doesNotHaveBean(TransactionMonitoringBeanPostProcessor.class);
             assertThat(context).doesNotHaveBean(ProxyingDataSourceBeanPostProcessor.class);
+            assertThat(context)
+                    .doesNotHaveBean(
+                            TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
+                                    .class);
         });
     }
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/config/TransactionMonitoringConfigurationProperties.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/config/TransactionMonitoringConfigurationProperties.java
@@ -88,7 +88,7 @@ public class TransactionMonitoringConfigurationProperties implements Validatable
     public String toString() {
         return "TransactionMonitoringConfigurationProperties{" + "maxTransactionsPerMethod=" + maxTransactionsPerMethod
                 + ", inMemoryPaginationDetection=" + inMemoryPaginationDetection
-                + "\"" + '}';
+                + '}';
     }
 
     @Override

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/config/TransactionMonitoringConfigurationProperties.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/config/TransactionMonitoringConfigurationProperties.java
@@ -28,6 +28,7 @@ import com.axelixlabs.axelix.common.utils.Assert;
  * @author Nikita Kirillov
  * @author Cherkasov Sergey
  * @author Mikhail Polivakha
+ * @author Ilya Naumov
  */
 public class TransactionMonitoringConfigurationProperties implements Validatable {
 
@@ -37,10 +38,16 @@ public class TransactionMonitoringConfigurationProperties implements Validatable
     private Integer maxTransactionsPerMethod;
 
     /**
+     * In memory pagination detection properties.
+     */
+    private InMemoryPaginationDetection inMemoryPaginationDetection;
+
+    /**
      * Create a new TransactionMonitoringConfigurationProperties
      */
     public TransactionMonitoringConfigurationProperties() {
         this.maxTransactionsPerMethod = 30;
+        this.inMemoryPaginationDetection = new InMemoryPaginationDetection(true);
     }
 
     public Integer getMaxTransactionsPerMethod() {
@@ -52,28 +59,78 @@ public class TransactionMonitoringConfigurationProperties implements Validatable
         return this;
     }
 
+    public InMemoryPaginationDetection getInMemoryPaginationDetection() {
+        return inMemoryPaginationDetection;
+    }
+
+    public TransactionMonitoringConfigurationProperties setInMemoryPaginationDetection(
+            InMemoryPaginationDetection inMemoryPaginationDetection) {
+        this.inMemoryPaginationDetection = inMemoryPaginationDetection;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
         TransactionMonitoringConfigurationProperties that = (TransactionMonitoringConfigurationProperties) o;
-        return Objects.equals(maxTransactionsPerMethod, that.maxTransactionsPerMethod);
+        return Objects.equals(maxTransactionsPerMethod, that.maxTransactionsPerMethod)
+                && Objects.equals(inMemoryPaginationDetection, that.inMemoryPaginationDetection);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxTransactionsPerMethod);
+        return Objects.hash(maxTransactionsPerMethod, inMemoryPaginationDetection);
     }
 
     @Override
     public String toString() {
         return "TransactionMonitoringConfigurationProperties{" + "maxTransactionsPerMethod=" + maxTransactionsPerMethod
+                + ", inMemoryPaginationDetection=" + inMemoryPaginationDetection
                 + "\"" + '}';
     }
 
     @Override
     public void validate() throws IllegalArgumentException {
         Assert.isTrue(maxTransactionsPerMethod > 0, "maxTransactionsPerMethod must be positive");
+    }
+
+    public static class InMemoryPaginationDetection {
+        /**
+         * Whether in-memory pagination detection is enabled.
+         */
+        private Boolean enabled;
+
+        public InMemoryPaginationDetection(Boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public Boolean getEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            InMemoryPaginationDetection that = (InMemoryPaginationDetection) o;
+            return Objects.equals(enabled, that.enabled);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(enabled);
+        }
+
+        @Override
+        public String toString() {
+            return "InMemoryPaginationDetection{" + "enabled=" + enabled + '}';
+        }
     }
 }


### PR DESCRIPTION
Closes #1250.

 ## What changed
  - Added a property to disable in-memory pagination detection.
  - Updated both Spring Boot 2 and Spring Boot 3 starter auto-configurations.
  - Added tests.
  - Documented the new option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation on Hibernate in-memory pagination detection, explaining the issue and how to configure it.

* **New Features**
  * Added configuration option `axelix.sbs.transaction.monitoring.in-memory-pagination-detection.enabled` to control in-memory pagination detection monitoring (enabled by default).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->