### PR TITLE
Implement Log4j2 support for Spring Boot 2 starter.

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/build.gradle.kts
+++ b/sbs/axelix-spring-boot-2-starter/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     compileOnly("org.springframework.cloud:spring-cloud-starter-openfeign")
     compileOnly("org.springframework.kafka:spring-kafka")
     compileOnly("com.github.ben-manes.caffeine:caffeine")
+    compileOnly("org.springframework.boot:spring-boot-starter-log4j2")
 
     // processor
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:${springBootVersion}")

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -17,6 +17,8 @@
  */
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
+import com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate.ConditionalOnLoggingSystem;
+import com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate.Log4j2InMemoryPaginationAppenderRegistrar;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -111,17 +113,35 @@ public class TransactionMonitoringAutoConfiguration {
 
     @Configuration
     @ConditionalOnHibernateActive
+    @ConditionalOnLoggingSystem(ConditionalOnLoggingSystem.System.LOGBACK)
     @ConditionalOnClass(name = "ch.qos.logback.classic.LoggerContext")
     @ConditionalOnProperty(
-            prefix = "axelix.sbs.transaction.monitoring.in-memory-pagination-detection",
-            name = "enabled",
-            havingValue = "true",
-            matchIfMissing = true)
+        prefix = "axelix.sbs.transaction.monitoring.in-memory-pagination-detection",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
     static class LogbackInMemoryPaginationAppenderConfiguration {
 
         @EventListener(ApplicationReadyEvent.class)
         public void registerAppender() {
             new LogbackInMemoryPaginationAppenderRegistrar().register();
+        }
+    }
+
+    @Configuration
+    @ConditionalOnHibernateActive
+    @ConditionalOnLoggingSystem(ConditionalOnLoggingSystem.System.LOG4J2)
+    @ConditionalOnClass(name = "org.apache.logging.log4j.core.LoggerContext")
+    @ConditionalOnProperty(
+        prefix = "axelix.sbs.transaction.monitoring.in-memory-pagination-detection",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+    static class Log4j2InMemoryPaginationAppenderConfiguration {
+
+        @EventListener(ApplicationReadyEvent.class)
+        public void registerAppender() {
+            new Log4j2InMemoryPaginationAppenderRegistrar().register();
         }
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -21,7 +21,6 @@ import com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate.ConditionalO
 import com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate.Log4j2InMemoryPaginationAppenderRegistrar;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -114,7 +113,6 @@ public class TransactionMonitoringAutoConfiguration {
     @Configuration
     @ConditionalOnHibernateActive
     @ConditionalOnLoggingSystem(ConditionalOnLoggingSystem.System.LOGBACK)
-    @ConditionalOnClass(name = "ch.qos.logback.classic.LoggerContext")
     @ConditionalOnProperty(
         prefix = "axelix.sbs.transaction.monitoring.in-memory-pagination-detection",
         name = "enabled",
@@ -131,7 +129,6 @@ public class TransactionMonitoringAutoConfiguration {
     @Configuration
     @ConditionalOnHibernateActive
     @ConditionalOnLoggingSystem(ConditionalOnLoggingSystem.System.LOG4J2)
-    @ConditionalOnClass(name = "org.apache.logging.log4j.core.LoggerContext")
     @ConditionalOnProperty(
         prefix = "axelix.sbs.transaction.monitoring.in-memory-pagination-detection",
         name = "enabled",

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/ConditionalOnLoggingSystem.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/ConditionalOnLoggingSystem.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate;
+
+import org.springframework.context.annotation.Conditional;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@link Conditional} annotation that restricts configuration components to a specific
+ * underlying logging subsystem active in the current application context.
+ *
+ * <p>Usage example:
+ * <pre>{@code
+ * @Configuration
+ * @ConditionalOnLoggingSystem(ConditionalOnLoggingSystem.System.LOG4J2)
+ * public class MyLog4j2Configuration { ... }
+ * }</pre>
+ *
+ * @author Vyacheslav Yanin
+ * @see OnLoggingSystemCondition
+ */
+@Documented
+@Conditional(OnLoggingSystemCondition.class)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ConditionalOnLoggingSystem {
+
+    System value();
+
+    enum System {
+        LOGBACK,
+        LOG4J2
+    }
+}

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/Log4j2InMemoryPaginationAppender.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/Log4j2InMemoryPaginationAppender.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+
+/**
+ * Log4j2 appender that detects Hibernate's in-memory pagination by intercepting
+ * the {@code HHH000104} warning emitted by Hibernate 5.x when {@code firstResult/maxResults}
+ * is specified with a collection fetch.
+ *
+ * @author Vyacheslav Yanin
+ * @see LogbackInMemoryPaginationAppender
+ */
+public class Log4j2InMemoryPaginationAppender extends AbstractAppender {
+
+    // Only for Hibernate 5.x (Spring Boot 2.x).
+    private static final String HHH000104 = "HHH000104";
+
+    protected Log4j2InMemoryPaginationAppender(String name) {
+        super(name, null, null, true, Property.EMPTY_ARRAY);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        if (event.getLevel() != Level.WARN) {
+            return;
+        }
+        String message = event.getMessage().getFormattedMessage();
+        if (message != null && (message.contains(HHH000104))) {
+            InMemoryPaginationHolder.mark();
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/Log4j2InMemoryPaginationAppenderRegistrar.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/Log4j2InMemoryPaginationAppenderRegistrar.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.slf4j.Log4jLoggerFactory;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Log4j2 implementation of {@link InMemoryPaginationAppenderRegistrar}.
+ *
+ * @author Vyacheslav Yanin
+ */
+public class Log4j2InMemoryPaginationAppenderRegistrar implements InMemoryPaginationAppenderRegistrar {
+
+    private static final String APPENDER_NAME = "axelix-in-memory-pagination";
+    // Hibernate 6+ (Spring Boot 3)
+    private static final String HIBERNATE_LOGGER = "org.hibernate.orm.query";
+
+    @Override
+    public void register() {
+        ILoggerFactory factory = LoggerFactory.getILoggerFactory();
+        if (!(factory instanceof Log4jLoggerFactory)) {
+            return;
+        }
+
+        if (!(LogManager.getContext(false) instanceof LoggerContext)) {
+            return;
+        }
+
+        LoggerContext context = (LoggerContext) LogManager.getContext(false);
+
+        Configuration configuration = context.getConfiguration();
+        Logger logger = context.getLogger(HIBERNATE_LOGGER);
+        if (logger.getAppenders().get(APPENDER_NAME) != null) {
+            return;
+        }
+
+        Log4j2InMemoryPaginationAppender appender = new Log4j2InMemoryPaginationAppender(APPENDER_NAME);
+        appender.start();
+        configuration.addAppender(appender);
+        logger.addAppender(appender);
+
+        context.updateLoggers();
+    }
+}

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/OnLoggingSystemCondition.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/OnLoggingSystemCondition.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+import java.util.Map;
+
+/**
+ * {@link Condition} implementation that checks if the active SLF4J {@link ILoggerFactory}
+ * matches the required logging system specified by {@link ConditionalOnLoggingSystem}.
+ *
+ * <p>This condition performs dynamic, type-safe runtime validation and safely prevents {@link NoClassDefFoundError}
+ * when a specific logging implementation is missing from the classpath.
+ *
+ * @author Vyacheslav Yanin
+ */
+public class OnLoggingSystemCondition implements Condition {
+
+    private static final String LOGBACK_FACTORY_FULL_CLASS_NAME = "ch.qos.logback.classic.LoggerContext";
+    private static final String LOG_4_J_FACTORY_FULL_CLASS_NAME = "org.apache.logging.slf4j.Log4jLoggerFactory";
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        Map<String, Object> attributes = metadata.getAnnotationAttributes(ConditionalOnLoggingSystem.class.getName());
+        if (attributes == null) {
+            return false;
+        }
+
+        ConditionalOnLoggingSystem.System requiredSystem = (ConditionalOnLoggingSystem.System) attributes.get("value");
+        if (requiredSystem == null) {
+            return false;
+        }
+
+        ILoggerFactory activeFactory = LoggerFactory.getILoggerFactory();
+        try {
+            switch (requiredSystem) {
+                case LOGBACK:
+                    return Class.forName(LOGBACK_FACTORY_FULL_CLASS_NAME).isInstance(activeFactory);
+                case LOG4J2:
+                    return Class.forName(LOG_4_J_FACTORY_FULL_CLASS_NAME).isInstance(activeFactory);
+                default:
+                    return false;
+            }
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/OnLoggingSystemCondition.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/transactions/hibernate/OnLoggingSystemCondition.java
@@ -18,7 +18,7 @@
 package com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate;
 
 import org.slf4j.ILoggerFactory;
-import org.slf4j.LoggerFactory;
+import org.springframework.boot.logging.LoggingSystem;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
@@ -36,8 +36,10 @@ import java.util.Map;
  */
 public class OnLoggingSystemCondition implements Condition {
 
-    private static final String LOGBACK_FACTORY_FULL_CLASS_NAME = "ch.qos.logback.classic.LoggerContext";
-    private static final String LOG_4_J_FACTORY_FULL_CLASS_NAME = "org.apache.logging.slf4j.Log4jLoggerFactory";
+    private static final String LOGBACK_LOGGING_SYSTEM_CLASS_NAME =
+        "org.springframework.boot.logging.logback.LogbackLoggingSystem";
+    private static final String LOG4J2_LOGGING_SYSTEM_FULL_CLASS_NAME =
+        "org.springframework.boot.logging.log4j2.Log4J2LoggingSystem";
 
     @Override
     public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
@@ -51,17 +53,23 @@ public class OnLoggingSystemCondition implements Condition {
             return false;
         }
 
-        ILoggerFactory activeFactory = LoggerFactory.getILoggerFactory();
+        LoggingSystem loggingSystem = LoggingSystem.get(getClass().getClassLoader());
+        switch (requiredSystem) {
+            case LOGBACK:
+                return isInstance(LOGBACK_LOGGING_SYSTEM_CLASS_NAME, loggingSystem);
+            case LOG4J2:
+                return isInstance(LOG4J2_LOGGING_SYSTEM_FULL_CLASS_NAME, loggingSystem);
+            default:
+                return false;
+        }
+    }
+
+    private static boolean isInstance(String loggingSystemClassName, LoggingSystem loggingSystem) {
         try {
-            switch (requiredSystem) {
-                case LOGBACK:
-                    return Class.forName(LOGBACK_FACTORY_FULL_CLASS_NAME).isInstance(activeFactory);
-                case LOG4J2:
-                    return Class.forName(LOG_4_J_FACTORY_FULL_CLASS_NAME).isInstance(activeFactory);
-                default:
-                    return false;
-            }
-        } catch (ClassNotFoundException e) {
+            return Class.forName(loggingSystemClassName).isInstance(loggingSystem);
+        } catch (ClassNotFoundException | LinkageError e) {
+            // if we were not able to load the LoggingSystem class, then LoggingSystem used by Spring Boot is definitely
+            // not the one that we're checking.
             return false;
         }
     }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -21,11 +21,13 @@ import java.util.List;
 
 import javax.persistence.EntityManagerFactory;
 
-import com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate.InMemoryPaginationAppenderRegistrar;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.logging.LoggingSystem;
+import org.springframework.boot.logging.log4j2.Log4J2LoggingSystem;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -41,6 +43,8 @@ import com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionMonitoringS
 import com.axelixlabs.axelix.sbs.spring.core.transactions.TransactionStatsCollector;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration.Log4j2InMemoryPaginationAppenderConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration;
 
 /**
  * Integration tests for {@link TransactionMonitoringAutoConfiguration}
@@ -67,10 +71,7 @@ class TransactionMonitoringAutoConfigurationTest {
             assertThat(context).hasSingleBean(TransactionMonitoringEndpoint.class);
             assertThat(context).hasSingleBean(TransactionMonitoringBeanPostProcessor.class);
             assertThat(context).hasSingleBean(ProxyingDataSourceBeanPostProcessor.class);
-            assertThat(context)
-                    .doesNotHaveBean(
-                            TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
-                                    .class);
+            assertThat(context).doesNotHaveBean(LogbackInMemoryPaginationAppenderConfiguration.class);
         });
     }
 
@@ -82,64 +83,31 @@ class TransactionMonitoringAutoConfigurationTest {
                 .withBean(EntityManagerFactory.class, () -> mockFactory)
                 .run(context -> assertThat(context)
                         .hasSingleBean(
-                                TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
+                                LogbackInMemoryPaginationAppenderConfiguration
                                         .class));
     }
 
     @Test // GH-1251
-    void shouldActivateCorrectConfiguration_whenConditionsAreMet() {
-        EntityManagerFactory mockFactory = Mockito.mock(EntityManagerFactory.class);
-
-        contextRunner.withBean(EntityManagerFactory.class, () -> mockFactory).run(context -> {
-            boolean hasLogbackConfig = context.containsBean(
-                TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration.class
-                    .getName());
-            boolean hasLog4j2Config = context.containsBean(
-                TransactionMonitoringAutoConfiguration.Log4j2InMemoryPaginationAppenderConfiguration.class
-                    .getName());
-
-            assertThat(hasLogbackConfig ^ hasLog4j2Config).isTrue();
-
-            if (hasLogbackConfig) {
-                assertThat(context)
-                    .hasSingleBean(
-                        TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
-                            .class);
-                assertThat(context)
-                    .doesNotHaveBean(
-                        TransactionMonitoringAutoConfiguration.Log4j2InMemoryPaginationAppenderConfiguration
-                            .class);
-            } else {
-                assertThat(context)
-                    .hasSingleBean(
-                        TransactionMonitoringAutoConfiguration.Log4j2InMemoryPaginationAppenderConfiguration
-                            .class);
-                assertThat(context)
-                    .doesNotHaveBean(
-                        TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
-                            .class);
-            }
-        });
-    }
-
-    @Test // GH-1251
-    void shouldNotCreateLog4j2Appender_whenLogbackTakesPrecedence() {
-        EntityManagerFactory mockFactory = Mockito.mock(EntityManagerFactory.class);
-
-        contextRunner.withBean(EntityManagerFactory.class, () -> mockFactory).run(context -> {
-            assertThat(context)
-                .hasSingleBean(
-                    TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
-                        .class);
-            assertThat(context)
-                .doesNotHaveBean(
-                    TransactionMonitoringAutoConfiguration.Log4j2InMemoryPaginationAppenderConfiguration.class);
-        });
+    @Disabled(
+        "TODO: We need to figure out how to run tests with log4j2, maybe we can create a new gradle test task or smth")
+    void shouldActivateLog4j2Configuration_whenLog4j2IsTheDetectedLoggingSystemBySpringBoot() {
+        contextRunner
+            .withBean(EntityManagerFactory.class, () -> Mockito.mock(EntityManagerFactory.class))
+            .withBean(
+                LoggingSystem.class,
+                () -> new Log4J2LoggingSystem(getClass().getClassLoader()))
+            .run(context -> {
+                assertThat(context).doesNotHaveBean(LogbackInMemoryPaginationAppenderConfiguration.class);
+                assertThat(context).hasSingleBean(Log4j2InMemoryPaginationAppenderConfiguration.class);
+            });
     }
 
     @Test // GH-1251
     void shouldNotCreateAnyAppender_whenEntityManagerFactoryIsMissing() {
-        contextRunner.run(context -> assertThat(context).doesNotHaveBean(InMemoryPaginationAppenderRegistrar.class));
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean(LogbackInMemoryPaginationAppenderConfiguration.class);
+            assertThat(context).doesNotHaveBean(Log4j2InMemoryPaginationAppenderConfiguration.class);
+        });
     }
 
     @Test // GH-1250

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import javax.persistence.EntityManagerFactory;
 
+import com.axelixlabs.axelix.sbs.spring.core.transactions.hibernate.InMemoryPaginationAppenderRegistrar;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -83,6 +84,62 @@ class TransactionMonitoringAutoConfigurationTest {
                         .hasSingleBean(
                                 TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
                                         .class));
+    }
+
+    @Test // GH-1251
+    void shouldActivateCorrectConfiguration_whenConditionsAreMet() {
+        EntityManagerFactory mockFactory = Mockito.mock(EntityManagerFactory.class);
+
+        contextRunner.withBean(EntityManagerFactory.class, () -> mockFactory).run(context -> {
+            boolean hasLogbackConfig = context.containsBean(
+                TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration.class
+                    .getName());
+            boolean hasLog4j2Config = context.containsBean(
+                TransactionMonitoringAutoConfiguration.Log4j2InMemoryPaginationAppenderConfiguration.class
+                    .getName());
+
+            assertThat(hasLogbackConfig ^ hasLog4j2Config).isTrue();
+
+            if (hasLogbackConfig) {
+                assertThat(context)
+                    .hasSingleBean(
+                        TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
+                            .class);
+                assertThat(context)
+                    .doesNotHaveBean(
+                        TransactionMonitoringAutoConfiguration.Log4j2InMemoryPaginationAppenderConfiguration
+                            .class);
+            } else {
+                assertThat(context)
+                    .hasSingleBean(
+                        TransactionMonitoringAutoConfiguration.Log4j2InMemoryPaginationAppenderConfiguration
+                            .class);
+                assertThat(context)
+                    .doesNotHaveBean(
+                        TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
+                            .class);
+            }
+        });
+    }
+
+    @Test // GH-1251
+    void shouldNotCreateLog4j2Appender_whenLogbackTakesPrecedence() {
+        EntityManagerFactory mockFactory = Mockito.mock(EntityManagerFactory.class);
+
+        contextRunner.withBean(EntityManagerFactory.class, () -> mockFactory).run(context -> {
+            assertThat(context)
+                .hasSingleBean(
+                    TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration
+                        .class);
+            assertThat(context)
+                .doesNotHaveBean(
+                    TransactionMonitoringAutoConfiguration.Log4j2InMemoryPaginationAppenderConfiguration.class);
+        });
+    }
+
+    @Test // GH-1251
+    void shouldNotCreateAnyAppender_whenEntityManagerFactoryIsMissing() {
+        contextRunner.run(context -> assertThat(context).doesNotHaveBean(InMemoryPaginationAppenderRegistrar.class));
     }
 
     @Test // GH-1250


### PR DESCRIPTION
Introduce a Log4j2-specific equivalent of the in-memory pagination logging appender by extending AbstractAppender. Register Log4j2InMemoryPaginationAppenderRegistrar conditionally via bean presence validation to achieve mutual exclusivity with the existing Logback configuration. Added integration tests using ApplicationContextRunner to verify runtime precedence of the Logback backend over Log4j2.

Close #1251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Log4j2 support for transaction monitoring, including automatic in-memory pagination detection and registration when enabled.
* **Bug Fixes**
  * Improved logging-system–specific activation so only the matching in-memory pagination setup is created (and it won’t initialize when required components are missing).
* **Chores**
  * Updated build configuration to include Log4j2 logging support for compilation.
* **Tests**
  * Expanded coverage to verify correct Logback vs Log4j2 in-memory pagination configuration behavior under different startup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->