### PR TITLE
Add @ConditionalOnHibernateActive composite annotation.

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -29,6 +28,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
 
 import com.axelixlabs.axelix.sbs.spring.core.config.TransactionMonitoringConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.ConditionalOnHibernateActive;
 import com.axelixlabs.axelix.sbs.spring.core.transactions.DefaultQueriesRecorder;
 import com.axelixlabs.axelix.sbs.spring.core.transactions.DefaultTransactionMonitoringService;
 import com.axelixlabs.axelix.sbs.spring.core.transactions.DefaultTransactionStatsCollector;
@@ -48,6 +48,7 @@ import com.axelixlabs.axelix.sbs.spring.core.validate.ValidationListener;
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
  * @author Ilya Naumov
+ * @author Vyacheslav Yanin
  */
 @AutoConfiguration
 @ConditionalOnAvailableEndpoint(endpoint = TransactionMonitoringEndpoint.class)
@@ -108,7 +109,7 @@ public class TransactionMonitoringAutoConfiguration {
     }
 
     @Configuration
-    @ConditionalOnClass(name = {"org.hibernate.Session", "ch.qos.logback.classic.LoggerContext"})
+    @ConditionalOnHibernateActive
     @ConditionalOnProperty(
             prefix = "axelix.sbs.transaction.monitoring.in-memory-pagination-detection",
             name = "enabled",

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ConditionalOnHibernateActive.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ConditionalOnHibernateActive.java
@@ -28,11 +28,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 
 /**
  * Composite {@code @Conditional} annotation that matches only if Hibernate is
- * active in the application context and the required logging classes are present on the classpath.
+ * active in the application context.
  *
  * <p>This annotation should be used on configuration classes or components
- * that require an active {@code EntityManagerFactory} bean alongside
- * {@code LoggerContext} to perform Hibernate-specific logging and monitoring operations.
+ * that require an active {@code EntityManagerFactory} bean to perform
+ * Hibernate-specific operations.
  *
  * @since 22.06.2026
  * @author Vyacheslav Yanin

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ConditionalOnHibernateActive.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ConditionalOnHibernateActive.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+
+/**
+ * Composite {@code @Conditional} annotation that matches only if Hibernate is
+ * active in the application context and the required logging classes are present on the classpath.
+ *
+ * <p>This annotation should be used on configuration classes or components
+ * that require an active {@code EntityManagerFactory} bean alongside
+ * {@code LoggerContext} to perform Hibernate-specific logging and monitoring operations.
+ *
+ * @since 22.06.2026
+ * @author Vyacheslav Yanin
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ConditionalOnClass(name = {"org.hibernate.Session", "ch.qos.logback.classic.LoggerContext"})
+@ConditionalOnBean(type = "javax.persistence.EntityManagerFactory")
+public @interface ConditionalOnHibernateActive {}

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ConditionalOnHibernateActive.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ConditionalOnHibernateActive.java
@@ -40,6 +40,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@ConditionalOnClass(name = {"org.hibernate.Session", "ch.qos.logback.classic.LoggerContext"})
+@ConditionalOnClass(name = {"org.hibernate.Session"})
 @ConditionalOnBean(type = "javax.persistence.EntityManagerFactory")
 public @interface ConditionalOnHibernateActive {}

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -19,7 +19,10 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import java.util.List;
 
+import javax.persistence.EntityManagerFactory;
+
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -45,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Ilya Naumov
+ * @author Vyacheslav Yanin
  */
 class TransactionMonitoringAutoConfigurationTest {
 
@@ -63,10 +67,22 @@ class TransactionMonitoringAutoConfigurationTest {
             assertThat(context).hasSingleBean(TransactionMonitoringBeanPostProcessor.class);
             assertThat(context).hasSingleBean(ProxyingDataSourceBeanPostProcessor.class);
             assertThat(context)
-                    .hasSingleBean(
+                    .doesNotHaveBean(
                             TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
                                     .class);
         });
+    }
+
+    @Test // GH-1254
+    void shouldCreatePaginationAppender_whenEntityManagerFactoryIsPresent() {
+        EntityManagerFactory mockFactory = Mockito.mock(EntityManagerFactory.class);
+
+        contextRunner
+                .withBean(EntityManagerFactory.class, () -> mockFactory)
+                .run(context -> assertThat(context)
+                        .hasSingleBean(
+                                TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
+                                        .class));
     }
 
     @Test // GH-1250

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -24,7 +24,6 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.condition.Conditi
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -36,6 +35,7 @@ import org.springframework.context.event.EventListener;
 import com.axelixlabs.axelix.sbs.spring.core.config.TransactionMonitoringConfigurationProperties;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.ConditionalOnHibernateActive;
 import com.axelixlabs.axelix.sbs.spring.core.transactions.DefaultQueriesRecorder;
 import com.axelixlabs.axelix.sbs.spring.core.transactions.DefaultTransactionMonitoringService;
 import com.axelixlabs.axelix.sbs.spring.core.transactions.DefaultTransactionStatsCollector;
@@ -55,6 +55,7 @@ import com.axelixlabs.axelix.sbs.spring.core.validate.ValidationListener;
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
  * @author Ilya Naumov
+ * @author Vyacheslav Yanin
  */
 @AutoConfiguration(after = CompositeMeterRegistryAutoConfiguration.class)
 @ConditionalOnAvailableEndpoint(endpoint = TransactionMonitoringEndpoint.class)
@@ -125,7 +126,7 @@ public class TransactionMonitoringAutoConfiguration {
     }
 
     @Configuration
-    @ConditionalOnClass(name = {"org.hibernate.Session", "ch.qos.logback.classic.LoggerContext"})
+    @ConditionalOnHibernateActive
     @ConditionalOnProperty(
             prefix = "axelix.sbs.transaction.monitoring.in-memory-pagination-detection",
             name = "enabled",

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ConditionalOnHibernateActive.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ConditionalOnHibernateActive.java
@@ -28,11 +28,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 
 /**
  * Composite {@code @Conditional} annotation that matches only if Hibernate is
- * active in the application context and the required logging classes are present on the classpath.
+ * active in the application context.
  *
  * <p>This annotation should be used on configuration classes or components
- * that require an active {@code EntityManagerFactory} bean alongside
- * {@code LoggerContext} to perform Hibernate-specific logging and monitoring operations.
+ * that require an active {@code EntityManagerFactory} bean to perform
+ * Hibernate-specific operations.
  *
  * @since 22.06.2026
  * @author Vyacheslav Yanin

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ConditionalOnHibernateActive.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ConditionalOnHibernateActive.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+
+/**
+ * Composite {@code @Conditional} annotation that matches only if Hibernate is
+ * active in the application context and the required logging classes are present on the classpath.
+ *
+ * <p>This annotation should be used on configuration classes or components
+ * that require an active {@code EntityManagerFactory} bean alongside
+ * {@code LoggerContext} to perform Hibernate-specific logging and monitoring operations.
+ *
+ * @since 22.06.2026
+ * @author Vyacheslav Yanin
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ConditionalOnClass(name = {"org.hibernate.Session", "ch.qos.logback.classic.LoggerContext"})
+@ConditionalOnBean(type = "jakarta.persistence.EntityManagerFactory")
+public @interface ConditionalOnHibernateActive {}

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ConditionalOnHibernateActive.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ConditionalOnHibernateActive.java
@@ -40,6 +40,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@ConditionalOnClass(name = {"org.hibernate.Session", "ch.qos.logback.classic.LoggerContext"})
+@ConditionalOnClass(name = {"org.hibernate.Session"})
 @ConditionalOnBean(type = "jakarta.persistence.EntityManagerFactory")
 public @interface ConditionalOnHibernateActive {}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -19,7 +19,10 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import java.util.List;
 
+import jakarta.persistence.EntityManagerFactory;
+
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -45,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Ilya Naumov
+ * @author Vyacheslav Yanin
  */
 class TransactionMonitoringAutoConfigurationTest {
 
@@ -63,10 +67,22 @@ class TransactionMonitoringAutoConfigurationTest {
             assertThat(context).hasSingleBean(TransactionMonitoringBeanPostProcessor.class);
             assertThat(context).hasSingleBean(ProxyingDataSourceBeanPostProcessor.class);
             assertThat(context)
-                    .hasSingleBean(
+                    .doesNotHaveBean(
                             TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
                                     .class);
         });
+    }
+
+    @Test // GH-1254
+    void shouldCreatePaginationAppender_whenEntityManagerFactoryIsPresent() {
+        EntityManagerFactory mockFactory = Mockito.mock(EntityManagerFactory.class);
+
+        contextRunner
+                .withBean(EntityManagerFactory.class, () -> mockFactory)
+                .run(context -> assertThat(context)
+                        .hasSingleBean(
+                                TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
+                                        .class));
     }
 
     @Test // GH-1250


### PR DESCRIPTION
Introduce custom annotation to combine classpath and bean checks for EntityManagerFactory. This ensures the logback appender bootstraps only when Hibernate is active. Fixed auto-configuration tests with mock context.

Closes #1254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Spring conditional annotation to enable Hibernate/transaction monitoring auto-configuration only when Hibernate is active and an `EntityManagerFactory` bean is present.

* **Refactor**
  * Updated transaction monitoring auto-configuration (Spring Boot 2 and 3) to use the new runtime Hibernate activation condition for in-memory pagination appender setup.

* **Tests**
  * Expanded auto-configuration tests to cover the `EntityManagerFactory`-present scenario and confirm the pagination appender configuration is created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->