### PR TITLE
GH-1318 Disallow overriding beans in `AxelixBeansEndpointAutoConfiguration` and `AxelixConditionsEndpointAutoConfiguration`

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 
@@ -45,13 +44,11 @@ import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRe
 public class AxelixBeansEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
         return new DefaultConditionalBeanRefBuilder();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public BeanMetaInfoExtractor beanMetaInfoExtractor(
             ConfigurableApplicationContext configurableApplicationContext,
             ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
@@ -65,13 +62,11 @@ public class AxelixBeansEndpointAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixBeansEndpoint beansEndpointExtension(BeansFeedBuilder cachingBeansFeedBuilder) {
         return new AxelixBeansEndpoint(cachingBeansFeedBuilder);
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
         return new QualifiersPersistencePostProcessor();
     }

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 
@@ -42,13 +41,11 @@ import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalTarget
 public class AxelixConditionsEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public ConditionalTargetUnwrapper conditionalTargetUnwrapper() {
         return new DefaultConditionalTargetUnwrapper();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public ConditionalFeedBuilder conditionalFeedBuilder(
             ConfigurableApplicationContext configurableApplicationContext,
             ConditionalTargetUnwrapper conditionalTargetUnwrapper) {
@@ -56,7 +53,6 @@ public class AxelixConditionsEndpointAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixConditionsEndpoint axelixConditionsEndpoint(ConditionalFeedBuilder conditionalFeedBuilder) {
         return new AxelixConditionsEndpoint(conditionalFeedBuilder);
     }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfigurationTest.java
@@ -17,18 +17,12 @@
  */
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfo;
 import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
 import com.axelixlabs.axelix.sbs.spring.core.beans.BeansFeedBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeansFeedBuilder;
@@ -89,66 +83,5 @@ class AxelixBeansEndpointAutoConfigurationTest {
             assertThat(context).doesNotHaveBean(BeansFeedBuilder.class);
             assertThat(context).doesNotHaveBean(QualifiersPersistencePostProcessor.class);
         });
-    }
-
-    @Test
-    void shouldFailWhenCustomBeansProvided() {
-        // given.
-        contextRunner
-                .withUserConfiguration(
-                        CustomConditionalBeanRefBuilderConfig.class,
-                        CustomBeanMetaInfoExtractorConfig.class,
-                        CustomAxelixBeansEndpointConfig.class)
-
-                // when.
-                .run(context -> {
-                    // then.
-                    assertThat(context).hasFailed();
-                    assertThat(context.getStartupFailure()).isInstanceOf(BeanDefinitionOverrideException.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomConditionalBeanRefBuilderConfig {
-        @Bean
-        public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
-            return new CustomConditionalBeanRefBuilder();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomBeanMetaInfoExtractorConfig {
-        @Bean
-        public BeanMetaInfoExtractor beanMetaInfoExtractor() {
-            return new CustomBeanMetaInfoExtractor();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomAxelixBeansEndpointConfig {
-        @Bean
-        public AxelixBeansEndpoint axelixBeansEndpoint() {
-            return new CustomAxelixBeansEndpoint();
-        }
-    }
-
-    static class CustomConditionalBeanRefBuilder implements ConditionalBeanRefBuilder {
-        @Override
-        public String buildBeanRefInternal(Class<?> beanClass, @Nullable String beanFactoryMethodName) {
-            return "";
-        }
-    }
-
-    static class CustomBeanMetaInfoExtractor implements BeanMetaInfoExtractor {
-        @Override
-        public BeanMetaInfo extract(String beanName, ConfigurableListableBeanFactory beanFactory) {
-            return null;
-        }
-    }
-
-    static class CustomAxelixBeansEndpoint extends AxelixBeansEndpoint {
-        public CustomAxelixBeansEndpoint() {
-            super(null);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfigurationTest.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -91,19 +92,19 @@ class AxelixBeansEndpointAutoConfigurationTest {
     }
 
     @Test
-    void shouldHandleMultipleCustomBeans() {
+    void shouldFailWhenCustomBeansProvided() {
+        // given.
         contextRunner
                 .withUserConfiguration(
                         CustomConditionalBeanRefBuilderConfig.class,
                         CustomBeanMetaInfoExtractorConfig.class,
                         CustomAxelixBeansEndpointConfig.class)
+
+                // when.
                 .run(context -> {
-                    assertThat(context.getBean(ConditionalBeanRefBuilder.class))
-                            .isExactlyInstanceOf(CustomConditionalBeanRefBuilder.class);
-                    assertThat(context.getBean(BeanMetaInfoExtractor.class))
-                            .isExactlyInstanceOf(CustomBeanMetaInfoExtractor.class);
-                    assertThat(context.getBean(AxelixBeansEndpoint.class))
-                            .isExactlyInstanceOf(CustomAxelixBeansEndpoint.class);
+                    // then.
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).isInstanceOf(BeanDefinitionOverrideException.class);
                 });
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfigurationTest.java
@@ -19,14 +19,10 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.conditions.AxelixConditionsEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalFeedBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,33 +67,5 @@ class AxelixConditionsEndpointAutoConfigurationTest {
             assertThat(context).doesNotHaveBean(AxelixConditionsEndpointAutoConfiguration.class);
             assertThat(context).doesNotHaveBean(AxelixConditionsEndpoint.class);
         });
-    }
-
-    @Test
-    void shouldFailWhenCustomBeanProvided() {
-        // given.
-        contextRunner
-                .withUserConfiguration(CustomAxelixConditionsEndpointConfig.class)
-
-                // when.
-                .run(context -> {
-                    // then.
-                    assertThat(context).hasFailed();
-                    assertThat(context.getStartupFailure()).isInstanceOf(BeanDefinitionOverrideException.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomAxelixConditionsEndpointConfig {
-        @Bean
-        public AxelixConditionsEndpoint axelixConditionsEndpoint(ConditionalFeedBuilder conditionalFeedBuilder) {
-            return new CustomAxelixConditionsEndpoint(conditionalFeedBuilder);
-        }
-    }
-
-    static class CustomAxelixConditionsEndpoint extends AxelixConditionsEndpoint {
-        public CustomAxelixConditionsEndpoint(ConditionalFeedBuilder conditionalFeedBuilder) {
-            super(conditionalFeedBuilder);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfigurationTest.java
@@ -19,6 +19,7 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -73,13 +74,16 @@ class AxelixConditionsEndpointAutoConfigurationTest {
     }
 
     @Test
-    void shouldNotCreateDefaultEndpointWhenCustomBeanProvided() {
+    void shouldFailWhenCustomBeanProvided() {
+        // given.
         contextRunner
                 .withUserConfiguration(CustomAxelixConditionsEndpointConfig.class)
+
+                // when.
                 .run(context -> {
-                    assertThat(context).hasSingleBean(AxelixConditionsEndpoint.class);
-                    assertThat(context.getBean(AxelixConditionsEndpoint.class))
-                            .isExactlyInstanceOf(CustomAxelixConditionsEndpoint.class);
+                    // then.
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).isInstanceOf(BeanDefinitionOverrideException.class);
                 });
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 
@@ -45,13 +44,11 @@ import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRe
 public class AxelixBeansEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
         return new DefaultConditionalBeanRefBuilder();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public BeanMetaInfoExtractor beanMetaInfoExtractor(
             ConfigurableApplicationContext configurableApplicationContext,
             ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
@@ -65,13 +62,11 @@ public class AxelixBeansEndpointAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixBeansEndpoint axelixBeansEndpoint(BeansFeedBuilder cachingBeansFeedBuilder) {
         return new AxelixBeansEndpoint(cachingBeansFeedBuilder);
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
         return new QualifiersPersistencePostProcessor();
     }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 
@@ -42,13 +41,11 @@ import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalTarget
 public class AxelixConditionsEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public ConditionalTargetUnwrapper conditionalTargetUnwrapper() {
         return new DefaultConditionalTargetUnwrapper();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public ConditionalFeedBuilder conditionalFeedBuilder(
             ConfigurableApplicationContext configurableApplicationContext,
             ConditionalTargetUnwrapper conditionalTargetUnwrapper) {
@@ -56,7 +53,6 @@ public class AxelixConditionsEndpointAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixConditionsEndpoint axelixConditionsEndpoint(ConditionalFeedBuilder conditionalFeedBuilder) {
         return new AxelixConditionsEndpoint(conditionalFeedBuilder);
     }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfigurationTest.java
@@ -17,18 +17,12 @@
  */
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfo;
 import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
 import com.axelixlabs.axelix.sbs.spring.core.beans.BeansFeedBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeansFeedBuilder;
@@ -89,66 +83,5 @@ class AxelixBeansEndpointAutoConfigurationTest {
             assertThat(context).doesNotHaveBean(BeansFeedBuilder.class);
             assertThat(context).doesNotHaveBean(QualifiersPersistencePostProcessor.class);
         });
-    }
-
-    @Test
-    void shouldFailWhenCustomBeansProvided() {
-        // given.
-        contextRunner
-                .withUserConfiguration(
-                        CustomConditionalBeanRefBuilderConfig.class,
-                        CustomBeanMetaInfoExtractorConfig.class,
-                        CustomAxelixBeansEndpointConfig.class)
-
-                // when.
-                .run(context -> {
-                    // then.
-                    assertThat(context).hasFailed();
-                    assertThat(context.getStartupFailure()).isInstanceOf(BeanDefinitionOverrideException.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomConditionalBeanRefBuilderConfig {
-        @Bean
-        public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
-            return new CustomConditionalBeanRefBuilder();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomBeanMetaInfoExtractorConfig {
-        @Bean
-        public BeanMetaInfoExtractor beanMetaInfoExtractor() {
-            return new CustomBeanMetaInfoExtractor();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomAxelixBeansEndpointConfig {
-        @Bean
-        public AxelixBeansEndpoint axelixBeansEndpoint() {
-            return new CustomAxelixBeansEndpoint();
-        }
-    }
-
-    static class CustomConditionalBeanRefBuilder implements ConditionalBeanRefBuilder {
-        @Override
-        public String buildBeanRefInternal(Class<?> beanClass, @Nullable String beanFactoryMethodName) {
-            return "";
-        }
-    }
-
-    static class CustomBeanMetaInfoExtractor implements BeanMetaInfoExtractor {
-        @Override
-        public BeanMetaInfo extract(String beanName, ConfigurableListableBeanFactory beanFactory) {
-            return null;
-        }
-    }
-
-    static class CustomAxelixBeansEndpoint extends AxelixBeansEndpoint {
-        public CustomAxelixBeansEndpoint() {
-            super(null);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixBeansEndpointAutoConfigurationTest.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -91,19 +92,19 @@ class AxelixBeansEndpointAutoConfigurationTest {
     }
 
     @Test
-    void shouldHandleMultipleCustomBeans() {
+    void shouldFailWhenCustomBeansProvided() {
+        // given.
         contextRunner
                 .withUserConfiguration(
                         CustomConditionalBeanRefBuilderConfig.class,
                         CustomBeanMetaInfoExtractorConfig.class,
                         CustomAxelixBeansEndpointConfig.class)
+
+                // when.
                 .run(context -> {
-                    assertThat(context.getBean(ConditionalBeanRefBuilder.class))
-                            .isExactlyInstanceOf(CustomConditionalBeanRefBuilder.class);
-                    assertThat(context.getBean(BeanMetaInfoExtractor.class))
-                            .isExactlyInstanceOf(CustomBeanMetaInfoExtractor.class);
-                    assertThat(context.getBean(AxelixBeansEndpoint.class))
-                            .isExactlyInstanceOf(CustomAxelixBeansEndpoint.class);
+                    // then.
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).isInstanceOf(BeanDefinitionOverrideException.class);
                 });
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfigurationTest.java
@@ -19,14 +19,10 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.conditions.AxelixConditionsEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalFeedBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,33 +67,5 @@ class AxelixConditionsEndpointAutoConfigurationTest {
             assertThat(context).doesNotHaveBean(AxelixConditionsEndpointAutoConfiguration.class);
             assertThat(context).doesNotHaveBean(AxelixConditionsEndpoint.class);
         });
-    }
-
-    @Test
-    void shouldFailWhenCustomBeanProvided() {
-        // given.
-        contextRunner
-                .withUserConfiguration(CustomAxelixConditionsEndpointConfig.class)
-
-                // when.
-                .run(context -> {
-                    // then.
-                    assertThat(context).hasFailed();
-                    assertThat(context.getStartupFailure()).isInstanceOf(BeanDefinitionOverrideException.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomAxelixConditionsEndpointConfig {
-        @Bean
-        public AxelixConditionsEndpoint axelixConditionsEndpoint(ConditionalFeedBuilder conditionalFeedBuilder) {
-            return new CustomAxelixConditionsEndpoint(conditionalFeedBuilder);
-        }
-    }
-
-    static class CustomAxelixConditionsEndpoint extends AxelixConditionsEndpoint {
-        public CustomAxelixConditionsEndpoint(ConditionalFeedBuilder conditionalFeedBuilder) {
-            super(conditionalFeedBuilder);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConditionsEndpointAutoConfigurationTest.java
@@ -19,6 +19,7 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -73,13 +74,16 @@ class AxelixConditionsEndpointAutoConfigurationTest {
     }
 
     @Test
-    void shouldNotCreateDefaultEndpointWhenCustomBeanProvided() {
+    void shouldFailWhenCustomBeanProvided() {
+        // given.
         contextRunner
                 .withUserConfiguration(CustomAxelixConditionsEndpointConfig.class)
+
+                // when.
                 .run(context -> {
-                    assertThat(context).hasSingleBean(AxelixConditionsEndpoint.class);
-                    assertThat(context.getBean(AxelixConditionsEndpoint.class))
-                            .isExactlyInstanceOf(CustomAxelixConditionsEndpoint.class);
+                    // then.
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).isInstanceOf(BeanDefinitionOverrideException.class);
                 });
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-configured beans for the enabled endpoints now register consistently across Spring Boot 2 and Spring Boot 3.
  * If an application supplies conflicting beans for these endpoint components, startup now fails fast with a bean-definition override error instead of silently changing wiring.
* **Tests**
  * Updated autoconfiguration tests to expect startup failure (including bean-definition override assertions) when custom overriding beans are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->