### PR TITLE
Isolate authentication and authorization test scenarios.

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/BadAuthorityEndpointInvocationContext.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/BadAuthorityEndpointInvocationContext.java
@@ -17,24 +17,23 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.utils.auth;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.Extension;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.axelixlabs.axelix.common.auth.core.Authority;
 import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
@@ -46,56 +45,56 @@ import static org.assertj.core.api.Assertions.assertThat;
  * the provided in {@link ProtectedEndpointTests} will result in {@link HttpStatus#FORBIDDEN}.
  *
  * @author Mikhail Polivakha
+ * @author Vyacheslav Yanin
  */
 public class BadAuthorityEndpointInvocationContext implements TestTemplateInvocationContext {
 
     private final DefaultAuthority accessAuthority;
+    private final DefaultAuthority forbiddenAuthority;
 
     /**
      * @param accessAuthority  the authority that is required to access the given endpoint. The assumption is that for
      *                         any given endpoint there will be just one authority required. Therefore, everything else,
      *                         any other authority except this one MUST produce 403 from the backend.
      */
-    public BadAuthorityEndpointInvocationContext(DefaultAuthority accessAuthority) {
+    private BadAuthorityEndpointInvocationContext(
+            DefaultAuthority accessAuthority, DefaultAuthority forbiddenAuthority) {
         this.accessAuthority = accessAuthority;
+        this.forbiddenAuthority = forbiddenAuthority;
+    }
+
+    public static Stream<TestTemplateInvocationContext> allBadAuthorityScenarios(DefaultAuthority accessAuthority) {
+        return EnumSet.complementOf(EnumSet.of(accessAuthority)).stream()
+                .map(forbiddenAuthority ->
+                        new BadAuthorityEndpointInvocationContext(accessAuthority, forbiddenAuthority));
     }
 
     @Override
-    public @NonNull List<Extension> getAdditionalExtensions() {
-
-        EnumSet<DefaultAuthority> allTheOtherAuthorities = EnumSet.complementOf(EnumSet.of(accessAuthority));
-
-        return allTheOtherAuthorities.stream()
-                .map(defaultAuthority -> (Extension) new TestInvocationCallback(defaultAuthority))
-                .collect(Collectors.toList());
+    public String getDisplayName(int invocationIndex) {
+        return String.format(
+                "Forbidden Auth [%d]: %s (endpoint requires: %s)",
+                invocationIndex, forbiddenAuthority.name(), accessAuthority.name());
     }
 
-    public static class TestInvocationCallback implements BeforeTestExecutionCallback {
-
-        private final Authority authority;
-
-        TestInvocationCallback(Authority authority) {
-            this.authority = authority;
-        }
-
-        @Override
-        public void beforeTestExecution(ExtensionContext context) {
+    @Override
+    public List<Extension> getAdditionalExtensions() {
+        return Collections.singletonList((BeforeTestExecutionCallback) context -> {
             ProtectedEndpointTests meta = context.getRequiredTestMethod().getAnnotation(ProtectedEndpointTests.class);
 
             ApplicationContext applicationContext = SpringExtension.getApplicationContext(context);
 
             TestRestTemplateBuilder testRestTemplateBuilder = applicationContext.getBean(TestRestTemplateBuilder.class);
 
-            TestRestTemplate integrationTestsRole =
-                    testRestTemplateBuilder.withRole(new DefaultRole("INTEGRATION_TESTS_ROLE", Set.of(authority)));
+            TestRestTemplate integrationTestsRole = testRestTemplateBuilder.withRole(
+                    new DefaultRole("INTEGRATION_TESTS_ROLE", Set.of(forbiddenAuthority)));
 
             ResponseEntity<Void> result = integrationTestsRole.exchange(
                     meta.path(),
-                    org.springframework.http.HttpMethod.valueOf(meta.method().name()),
+                    HttpMethod.valueOf(meta.method().name()),
                     ProtectedEndpointRequestSupport.httpEntity(meta),
                     Void.class);
 
             assertThat(result.getStatusCode().value()).isEqualTo(HttpStatus.FORBIDDEN.value());
-        }
+        });
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/BadTokenProtectedEndpointInvocationContext.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/BadTokenProtectedEndpointInvocationContext.java
@@ -17,9 +17,8 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.utils.auth;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.Extension;
@@ -37,35 +36,42 @@ import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * {@link TestTemplateInvocationContext} for scenarios with bad token.
+ * {@link TestTemplateInvocationContext} for a specific scenario with bad token.
  *
  * @author Mikhail Polivakha
+ * @author Vyacheslav Yanin
  */
 public class BadTokenProtectedEndpointInvocationContext implements TestTemplateInvocationContext {
 
+    private final InvalidAuthScenario scenario;
+
+    public BadTokenProtectedEndpointInvocationContext(InvalidAuthScenario scenario) {
+        this.scenario = scenario;
+    }
+
+    @Override
+    public String getDisplayName(int invocationIndex) {
+        return "Bad Auth [" + invocationIndex + "]: " + scenario.name();
+    }
+
     @Override
     public List<Extension> getAdditionalExtensions() {
-        return Arrays.stream(InvalidAuthScenario.values())
-                .map(invalidAuthScenario -> (Extension) (BeforeTestExecutionCallback) context -> {
-                    ProtectedEndpointTests meta =
-                            context.getRequiredTestMethod().getAnnotation(ProtectedEndpointTests.class);
+        return Collections.singletonList((BeforeTestExecutionCallback) context -> {
+            ProtectedEndpointTests meta = context.getRequiredTestMethod().getAnnotation(ProtectedEndpointTests.class);
 
-                    ApplicationContext applicationContext = SpringExtension.getApplicationContext(context);
+            ApplicationContext applicationContext = SpringExtension.getApplicationContext(context);
 
-                    TestRestTemplateBuilder testRestTemplateBuilder =
-                            applicationContext.getBean(TestRestTemplateBuilder.class);
+            TestRestTemplateBuilder testRestTemplateBuilder = applicationContext.getBean(TestRestTemplateBuilder.class);
 
-                    ResponseEntity<Void> result = invalidAuthScenario
-                            .getModifier()
-                            .apply(testRestTemplateBuilder)
-                            .exchange(
-                                    meta.path(),
-                                    HttpMethod.valueOf(meta.method().name()),
-                                    ProtectedEndpointRequestSupport.httpEntity(meta),
-                                    Void.class);
+            ResponseEntity<Void> result = scenario.getModifier()
+                    .apply(testRestTemplateBuilder)
+                    .exchange(
+                            meta.path(),
+                            HttpMethod.valueOf(meta.method().name()),
+                            ProtectedEndpointRequestSupport.httpEntity(meta),
+                            Void.class);
 
-                    assertThat(result.getStatusCode().value()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-                })
-                .collect(Collectors.toList());
+            assertThat(result.getStatusCode().value()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        });
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/ProtectedEndpointExtension.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/utils/auth/ProtectedEndpointExtension.java
@@ -18,17 +18,21 @@
 package com.axelixlabs.axelix.sbs.spring.core.utils.auth;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 
+import com.axelixlabs.axelix.sbs.spring.core.utils.InvalidAuthScenario;
+
 /**
  * A specific extension for Junit 6 to provide {@link TestTemplateInvocationContext} instances for the given
  * {@link ProtectedEndpointTests} methods.
  *
  * @author Mikhail Polivakha
+ * @author Vyacheslav Yanin
  */
 public class ProtectedEndpointExtension implements TestTemplateInvocationContextProvider {
 
@@ -45,20 +49,17 @@ public class ProtectedEndpointExtension implements TestTemplateInvocationContext
 
         ProtectedEndpointTests annotation = requiredTestMethod.getAnnotation(ProtectedEndpointTests.class);
 
-        Stream<BadAuthorityEndpointInvocationContext> first;
-
+        Stream<TestTemplateInvocationContext> badAuthorityScenarios;
         if (annotation.requiredAuthority().length > 0) {
-            first = Stream.of(
-                    new BadAuthorityEndpointInvocationContext(annotation.requiredAuthority()[0]));
+            badAuthorityScenarios = BadAuthorityEndpointInvocationContext.allBadAuthorityScenarios(
+                    annotation.requiredAuthority()[0]);
         } else {
-            first = Stream.of();
+            badAuthorityScenarios = Stream.of();
         }
 
-        return Stream.concat(
-                // authorization negative cases
-                first,
+        Stream<TestTemplateInvocationContext> badTokenScenarios =
+                Arrays.stream(InvalidAuthScenario.values()).map(BadTokenProtectedEndpointInvocationContext::new);
 
-                // authentication negative cases
-                Stream.of(new BadTokenProtectedEndpointInvocationContext()));
+        return Stream.concat(badAuthorityScenarios, badTokenScenarios);
     }
 }


### PR DESCRIPTION
Fixes architecture issue where multiple before-test callbacks were executed within a single JUnit 5 TestTemplateInvocationContext.

Part of #1051

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded negative authentication checks to cover all invalid token scenarios and all forbidden authority scenarios.
  * Test cases now show clearer names that include the specific scenario being exercised.

* **Bug Fixes**
  * Improved coverage for unauthorized and forbidden access responses, ensuring expected `401` and `403` outcomes are validated across all cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->