### PR TITLE
GH-1316 Integrate core build & deploy logic for Feature Service (SB3) playground

### DIFF
--- a/.github/workflows/backend_pull_requests.yaml
+++ b/.github/workflows/backend_pull_requests.yaml
@@ -11,7 +11,7 @@ on:
       - 'common/**'
 
       # Playground projects
-      - 'playgrounds/petclinic-maven-sb-2/**'
+      - 'playgrounds/**'
 
       # Core Gradle build configuration
       - 'buildSrc/**'
@@ -56,10 +56,6 @@ jobs:
       NEXUS_USER: ${{ secrets.NEXUS_USER }}
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
       NEXUS_URL: ${{ secrets.NEXUS_URL }}
-
-      # Required variables for playground builds
-      AXELIX_SBS_AUTH_JWT_ALGORITHM: HMAC512
-      AXELIX_SBS_AUTH_JWT_SIGNING_KEY: ${{ secrets.JWT_SIGNING_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -85,6 +81,10 @@ jobs:
               - 'sbs/axelix-spring-boot-2-starter/**'
               - 'playgrounds/petclinic-maven-sb-2/**'
             
+            sb3_specific:
+              - 'sbs/axelix-spring-boot-3-starter/**'
+              - 'playgrounds/feature-service-maven-sb-3/**'
+            
             global_trigger:
               - 'common/**'
               - 'sbs/starter-domain/**'
@@ -97,12 +97,20 @@ jobs:
               - 'Makefile'
           
       - name: Run Conditional Playground Build via Make
+        env:
+          # Required variables for playground builds
+          AXELIX_SBS_AUTH_JWT_ALGORITHM: HMAC512
+          AXELIX_SBS_AUTH_JWT_SIGNING_KEY: ${{ env.SANDBOX_JWT_SIGNING_KEY }}
         run: |
           SHOULD_BUILD_SB2="false"
           if [ "${{ steps.filter.outputs.sb2_specific }}" = "true" ] || [ "${{ steps.filter.outputs.global_trigger }}" = "true" ]; then
             SHOULD_BUILD_SB2="true"
           fi
+          
+          SHOULD_BUILD_SB3="false"
+          if [ "${{ steps.filter.outputs.sb3_specific }}" = "true" ] || [ "${{ steps.filter.outputs.global_trigger }}" = "true" ]; then
+            SHOULD_BUILD_SB3="true"
+          fi
 
           make build-playground BUILD_SB2="$SHOULD_BUILD_SB2"
-
-      
+          make build-playground BUILD_SB3="$SHOULD_BUILD_SB3"

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -24,7 +24,7 @@ on:
       - 'sbs/**'
 
       # Playground projects
-      - 'playgrounds/petclinic-maven-sb-2/**'
+      - 'playgrounds/**'
 
       # Core Gradle build configuration
       - 'buildSrc/**'
@@ -164,6 +164,14 @@ jobs:
           image-tag: petclinic-maven-sb-2:2.7.18-SNAPSHOT
           helm-release: petclinic-maven-sb-2
 
+      - name: Deploy Playground Feature Service Maven SB 3
+        uses: ./.github/actions/deploy-playground
+        with:
+          working-directory: playgrounds/feature-service-maven-sb-3
+          cr-repository-path: ${{ vars.CR_PLAYGROUND_REPOSITORY }}/feature-service-sb-3
+          image-tag: feature-service-maven-sb-3:0.0.2-SNAPSHOT
+          helm-release: feature-service-maven-sb-3
+
   dispatch:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch' }}
     needs: [build-deploy-source]
@@ -171,7 +179,6 @@ jobs:
       matrix:
         playground_repo: [
           'axelixlabs/notification-service',
-          'axelixlabs/feature-service',
           'axelixlabs/spring-petclinic',
         ]
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
-.PHONY: clean clean-all clean-playgrounds spotless publish-local \
-        build build-with-playgrounds build-playground \
-        publish-starter-sb2 build-petclinic-maven-sb2 spotless-all
+.PHONY: clean clean-all clean-playgrounds spotless publish-local build build-with-playgrounds \
+        build-playground publish-starter-sb2 build-petclinic-maven-sb2 spotless-all publish-starter-sb3 \
+        build-feature-service-maven-sb3
 
 BUILD_ALL_PLAYGROUNDS ?= false
 BUILD_SB2             ?= false
+BUILD_SB3             ?= false
 
 clean:
 	./gradlew clean
 
 clean-playgrounds:
 	cd playgrounds/petclinic-maven-sb-2 && ./mvnw clean
+	cd playgrounds/feature-service-maven-sb-3 && ./mvnw clean
 
 clean-all: clean clean-playgrounds
 
@@ -21,6 +23,8 @@ spotless-all:
 	./gradlew spotlessApply
 	@echo "=== Formatting Petclinic Maven SB-2 Project ==="
 	cd playgrounds/petclinic-maven-sb-2 && ./mvnw spring-javaformat:apply
+	@echo "=== Formatting Feature Service Maven SB-3 Project ==="
+	cd playgrounds/feature-service-maven-sb-3 && ./mvnw spotless:apply
 
 publish-local:
 	./gradlew publishToMavenLocal
@@ -34,22 +38,37 @@ build-all: build
 
 # BUILD PLAYGROUND PROJECTS
 build-playground:
-	@echo "=== Starting Conditional Monorepo Build ==="
 
 ifeq ($(BUILD_ALL_PLAYGROUNDS),true)
-	@echo "=== Build all playgrounds ==="
+	@echo "=== Build all Playgrounds ==="
 	$(MAKE) publish-starter-sb2
 	$(MAKE) build-petclinic-maven-sb2
+	$(MAKE) publish-starter-sb3
+	$(MAKE) build-feature-service-maven-sb3
 else ifeq ($(BUILD_SB2),true)
-	@echo "=== Build Petclinic Maven Spring boot 2 ==="
+	@echo "=== Publish Axelix Spring boot 2 Starter ==="
 	$(MAKE) publish-starter-sb2
+	@echo "=== Build Petclinic Maven Spring boot 2 ==="
 	$(MAKE) build-petclinic-maven-sb2
+else ifeq ($(BUILD_SB3),true)
+	@echo "=== Publish Axelix Spring boot 3 Starter ==="
+	$(MAKE) publish-starter-sb3
+	@echo "=== Build Feature Service Maven Spring boot 3 ==="
+	$(MAKE) build-feature-service-maven-sb3
 endif
 
 publish-starter-sb2:
 	@echo "=== Compiling and publishing Spring Boot 2 Axelix Starter ==="
 	./gradlew :sbs:axelix-spring-boot-2-starter:publishToMavenLocal
 
+publish-starter-sb3:
+	@echo "=== Compiling and publishing Spring Boot 3 Axelix Starter ==="
+	./gradlew :sbs:axelix-spring-boot-3-starter:publishToMavenLocal
+
 build-petclinic-maven-sb2:
-	@echo "=== Running Maven build for Petclinic SB 2 ==="
+	@echo "=== Running Maven build for Petclinic Spring boot 2 ==="
 	cd playgrounds/petclinic-maven-sb-2 && ./mvnw clean package -B
+
+build-feature-service-maven-sb3:
+	@echo "=== Running Maven build for Feature Service Spring boot 3 ==="
+	cd playgrounds/feature-service-maven-sb-3 && ./mvnw clean package -B

--- a/playgrounds/feature-service-maven-sb-3/src/main/resources/application-local.properties
+++ b/playgrounds/feature-service-maven-sb-3/src/main/resources/application-local.properties
@@ -4,5 +4,5 @@ axelix.sbs.auth.jwt.algorithm=HMAC512
 axelix.sbs.auth.jwt.signing-key=22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
 axelix.sbs.discovery.instance-actuator-url=http://localhost:8091/actuator
 axelix.sbs.discovery.master-url=http://localhost:8080/api/internal/service/register
-axelix.sbs.discovery.instance-name=petclinic-sb-2
+axelix.sbs.discovery.instance-name=feature-service-maven-sb-3
 axelix.sbs.discovery.auto=true

--- a/playgrounds/petclinic-maven-sb-2/src/main/resources/application-local.properties
+++ b/playgrounds/petclinic-maven-sb-2/src/main/resources/application-local.properties
@@ -4,5 +4,5 @@ axelix.sbs.auth.jwt.algorithm=HMAC512
 axelix.sbs.auth.jwt.signing-key=22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
 axelix.sbs.discovery.instance-actuator-url=http://localhost:8091/actuator
 axelix.sbs.discovery.master-url=http://localhost:8080/api/internal/service/register
-axelix.sbs.discovery.instance-name=petclinic-sb-2
+axelix.sbs.discovery.instance-name=petclinic-maven-sb-2
 axelix.sbs.discovery.auto=true


### PR DESCRIPTION
close #1316 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded build and deployment workflows to cover all playgrounds and added dedicated support for the Spring Boot 3 feature service playground.
  * Extended the build system with SB3-specific starter publishing and feature-service Maven build targets.
* **Bug Fixes**
  * Broadened automated triggers so playground changes are picked up correctly.
  * Updated local service discovery instance names for the SB2 and SB3 playgrounds.
* **Chores**
  * Included SB3 playground formatting in the automated formatting task.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->