### PR TITLE
GH-1321 Disallow overriding beans in `AxelixHeapDumpEndpointAutoConfiguration` and `AxelixMetricsAutoConfiguration`

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
@@ -34,7 +33,6 @@ import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
 public class AxelixHeapDumpEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixHeapDumpEndpoint axelixHeapDumpEndpoint() {
         return new AxelixHeapDumpEndpoint();
     }

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixMetricsAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixMetricsAutoConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegi
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.common.api.transform.BaseUnitParser;
@@ -50,7 +49,6 @@ import com.axelixlabs.axelix.sbs.spring.core.metrics.ServiceMetricsGroupsAssembl
 public class AxelixMetricsAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixMetricsEndpoint axelixMetricsEndpoint(
             MeterRegistry registry,
             BaseUnitParser baseUnitParser,
@@ -61,25 +59,21 @@ public class AxelixMetricsAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public BytesMemoryBaseUnitValueTransformer bytesMemoryBaseUnitValueTransformer() {
         return new BytesMemoryBaseUnitValueTransformer();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public KilobytesMemoryBaseUnitValueTransformer kilobytesMemoryBaseUnitValueTransformer() {
         return new KilobytesMemoryBaseUnitValueTransformer();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public BaseUnitParser baseUnitParser() {
         return new BaseUnitParser();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public ServiceMetricsGroupsAssembler serviceMetricsGroupsAssembler(MeterRegistry registry) {
         return new DefaultServiceMetricsGroupsAssembler(registry);
     }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfigurationTest.java
@@ -19,11 +19,8 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
 
@@ -64,33 +61,5 @@ class AxelixHeapDumpEndpointAutoConfigurationTest {
                     assertThat(context).doesNotHaveBean(AxelixHeapDumpEndpointAutoConfiguration.class);
                     assertThat(context).doesNotHaveBean(AxelixHeapDumpEndpoint.class);
                 });
-    }
-
-    @Test
-    void shouldFailWhenCustomBeanProvided() {
-        // given.
-        contextRunner
-                .withUserConfiguration(CustomAxelixHeapDumpEndpointConfig.class)
-
-                // when.
-                .run(context -> {
-                    // then.
-                    assertThat(context).hasFailed();
-                    assertThat(context.getStartupFailure()).isInstanceOf(BeanDefinitionOverrideException.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomAxelixHeapDumpEndpointConfig {
-        @Bean
-        public AxelixHeapDumpEndpoint axelixHeapDumpEndpoint() {
-            return new CustomAxelixHeapDumpEndpoint();
-        }
-    }
-
-    static class CustomAxelixHeapDumpEndpoint extends AxelixHeapDumpEndpoint {
-        public CustomAxelixHeapDumpEndpoint() {
-            super();
-        }
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfigurationTest.java
@@ -19,6 +19,7 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -66,22 +67,23 @@ class AxelixHeapDumpEndpointAutoConfigurationTest {
     }
 
     @Test
-    void shouldNotCreateDefaultAxelixHeapDumpEndpoint_whenCustomBeanProvided() {
+    void shouldFailWhenCustomBeanProvided() {
+        // given.
         contextRunner
                 .withUserConfiguration(CustomAxelixHeapDumpEndpointConfig.class)
+
+                // when.
                 .run(context -> {
-                    assertThat(context).hasSingleBean(AxelixHeapDumpEndpoint.class);
-                    var beans = context.getBeansOfType(AxelixHeapDumpEndpoint.class);
-                    assertThat(beans).hasSize(1);
-                    assertThat(beans.values().iterator().next())
-                            .isExactlyInstanceOf(CustomAxelixHeapDumpEndpoint.class);
+                    // then.
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).isInstanceOf(BeanDefinitionOverrideException.class);
                 });
     }
 
     @TestConfiguration
     static class CustomAxelixHeapDumpEndpointConfig {
         @Bean
-        public AxelixHeapDumpEndpoint customAxelixHeapDumpEndpoint() {
+        public AxelixHeapDumpEndpoint axelixHeapDumpEndpoint() {
             return new CustomAxelixHeapDumpEndpoint();
         }
     }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixMetricsAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixMetricsAutoConfigurationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import com.axelixlabs.axelix.common.api.transform.BaseUnitParser;
+import com.axelixlabs.axelix.common.api.transform.BaseUnitValueTransformer;
+import com.axelixlabs.axelix.common.api.transform.BytesMemoryBaseUnitValueTransformer;
+import com.axelixlabs.axelix.common.api.transform.KilobytesMemoryBaseUnitValueTransformer;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.ServiceMetricsGroupsAssembler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link AxelixMetricsAutoConfiguration}.
+ *
+ * @author Sergey Cherkasov
+ */
+class AxelixMetricsAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-metrics")
+            .withBean(MeterRegistry.class, SimpleMeterRegistry::new)
+            .withConfiguration(AutoConfigurations.of(AxelixMetricsAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(AxelixMetricsAutoConfiguration.class);
+            assertThat(context).hasSingleBean(AxelixMetricsEndpoint.class);
+            assertThat(context).hasSingleBean(BytesMemoryBaseUnitValueTransformer.class);
+            assertThat(context).hasSingleBean(KilobytesMemoryBaseUnitValueTransformer.class);
+            assertThat(context).hasSingleBean(BaseUnitParser.class);
+            assertThat(context).hasSingleBean(ServiceMetricsGroupsAssembler.class);
+            assertThat(context).getBeans(BaseUnitValueTransformer.class).hasSize(2);
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
+        new ApplicationContextRunner()
+                .withBean(MeterRegistry.class, SimpleMeterRegistry::new)
+                .withConfiguration(AutoConfigurations.of(AxelixMetricsAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixMetricsAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixMetricsEndpoint.class);
+                    assertThat(context).doesNotHaveBean(BytesMemoryBaseUnitValueTransformer.class);
+                    assertThat(context).doesNotHaveBean(KilobytesMemoryBaseUnitValueTransformer.class);
+                    assertThat(context).doesNotHaveBean(BaseUnitParser.class);
+                    assertThat(context).doesNotHaveBean(ServiceMetricsGroupsAssembler.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutMeterRegistry() {
+        new ApplicationContextRunner()
+                .withPropertyValues("management.endpoints.web.exposure.include=axelix-metrics")
+                .withConfiguration(AutoConfigurations.of(AxelixMetricsAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixMetricsAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixMetricsEndpoint.class);
+                    assertThat(context).doesNotHaveBean(BytesMemoryBaseUnitValueTransformer.class);
+                    assertThat(context).doesNotHaveBean(KilobytesMemoryBaseUnitValueTransformer.class);
+                    assertThat(context).doesNotHaveBean(BaseUnitParser.class);
+                    assertThat(context).doesNotHaveBean(ServiceMetricsGroupsAssembler.class);
+                });
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
@@ -34,7 +33,6 @@ import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
 public class AxelixHeapDumpEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixHeapDumpEndpoint axelixHeapDumpEndpoint() {
         return new AxelixHeapDumpEndpoint();
     }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixMetricsAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixMetricsAutoConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegi
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.common.api.transform.BaseUnitParser;
@@ -50,7 +49,6 @@ import com.axelixlabs.axelix.sbs.spring.core.metrics.ServiceMetricsGroupsAssembl
 public class AxelixMetricsAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixMetricsEndpoint axelixMetricsEndpoint(
             MeterRegistry registry,
             BaseUnitParser baseUnitParser,
@@ -61,25 +59,21 @@ public class AxelixMetricsAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public BytesMemoryBaseUnitValueTransformer bytesMemoryBaseUnitValueTransformer() {
         return new BytesMemoryBaseUnitValueTransformer();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public KilobytesMemoryBaseUnitValueTransformer kilobytesMemoryBaseUnitValueTransformer() {
         return new KilobytesMemoryBaseUnitValueTransformer();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public BaseUnitParser baseUnitParser() {
         return new BaseUnitParser();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public ServiceMetricsGroupsAssembler serviceMetricsGroupsAssembler(MeterRegistry registry) {
         return new DefaultServiceMetricsGroupsAssembler(registry);
     }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfigurationTest.java
@@ -19,11 +19,8 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
 
@@ -64,33 +61,5 @@ class AxelixHeapDumpEndpointAutoConfigurationTest {
                     assertThat(context).doesNotHaveBean(AxelixHeapDumpEndpointAutoConfiguration.class);
                     assertThat(context).doesNotHaveBean(AxelixHeapDumpEndpoint.class);
                 });
-    }
-
-    @Test
-    void shouldFailWhenCustomBeanProvided() {
-        // given.
-        contextRunner
-                .withUserConfiguration(CustomAxelixHeapDumpEndpointConfig.class)
-
-                // when.
-                .run(context -> {
-                    // then.
-                    assertThat(context).hasFailed();
-                    assertThat(context.getStartupFailure()).isInstanceOf(BeanDefinitionOverrideException.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomAxelixHeapDumpEndpointConfig {
-        @Bean
-        public AxelixHeapDumpEndpoint axelixHeapDumpEndpoint() {
-            return new CustomAxelixHeapDumpEndpoint();
-        }
-    }
-
-    static class CustomAxelixHeapDumpEndpoint extends AxelixHeapDumpEndpoint {
-        public CustomAxelixHeapDumpEndpoint() {
-            super();
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixHeapDumpEndpointAutoConfigurationTest.java
@@ -19,6 +19,7 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -66,22 +67,23 @@ class AxelixHeapDumpEndpointAutoConfigurationTest {
     }
 
     @Test
-    void shouldNotCreateDefaultAxelixHeapDumpEndpoint_whenCustomBeanProvided() {
+    void shouldFailWhenCustomBeanProvided() {
+        // given.
         contextRunner
                 .withUserConfiguration(CustomAxelixHeapDumpEndpointConfig.class)
+
+                // when.
                 .run(context -> {
-                    assertThat(context).hasSingleBean(AxelixHeapDumpEndpoint.class);
-                    var beans = context.getBeansOfType(AxelixHeapDumpEndpoint.class);
-                    assertThat(beans).hasSize(1);
-                    assertThat(beans.values().iterator().next())
-                            .isExactlyInstanceOf(CustomAxelixHeapDumpEndpoint.class);
+                    // then.
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure()).isInstanceOf(BeanDefinitionOverrideException.class);
                 });
     }
 
     @TestConfiguration
     static class CustomAxelixHeapDumpEndpointConfig {
         @Bean
-        public AxelixHeapDumpEndpoint customAxelixHeapDumpEndpoint() {
+        public AxelixHeapDumpEndpoint axelixHeapDumpEndpoint() {
             return new CustomAxelixHeapDumpEndpoint();
         }
     }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixMetricsAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixMetricsAutoConfigurationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import com.axelixlabs.axelix.common.api.transform.BaseUnitParser;
+import com.axelixlabs.axelix.common.api.transform.BaseUnitValueTransformer;
+import com.axelixlabs.axelix.common.api.transform.BytesMemoryBaseUnitValueTransformer;
+import com.axelixlabs.axelix.common.api.transform.KilobytesMemoryBaseUnitValueTransformer;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.ServiceMetricsGroupsAssembler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for {@link AxelixMetricsAutoConfiguration}.
+ *
+ * @author Sergey Cherkasov
+ */
+class AxelixMetricsAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-metrics")
+            .withBean(MeterRegistry.class, SimpleMeterRegistry::new)
+            .withConfiguration(AutoConfigurations.of(AxelixMetricsAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(AxelixMetricsAutoConfiguration.class);
+            assertThat(context).hasSingleBean(AxelixMetricsEndpoint.class);
+            assertThat(context).hasSingleBean(BytesMemoryBaseUnitValueTransformer.class);
+            assertThat(context).hasSingleBean(KilobytesMemoryBaseUnitValueTransformer.class);
+            assertThat(context).hasSingleBean(BaseUnitParser.class);
+            assertThat(context).hasSingleBean(ServiceMetricsGroupsAssembler.class);
+            assertThat(context).getBeans(BaseUnitValueTransformer.class).hasSize(2);
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
+        new ApplicationContextRunner()
+                .withBean(MeterRegistry.class, SimpleMeterRegistry::new)
+                .withConfiguration(AutoConfigurations.of(AxelixMetricsAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixMetricsAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixMetricsEndpoint.class);
+                    assertThat(context).doesNotHaveBean(BytesMemoryBaseUnitValueTransformer.class);
+                    assertThat(context).doesNotHaveBean(KilobytesMemoryBaseUnitValueTransformer.class);
+                    assertThat(context).doesNotHaveBean(BaseUnitParser.class);
+                    assertThat(context).doesNotHaveBean(ServiceMetricsGroupsAssembler.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutMeterRegistry() {
+        new ApplicationContextRunner()
+                .withPropertyValues("management.endpoints.web.exposure.include=axelix-metrics")
+                .withConfiguration(AutoConfigurations.of(AxelixMetricsAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixMetricsAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixMetricsEndpoint.class);
+                    assertThat(context).doesNotHaveBean(BytesMemoryBaseUnitValueTransformer.class);
+                    assertThat(context).doesNotHaveBean(KilobytesMemoryBaseUnitValueTransformer.class);
+                    assertThat(context).doesNotHaveBean(BaseUnitParser.class);
+                    assertThat(context).doesNotHaveBean(ServiceMetricsGroupsAssembler.class);
+                });
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/TestContextArchitectureTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/TestContextArchitectureTest.java
@@ -17,6 +17,9 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core;
 
+import java.lang.annotation.Annotation;
+import java.util.List;
+
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.autoconfigure.data.cassandra.AutoConfigureDataCassandra;
@@ -64,9 +67,6 @@ import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import java.lang.annotation.Annotation;
-import java.util.List;
-
 /**
  * Tests that check for context pollution in Spring Boot tests
  *
@@ -85,51 +85,50 @@ public class TestContextArchitectureTest {
      * not used in places where they would compromise context reuse or isolation.
      */
     public static final List<Class<? extends Annotation>> RESTRICTED_TYPE_ANNOTATIONS = List.of(
-        ContextConfiguration.class,
-        ActiveProfiles.class,
-        ContextHierarchy.class,
-        TestPropertySource.class,
-        WebAppConfiguration.class,
-        SpringBootTest.class,
-        Import.class,
-        AutoConfigureMockMvc.class,
-        WebMvcTest.class,
-        AutoConfigureWebTestClient.class,
-        DirtiesContext.class,
-        AutoConfigureObservability.class,
-        JsonTest.class,
-        AutoConfigureJsonTesters.class,
-        WebFluxTest.class,
-        GraphQlTest.class,
-        AutoConfigureGraphQlTester.class,
-        DataCassandraTest.class,
-        AutoConfigureDataCassandra.class,
-        DataCouchbaseTest.class,
-        AutoConfigureDataCouchbase.class,
-        DataElasticsearchTest.class,
-        AutoConfigureDataElasticsearch.class,
-        DataJpaTest.class,
-        AutoConfigureDataJpa.class,
-        DataJdbcTest.class,
-        AutoConfigureDataJdbc.class,
-        JdbcTest.class,
-        AutoConfigureJdbc.class,
-        DataR2dbcTest.class,
-        AutoConfigureDataR2dbc.class,
-        JooqTest.class,
-        AutoConfigureJooq.class,
-        DataMongoTest.class,
-        AutoConfigureDataMongo.class,
-        DataNeo4jTest.class,
-        AutoConfigureDataNeo4j.class,
-        DataRedisTest.class,
-        AutoConfigureDataRedis.class,
-        DataLdapTest.class,
-        AutoConfigureDataLdap.class,
-        RestClientTest.class,
-        AutoConfigureMockRestServiceServer.class,
-        AutoConfigureRestDocs.class,
-        WebServiceClientTest.class,
-        ImportAutoConfiguration.class
-    );
+            ContextConfiguration.class,
+            ActiveProfiles.class,
+            ContextHierarchy.class,
+            TestPropertySource.class,
+            WebAppConfiguration.class,
+            SpringBootTest.class,
+            Import.class,
+            AutoConfigureMockMvc.class,
+            WebMvcTest.class,
+            AutoConfigureWebTestClient.class,
+            DirtiesContext.class,
+            AutoConfigureObservability.class,
+            JsonTest.class,
+            AutoConfigureJsonTesters.class,
+            WebFluxTest.class,
+            GraphQlTest.class,
+            AutoConfigureGraphQlTester.class,
+            DataCassandraTest.class,
+            AutoConfigureDataCassandra.class,
+            DataCouchbaseTest.class,
+            AutoConfigureDataCouchbase.class,
+            DataElasticsearchTest.class,
+            AutoConfigureDataElasticsearch.class,
+            DataJpaTest.class,
+            AutoConfigureDataJpa.class,
+            DataJdbcTest.class,
+            AutoConfigureDataJdbc.class,
+            JdbcTest.class,
+            AutoConfigureJdbc.class,
+            DataR2dbcTest.class,
+            AutoConfigureDataR2dbc.class,
+            JooqTest.class,
+            AutoConfigureJooq.class,
+            DataMongoTest.class,
+            AutoConfigureDataMongo.class,
+            DataNeo4jTest.class,
+            AutoConfigureDataNeo4j.class,
+            DataRedisTest.class,
+            AutoConfigureDataRedis.class,
+            DataLdapTest.class,
+            AutoConfigureDataLdap.class,
+            RestClientTest.class,
+            AutoConfigureMockRestServiceServer.class,
+            AutoConfigureRestDocs.class,
+            WebServiceClientTest.class,
+            ImportAutoConfiguration.class);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The heap dump endpoint is now registered whenever it’s available, even if a custom bean of the same type already exists.
  * Updated test coverage to reflect the new behavior and removed the outdated custom-bean scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->