### PR TITLE
GH-1300 Introduce core infrastructure for N+1 and Batch+1 query detection

### DIFF
--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ProxyingPreparedStatement.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/ProxyingPreparedStatement.java
@@ -74,7 +74,7 @@ public class ProxyingPreparedStatement implements PreparedStatement {
             boolean inMemoryPaginated = InMemoryPaginationHolder.isMarked();
             InMemoryPaginationHolder.clear();
             queriesRecorder.recordQuery(
-                    new SqlQueryRecord(sql, durationNs / 1_000_000, startTimestampMs, inMemoryPaginated));
+                    new SqlQueryRecord(sql, durationNs / 1_000_000, startTimestampMs, inMemoryPaginated, null));
         }
     }
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/SqlQueryRecord.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/SqlQueryRecord.java
@@ -17,6 +17,8 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.transactions;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Record of a single SQL query execution.
  *
@@ -28,19 +30,27 @@ public class SqlQueryRecord {
     private final String sql;
     private final long durationMs;
     private final long startTimestampMs;
+
     private final boolean inMemoryPaginated;
+    private final @Nullable Integer sqlIndex;
+    private boolean nPlusOne = false;
+    private boolean batchPlusOne = false;
 
     /**
      * @param sql               the executed SQL statement
      * @param durationMs        query execution duration in milliseconds.
      * @param startTimestampMs  unix timestamp (milliseconds from epoch) when the query started.
      * @param inMemoryPaginated whether Hibernate applied pagination in memory for this query.
+     * @param sqlIndex          the sequential execution index of this SQL statement within the current tracking
+     *                          context, used to correlate queries with specific entity or collection loads.
      */
-    public SqlQueryRecord(String sql, long durationMs, long startTimestampMs, boolean inMemoryPaginated) {
+    public SqlQueryRecord(
+            String sql, long durationMs, long startTimestampMs, boolean inMemoryPaginated, @Nullable Integer sqlIndex) {
         this.sql = sql;
         this.durationMs = durationMs;
         this.startTimestampMs = startTimestampMs;
         this.inMemoryPaginated = inMemoryPaginated;
+        this.sqlIndex = sqlIndex;
     }
 
     public String getSql() {
@@ -61,5 +71,25 @@ public class SqlQueryRecord {
 
     public boolean isInMemoryPaginated() {
         return inMemoryPaginated;
+    }
+
+    public @Nullable Integer getSqlIndex() {
+        return sqlIndex;
+    }
+
+    public boolean isNPlusOne() {
+        return nPlusOne;
+    }
+
+    public boolean isBatchPlusOne() {
+        return batchPlusOne;
+    }
+
+    public void markAsNPlusOne() {
+        this.nPlusOne = true;
+    }
+
+    public void markAsBatchPlusOne() {
+        this.batchPlusOne = true;
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/NPlusOneAnalyzer.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/NPlusOneAnalyzer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.axelixlabs.axelix.sbs.spring.core.transactions.QueriesRecorder;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.SqlQueryRecord;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate.NPlusOneHolder.LoadSnapshot;
+
+/**
+ * Analyzes transaction execution data to detect N+1 and Batch+1 fetch patterns.
+ *
+ * @author Nikita Kirillov
+ */
+public class NPlusOneAnalyzer {
+
+    /**
+     * @param context completed transaction context from {@link NPlusOneHolder}
+     * @param queries SQL records from {@link QueriesRecorder} for the same transaction
+     */
+    public void analyzeAndMarkNPlusOneQueries(NPlusOneHolder.NPlusOneContext context, List<SqlQueryRecord> queries) {
+        // Analyze Collections
+        analyzeSnapshot(context.getCollectionLoadsSnapshot(), queries);
+        // Analyze Entities
+        analyzeSnapshot(context.getEntityLoadsSnapshot(), queries);
+    }
+
+    private void analyzeSnapshot(LoadSnapshot snapshot, List<SqlQueryRecord> queries) {
+        // Analyze N+1
+        markQueries(snapshot.getStandardLoads(), queries, SqlQueryRecord::markAsNPlusOne);
+        // Analyze Batch+1
+        markQueries(snapshot.getBatchLoads(), queries, SqlQueryRecord::markAsBatchPlusOne);
+    }
+
+    private void markQueries(
+            Map<String, Map<Object, Integer>> loads, List<SqlQueryRecord> queries, Consumer<SqlQueryRecord> marker) {
+        loads.forEach((role, idToSqlIndex) -> {
+
+            // Deduplicate SQL execution indices to prevent false-positives during batch fetching.
+            // A single batch query may initialize multiple entity IDs under the exact same SQL index.
+            List<Integer> distinctSqlIndices =
+                    idToSqlIndex.values().stream().distinct().collect(Collectors.toList());
+
+            // If the same role/entity was fetched across multiple distinct database requests,
+            // it strictly indicates an N+1 or Batch+1 defect.
+            if (distinctSqlIndices.size() > 1) {
+                distinctSqlIndices.forEach(sqlIndex -> queries.stream()
+                        .filter(query -> Objects.equals(query.getSqlIndex(), sqlIndex))
+                        .findFirst()
+                        .ifPresent(marker));
+            }
+        });
+    }
+}

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/NPlusOneHolder.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/NPlusOneHolder.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Thread-local storage for N+1 and Batch+1 query detection within a single transaction.
+ *
+ * @author Nikita Kirillov
+ */
+public final class NPlusOneHolder {
+
+    // assume no REQUIRES_NEW transactions by default
+    private final ThreadLocal<Deque<NPlusOneContext>> contextStack = ThreadLocal.withInitial(() -> new ArrayDeque<>(1));
+
+    /**
+     * Pushes a new context onto the stack.
+     * Must be called at the start of each tracked transaction.
+     */
+    public void startContext() {
+        contextStack.get().push(new NPlusOneContext());
+    }
+
+    /**
+     * Pops and returns the current context from the stack.
+     * Must be called in the {@code finally} block of each tracked transaction.
+     *
+     * @return the completed context, or {@code null} if the stack is empty
+     */
+    @Nullable
+    public NPlusOneContext popContext() {
+        Deque<NPlusOneContext> stack = contextStack.get();
+        NPlusOneContext currentContext = stack.poll();
+        if (stack.isEmpty()) {
+            contextStack.remove();
+        }
+        return currentContext;
+    }
+
+    /**
+     * Clears all contexts from the stack.
+     * Called by {@code NPlusOneCleanupFilter} after each HTTP request
+     * to prevent ThreadLocal leaks when OSIV is enabled.
+     */
+    public void clearAll() {
+        contextStack.remove();
+    }
+
+    /**
+     * Records a lazy collection load triggered by {@code EventType.INIT_COLLECTION}.
+     *
+     * @param role    collection role (e.g. {@code com.example.Order.items})
+     * @param ownerId ID of the entity that owns the collection
+     * @param isBatch {@code true} if batch loaded, otherwise {@code false}
+     */
+    public void recordCollectionLoad(String role, Object ownerId, boolean isBatch) {
+        NPlusOneContext currentContext = currentContext();
+        if (currentContext != null) {
+            currentContext.collectionLoadsSnapshot.record(role, ownerId, currentContext.sqlCounter, isBatch);
+        }
+    }
+
+    /**
+     * Records an owning-side entity load triggered by {@code EventType.LOAD}.
+     *
+     * @param entityClassName fully qualified entity class name
+     * @param id              loaded entity ID
+     * @param isBatch         {@code true} if batch loaded, otherwise {@code false}
+     */
+    public void recordEntityLoad(String entityClassName, Object id, boolean isBatch) {
+        NPlusOneContext currentContext = currentContext();
+        if (currentContext != null) {
+            currentContext.entityLoadsSnapshot.record(entityClassName, id, currentContext.sqlCounter, isBatch);
+        }
+    }
+
+    /**
+     * Increments the SQL statement counter for the current context.
+     * Called from {@code ProxyingPreparedStatement} before each SQL execution.
+     */
+    public @Nullable Integer incrementAndGetSqlCount() {
+        NPlusOneContext currentContext = currentContext();
+        return currentContext != null ? ++currentContext.sqlCounter : null;
+    }
+
+    @Nullable
+    private NPlusOneContext currentContext() {
+        return contextStack.get().peek();
+    }
+
+    /**
+     * Holds all N+1 and Batch+1 tracking data for a single transaction boundary.
+     */
+    public static class NPlusOneContext {
+
+        private final LoadSnapshot collectionLoadsSnapshot = new LoadSnapshot();
+        private final LoadSnapshot entityLoadsSnapshot = new LoadSnapshot();
+
+        /**
+         * Counts SQL statements executed within this transaction.
+         * Used to assign snapshots for distinguishing bulk loads from secondary selects.
+         */
+        private int sqlCounter = 0;
+
+        public LoadSnapshot getCollectionLoadsSnapshot() {
+            return collectionLoadsSnapshot;
+        }
+
+        public LoadSnapshot getEntityLoadsSnapshot() {
+            return entityLoadsSnapshot;
+        }
+    }
+
+    public static class LoadSnapshot {
+        // Key: role or entityClassName
+        // Value: map of id → sqlIndex
+        private final Map<String, Map<Object, Integer>> standardLoads = new HashMap<>();
+        private final Map<String, Map<Object, Integer>> batchLoads = new HashMap<>();
+
+        public void record(String targetName, Object id, int sqlCounter, boolean isBatch) {
+            Map<String, Map<Object, Integer>> targetMap = isBatch ? batchLoads : standardLoads;
+            targetMap.computeIfAbsent(targetName, k -> new HashMap<>()).put(id, sqlCounter);
+        }
+
+        public Map<String, Map<Object, Integer>> getStandardLoads() {
+            return standardLoads;
+        }
+
+        public Map<String, Map<Object, Integer>> getBatchLoads() {
+            return batchLoads;
+        }
+    }
+}

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/NPlusOneAnalyzerTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/NPlusOneAnalyzerTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.axelixlabs.axelix.sbs.spring.core.transactions.SqlQueryRecord;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate.NPlusOneHolder.NPlusOneContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** * Unit tests for {@link NPlusOneAnalyzer}.
+ *
+ * @author Nikita Kirillov
+ */
+class NPlusOneAnalyzerTest {
+
+    private final NPlusOneAnalyzer analyzer = new NPlusOneAnalyzer();
+
+    @Test
+    void shouldNotMarkQuery_whenSingleCollectionLoad() {
+        // given
+        NPlusOneContext context = new NPlusOneContext();
+
+        context.getCollectionLoadsSnapshot().record("Order.items", 1, 1, false);
+
+        SqlQueryRecord query = queryWithIndex(1);
+        List<SqlQueryRecord> queries = List.of(query);
+
+        // when
+        analyzer.analyzeAndMarkNPlusOneQueries(context, queries);
+
+        // then
+        assertThat(query.isNPlusOne()).isFalse();
+        assertThat(query.isBatchPlusOne()).isFalse();
+    }
+
+    @Test
+    void shouldMarkQueries_whenMultipleCollectionLoads() {
+        // given
+        NPlusOneContext context = new NPlusOneContext();
+        context.getCollectionLoadsSnapshot().record("Order.items", 1, 1, false);
+        context.getCollectionLoadsSnapshot().record("Order.items", 2, 2, false);
+        context.getCollectionLoadsSnapshot().record("Order.items", 3, 3, false);
+
+        SqlQueryRecord query1 = queryWithIndex(1);
+        SqlQueryRecord query2 = queryWithIndex(2);
+        SqlQueryRecord query3 = queryWithIndex(3);
+        SqlQueryRecord unrelatedQuery = queryWithIndex(4);
+        List<SqlQueryRecord> queries = List.of(query1, query2, query3, unrelatedQuery);
+
+        // when
+        analyzer.analyzeAndMarkNPlusOneQueries(context, queries);
+
+        // then
+        assertThat(query1.isNPlusOne()).isTrue();
+        assertThat(query2.isNPlusOne()).isTrue();
+        assertThat(query3.isNPlusOne()).isTrue();
+        assertThat(query1.isBatchPlusOne()).isFalse();
+        assertThat(query2.isBatchPlusOne()).isFalse();
+        assertThat(query3.isBatchPlusOne()).isFalse();
+
+        assertThat(unrelatedQuery.isNPlusOne()).isFalse();
+        assertThat(unrelatedQuery.isBatchPlusOne()).isFalse();
+    }
+
+    @Test
+    void shouldMarkAsBatchPlusOne_whenMultipleBatchCollectionLoads() {
+        // given
+        NPlusOneContext context = new NPlusOneContext();
+        context.getCollectionLoadsSnapshot().record("Order.items", 1, 1, true);
+        context.getCollectionLoadsSnapshot().record("Order.items", 2, 2, true);
+
+        SqlQueryRecord query1 = queryWithIndex(1);
+        SqlQueryRecord query2 = queryWithIndex(2);
+        List<SqlQueryRecord> queries = List.of(query1, query2);
+
+        // when
+        analyzer.analyzeAndMarkNPlusOneQueries(context, queries);
+
+        // then
+        assertThat(query1.isBatchPlusOne()).isTrue();
+        assertThat(query2.isBatchPlusOne()).isTrue();
+        assertThat(query1.isNPlusOne()).isFalse();
+        assertThat(query2.isNPlusOne()).isFalse();
+    }
+
+    @Test
+    void shouldHandleMultipleRoles_independently() {
+        // given
+        NPlusOneContext context = new NPlusOneContext();
+        // N+1 on first role
+        context.getCollectionLoadsSnapshot().record("Order.items", 1, 1, false);
+        context.getCollectionLoadsSnapshot().record("Order.items", 2, 2, false);
+        // only one load, not N+1
+        context.getCollectionLoadsSnapshot().record("Order.tags", 1, 3, false);
+
+        SqlQueryRecord query1 = queryWithIndex(1);
+        SqlQueryRecord query2 = queryWithIndex(2);
+        SqlQueryRecord query3 = queryWithIndex(3);
+        List<SqlQueryRecord> queries = List.of(query1, query2, query3);
+
+        // when
+        analyzer.analyzeAndMarkNPlusOneQueries(context, queries);
+
+        // then
+        assertThat(query1.isNPlusOne()).isTrue();
+        assertThat(query2.isNPlusOne()).isTrue();
+        assertThat(query3.isNPlusOne()).isFalse();
+    }
+
+    @Test
+    void shouldNotMarkQuery_whenSingleEntityLoad() {
+        // given
+        NPlusOneContext context = new NPlusOneContext();
+        context.getEntityLoadsSnapshot().record("Item", 1, 1, false);
+
+        SqlQueryRecord query = queryWithIndex(1);
+        List<SqlQueryRecord> queries = List.of(query);
+
+        // when
+        analyzer.analyzeAndMarkNPlusOneQueries(context, queries);
+
+        // then
+        assertThat(query.isNPlusOne()).isFalse();
+        assertThat(query.isBatchPlusOne()).isFalse();
+    }
+
+    @Test
+    void shouldMarkQueries_whenMultipleEntityLoads() {
+        // given
+        NPlusOneContext context = new NPlusOneContext();
+        context.getEntityLoadsSnapshot().record("Item", 1, 1, false);
+        context.getEntityLoadsSnapshot().record("Item", 2, 2, false);
+        context.getEntityLoadsSnapshot().record("Item", 3, 3, false);
+
+        SqlQueryRecord query1 = queryWithIndex(1);
+        SqlQueryRecord query2 = queryWithIndex(2);
+        SqlQueryRecord query3 = queryWithIndex(3);
+        List<SqlQueryRecord> queries = List.of(query1, query2, query3);
+
+        // when
+        analyzer.analyzeAndMarkNPlusOneQueries(context, queries);
+
+        // then
+        assertThat(query1.isNPlusOne()).isTrue();
+        assertThat(query2.isNPlusOne()).isTrue();
+        assertThat(query3.isNPlusOne()).isTrue();
+        assertThat(query1.isBatchPlusOne()).isFalse();
+        assertThat(query2.isBatchPlusOne()).isFalse();
+        assertThat(query3.isBatchPlusOne()).isFalse();
+    }
+
+    @Test
+    void shouldMarkAsBatchPlusOne_whenMultipleBatchEntityLoads() {
+        // given
+        NPlusOneContext context = new NPlusOneContext();
+        context.getEntityLoadsSnapshot().record("Item", 1, 1, true);
+        context.getEntityLoadsSnapshot().record("Item", 2, 2, true);
+
+        SqlQueryRecord query1 = queryWithIndex(1);
+        SqlQueryRecord query2 = queryWithIndex(2);
+        List<SqlQueryRecord> queries = List.of(query1, query2);
+
+        // when
+        analyzer.analyzeAndMarkNPlusOneQueries(context, queries);
+
+        // then
+        assertThat(query1.isBatchPlusOne()).isTrue();
+        assertThat(query2.isBatchPlusOne()).isTrue();
+        assertThat(query1.isNPlusOne()).isFalse();
+        assertThat(query2.isNPlusOne()).isFalse();
+    }
+
+    @Test
+    void shouldNotMarkAnything_whenContextIsEmpty() {
+        // given
+        NPlusOneContext context = new NPlusOneContext();
+        SqlQueryRecord query = queryWithIndex(1);
+        List<SqlQueryRecord> queries = List.of(query);
+
+        // when
+        analyzer.analyzeAndMarkNPlusOneQueries(context, queries);
+
+        // then
+        assertThat(query.isNPlusOne()).isFalse();
+        assertThat(query.isBatchPlusOne()).isFalse();
+    }
+
+    @Test
+    void shouldNotMarkAnything_whenQueriesListIsEmpty() {
+        // given
+        NPlusOneContext context = new NPlusOneContext();
+        context.getCollectionLoadsSnapshot().record("Order.items", 1, 1, false);
+        context.getCollectionLoadsSnapshot().record("Order.items", 2, 2, false);
+
+        // when + then — no exception
+        analyzer.analyzeAndMarkNPlusOneQueries(context, List.of());
+    }
+
+    private SqlQueryRecord queryWithIndex(int sqlIndex) {
+        return new SqlQueryRecord("select 1", 0L, 0L, false, sqlIndex);
+    }
+}


### PR DESCRIPTION
close #1300 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added N+1 and batch+1 detection that analyzes transaction load snapshots and marks matching executed query records accordingly.
  * Introduced per-transaction tracking for both collection loads and entity loads to improve identification of repeated query patterns.
  * Expanded query record metadata with an optional execution index and N+1/batch+1 flags for better diagnostics.
* **Tests**
  * Added coverage to validate N+1 vs batch+1 marking across multiple scenarios (collections, entities, empty inputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->