### PR TITLE
GH-1292: Add instance name postfix generation

### DIFF
--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssembler.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssembler.java
@@ -18,6 +18,7 @@
 package com.axelixlabs.axelix.sbs.spring.core.master;
 
 import java.time.Instant;
+import java.util.Random;
 import java.util.UUID;
 
 import com.axelixlabs.axelix.common.api.registration.SelfRegistrationMetadata;
@@ -28,8 +29,14 @@ import com.axelixlabs.axelix.sbs.spring.core.config.SelfRegistrationConfiguratio
  *
  * @since 05.02.2026
  * @author Nikita Kirillov
+ * @author Ilya Naumov
  */
 public class DefaultSelfRegistrationMetadataAssembler implements SelfRegistrationMetadataAssembler {
+
+    private static final char[] NAME_POSTFIX_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
+    private static final int NAME_POSTFIX_LENGTH = 8;
+
+    private final Random random = new Random();
 
     private final SelfRegistrationConfigurationProperties selfRegistrationConfigurationProperties;
 
@@ -50,11 +57,22 @@ public class DefaultSelfRegistrationMetadataAssembler implements SelfRegistratio
 
     @Override
     public SelfRegistrationMetadata assemble() {
+        String uniqueInstanceName =
+                selfRegistrationConfigurationProperties.getInstanceName() + "-" + generateNamePostfix();
+
         return new SelfRegistrationMetadata(
                 serviceMetadataAssembler.assemble(),
                 instanceId,
-                selfRegistrationConfigurationProperties.getInstanceName(),
+                uniqueInstanceName,
                 selfRegistrationConfigurationProperties.getInstanceActuatorUrl(),
                 deploymentAt);
+    }
+
+    private String generateNamePostfix() {
+        StringBuilder sb = new StringBuilder(NAME_POSTFIX_LENGTH);
+        for (int i = 0; i < NAME_POSTFIX_LENGTH; i++) {
+            sb.append(NAME_POSTFIX_CHARS[random.nextInt(NAME_POSTFIX_CHARS.length)]);
+        }
+        return sb.toString();
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssembler.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssembler.java
@@ -44,6 +44,8 @@ public class DefaultSelfRegistrationMetadataAssembler implements SelfRegistratio
 
     private final String instanceId;
 
+    private final String instanceName;
+
     private final String deploymentAt;
 
     public DefaultSelfRegistrationMetadataAssembler(
@@ -52,18 +54,17 @@ public class DefaultSelfRegistrationMetadataAssembler implements SelfRegistratio
         this.selfRegistrationConfigurationProperties = selfRegistrationConfigurationProperties;
         this.serviceMetadataAssembler = serviceMetadataAssembler;
         this.instanceId = UUID.randomUUID().toString();
+        this.instanceName = selfRegistrationConfigurationProperties.getInstanceName() + "-" + generateNamePostfix();
         this.deploymentAt = Instant.now().toString();
     }
 
     @Override
     public SelfRegistrationMetadata assemble() {
-        String uniqueInstanceName =
-                selfRegistrationConfigurationProperties.getInstanceName() + "-" + generateNamePostfix();
 
         return new SelfRegistrationMetadata(
                 serviceMetadataAssembler.assemble(),
                 instanceId,
-                uniqueInstanceName,
+                instanceName,
                 selfRegistrationConfigurationProperties.getInstanceActuatorUrl(),
                 deploymentAt);
     }

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssemblerTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssemblerTest.java
@@ -143,11 +143,13 @@ class DefaultSelfRegistrationMetadataAssemblerTest {
     void shouldAssembleTheSelfRegistrationMetadataAboutGivenService() {
         // when.
         SelfRegistrationMetadata metadata = subject.assemble();
+        SelfRegistrationMetadata secondMetadata = subject.assemble();
         BasicDiscoveryMetadata basicMetadata = metadata.getBasicDiscoveryMetadata();
 
         // then.
         assertThat(metadata.getInstanceId()).isNotBlank();
         assertThat(metadata.getInstanceName()).startsWith("testApp-").hasSize("testApp-".length() + 8);
+        assertThat(metadata.getInstanceName()).isNotEqualTo(secondMetadata.getInstanceName());
         assertThat(metadata.getInstanceActuatorUrl()).isEqualTo("http://localhost:8089/actuator");
         assertThat(metadata.getDeploymentAt()).isNotBlank();
         assertThat(Instant.parse(metadata.getDeploymentAt()).isBefore(Instant.now()))

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssemblerTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssemblerTest.java
@@ -71,6 +71,12 @@ class DefaultSelfRegistrationMetadataAssemblerTest {
     @Autowired
     private SelfRegistrationMetadataAssembler subject;
 
+    @Autowired
+    private ServiceMetadataAssembler service;
+
+    @Autowired
+    private SelfRegistrationConfigurationProperties properties;
+
     @TestConfiguration
     static class CurrentConfig {
 
@@ -143,13 +149,11 @@ class DefaultSelfRegistrationMetadataAssemblerTest {
     void shouldAssembleTheSelfRegistrationMetadataAboutGivenService() {
         // when.
         SelfRegistrationMetadata metadata = subject.assemble();
-        SelfRegistrationMetadata secondMetadata = subject.assemble();
         BasicDiscoveryMetadata basicMetadata = metadata.getBasicDiscoveryMetadata();
 
         // then.
         assertThat(metadata.getInstanceId()).isNotBlank();
         assertThat(metadata.getInstanceName()).startsWith("testApp-").hasSize("testApp-".length() + 8);
-        assertThat(metadata.getInstanceName()).isNotEqualTo(secondMetadata.getInstanceName());
         assertThat(metadata.getInstanceActuatorUrl()).isEqualTo("http://localhost:8089/actuator");
         assertThat(metadata.getDeploymentAt()).isNotBlank();
         assertThat(Instant.parse(metadata.getDeploymentAt()).isBefore(Instant.now()))
@@ -160,5 +164,33 @@ class DefaultSelfRegistrationMetadataAssemblerTest {
         assertThat(basicMetadata.getHealthStatus()).isEqualTo(BasicDiscoveryMetadata.HealthStatus.UP);
         assertThat(basicMetadata.getSoftwareVersions().getSpringBoot()).isEqualTo(SpringBootVersion.getVersion());
         assertThat(basicMetadata.getSoftwareVersions().getSpringFramework()).isEqualTo(SpringVersion.getVersion());
+    }
+
+    @Test // GH-1292
+    void shouldReturnStableInstanceNameOnRepeatedCalls() {
+        // when.
+        SelfRegistrationMetadata firstMetadata = subject.assemble();
+        SelfRegistrationMetadata secondMetadata = subject.assemble();
+
+        // then.
+        assertThat(firstMetadata.getInstanceName()).isEqualTo(secondMetadata.getInstanceName());
+    }
+
+    @Test // GH-1292
+    void shouldReturnDifferentInstanceNameForDifferentInstances() {
+        // given.
+        DefaultSelfRegistrationMetadataAssembler assembler1 =
+                new DefaultSelfRegistrationMetadataAssembler(service, properties);
+        DefaultSelfRegistrationMetadataAssembler assembler2 =
+                new DefaultSelfRegistrationMetadataAssembler(service, properties);
+
+        // when.
+        SelfRegistrationMetadata metadata1 = assembler1.assemble();
+        SelfRegistrationMetadata metadata2 = assembler2.assemble();
+
+        // then.
+        assertThat(metadata1.getInstanceName()).startsWith("testApp-");
+        assertThat(metadata2.getInstanceName()).startsWith("testApp-");
+        assertThat(metadata1.getInstanceName()).isNotEqualTo(metadata2.getInstanceName());
     }
 }

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssemblerTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssemblerTest.java
@@ -52,6 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since 06.02.2026
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
+ * @author Ilya Naumov
  */
 @SpringBootTest(classes = DefaultSelfRegistrationMetadataAssemblerTest.TestApplication.class)
 @TestPropertySource(
@@ -146,7 +147,7 @@ class DefaultSelfRegistrationMetadataAssemblerTest {
 
         // then.
         assertThat(metadata.getInstanceId()).isNotBlank();
-        assertThat(metadata.getInstanceName()).isEqualTo("testApp");
+        assertThat(metadata.getInstanceName()).startsWith("testApp-").hasSize("testApp-".length() + 8);
         assertThat(metadata.getInstanceActuatorUrl()).isEqualTo("http://localhost:8089/actuator");
         assertThat(metadata.getDeploymentAt()).isNotBlank();
         assertThat(Instant.parse(metadata.getDeploymentAt()).isBefore(Instant.now()))


### PR DESCRIPTION
Closes #1292.

## What changed
- Added random 8-char postfix (lowercase letters + digits) to instance name in `DefaultSelfRegistrationMetadataAssembler` to ensure unique instance names.
- Updated `DefaultSelfRegistrationMetadataAssemblerTest` - changed assertion to verify instance name starts with configured name + 8-char postfix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registration metadata instance names now include a generated unique suffix in addition to the configured base name, reducing collisions when multiple instances register.
  * Metadata creation now consistently uses this full generated instance name.

* **Tests**
  * Updated assertions to match the new instance-name format (prefix plus expected length).
  * Added coverage to confirm name stability within repeated assemblies and uniqueness across different assembler instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->