### PR TITLE
GH-1320 Integrate core build & deploy logic for all playground

### DIFF
--- a/.github/actions/build-master/action.yaml
+++ b/.github/actions/build-master/action.yaml
@@ -57,18 +57,3 @@ runs:
         path: 'build/reports/spring-test-profiler'
         retention-days: 3
         if-no-files-found: ignore
-
-    - name: Download and trust Nexus SSL certificate for Gradle
-      if: ${{ inputs.deploy-to-nexus == 'true' }}
-      run: |
-        TRUSTSTORE="$JAVA_HOME/lib/security/cacerts"
-        openssl s_client -connect $NEXUS_HOST_PORT -showcerts </dev/null 2>/dev/null | openssl x509 -outform PEM > nexus.crt
-        sudo keytool -importcert -file nexus.crt -alias nexus-ssl -keystore $TRUSTSTORE -storepass changeit -noprompt
-            
-        echo "org.gradle.jvmargs=-Djavax.net.ssl.trustStore=$TRUSTSTORE -Djavax.net.ssl.trustStorePassword=changeit" >> $HOME/.gradle/gradle.properties
-      shell: bash
-
-    - name: Publish Libraries to Nexus
-      if: ${{ inputs.deploy-to-nexus == 'true' }}
-      run: ./gradlew publishMainPublicationToNexusAxelixRepository
-      shell: bash

--- a/.github/workflows/backend_pull_requests.yaml
+++ b/.github/workflows/backend_pull_requests.yaml
@@ -52,10 +52,6 @@ jobs:
 
   backend-build:
     runs-on: ubuntu-latest
-    env:
-      NEXUS_USER: ${{ secrets.NEXUS_USER }}
-      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-      NEXUS_URL: ${{ secrets.NEXUS_URL }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -66,10 +62,27 @@ jobs:
         with:
           gradle-cache-encryption-key: ''
 
-      - name: Loading Secrets
-        uses: ./.github/actions/bitwarden
+      # Set up Extra JDKs for Playgrounds
+      - name: Set up JDK 17 for Playgrounds
+        uses: actions/setup-java@v4
+        id: setup-java-17
         with:
-          bw-access-token: ${{ secrets.BW_ACCESS_TOKEN }}
+          java-version: '17'
+          distribution: 'liberica'
+
+      - name: Set up JDK 21 for Playgrounds
+        uses: actions/setup-java@v4
+        id: setup-java-21
+        with:
+          java-version: '21'
+          distribution: 'liberica'
+
+      - name: Set up JDK 24 for Playgrounds
+        uses: actions/setup-java@v4
+        id: setup-java-24
+        with:
+          java-version: '24'
+          distribution: 'liberica'
 
       # Starting build playground projects
       - name: Detect Changed Modules
@@ -77,15 +90,17 @@ jobs:
         id: filter
         with:
           filters: |
-            sb2_specific:
+            sb2_specific_trigger:
               - 'sbs/axelix-spring-boot-2-starter/**'
               - 'playgrounds/spring-petclinic-maven-sb-2/**'
+              - 'playgrounds/notification-service-gradle-sb-2/**'
             
-            sb3_specific:
+            sb3_specific_trigger:
               - 'sbs/axelix-spring-boot-3-starter/**'
+              - 'playgrounds/spring-petclinic-gradle-sb-3/**'
               - 'playgrounds/feature-service-maven-sb-3/**'
             
-            global_trigger:
+            sbs_global_trigger:
               - 'common/**'
               - 'sbs/starter-domain/**'
               - 'buildSrc/**'
@@ -98,19 +113,22 @@ jobs:
           
       - name: Run Conditional Playground Build via Make
         env:
-          # Required variables for playground builds
-          AXELIX_SBS_AUTH_JWT_ALGORITHM: HMAC512
-          AXELIX_SBS_AUTH_JWT_SIGNING_KEY: ${{ env.SANDBOX_JWT_SIGNING_KEY }}
+          SB2_CHANGE_TRIGGER: ${{ steps.filter.outputs.sb2_specific_trigger }}
+          SB3_CHANGE_TRIGGER: ${{ steps.filter.outputs.sb3_specific_trigger }}
+          GLOBAL_CHANGE_TRIGGER: ${{ steps.filter.outputs.sbs_global_trigger }}
+
+          JAVA_17_HOME: ${{ steps.setup-java-17.outputs.path }}
+          JAVA_21_HOME: ${{ steps.setup-java-21.outputs.path }}
+          JAVA_24_HOME: ${{ steps.setup-java-24.outputs.path }}
         run: |
           SHOULD_BUILD_SB2="false"
-          if [ "${{ steps.filter.outputs.sb2_specific }}" = "true" ] || [ "${{ steps.filter.outputs.global_trigger }}" = "true" ]; then
+          if [ "$SB2_CHANGE_TRIGGER" = "true" ] || [ "$GLOBAL_CHANGE_TRIGGER" = "true" ]; then
             SHOULD_BUILD_SB2="true"
           fi
           
           SHOULD_BUILD_SB3="false"
-          if [ "${{ steps.filter.outputs.sb3_specific }}" = "true" ] || [ "${{ steps.filter.outputs.global_trigger }}" = "true" ]; then
+          if [ "$SB3_CHANGE_TRIGGER" = "true" ] || [ "$GLOBAL_CHANGE_TRIGGER" = "true" ]; then
             SHOULD_BUILD_SB3="true"
           fi
 
-          make build-playground BUILD_SB2="$SHOULD_BUILD_SB2"
-          make build-playground BUILD_SB3="$SHOULD_BUILD_SB3"
+          make build-playground BUILD_SB2="$SHOULD_BUILD_SB2" BUILD_SB3="$SHOULD_BUILD_SB3"

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -53,13 +53,6 @@ jobs:
       # Use branch from workflow_dispatch input if provided, otherwise default to 'main'
       HELM_CHART_BRANCH: ${{ github.event.inputs.helm_chart_branch || 'main' }}
 
-      # We need Nexus so that the playground repos have the place to pull the dependency from
-      # These are needed in order to publish the final build artifacts into Nexus package registry
-      NEXUS_USER: ${{ secrets.NEXUS_USER }}
-      NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-      NEXUS_URL: ${{ secrets.NEXUS_URL }}
-      NEXUS_HOST_PORT: ${{ secrets.NEXUS_HOST_PORT }}
-
       # OIDC Related settings
       AXELIX_MASTER_AUTH_OPTIONS_OAUTH2_ENABLED: true
       AXELIX_MASTER_AUTH_OPTIONS_OAUTH2_ISSUER_URI: ${{ secrets.OIDC_GOOGLE_ISSUER_URL }}
@@ -148,52 +141,73 @@ jobs:
             --set axelix.master.discovery.selfRegistration.enabled=true \
             --install axelix-master . \
             -f values.yaml
+
+      # Set up Extra JDKs for Playgrounds
+      - name: Set up JDK 17 for Playgrounds
+        uses: actions/setup-java@v4
+        id: setup-java-17
+        with:
+          java-version: '17'
+          distribution: 'liberica'
+
+      - name: Set up JDK 21 for Playgrounds
+        uses: actions/setup-java@v4
+        id: setup-java-21
+        with:
+          java-version: '21'
+          distribution: 'liberica'
+
+      - name: Set up JDK 24 for Playgrounds
+        uses: actions/setup-java@v4
+        id: setup-java-24
+        with:
+          java-version: '24'
+          distribution: 'liberica'
           
-      - name: Build Playgrounds via Make
+      - name: Build Playgrounds
         env:
-          AXELIX_SBS_AUTH_JWT_ALGORITHM: HMAC512
-          AXELIX_SBS_AUTH_JWT_SIGNING_KEY: $SANDBOX_JWT_SIGNING_KEY
+          JAVA_17_HOME: ${{ steps.setup-java-17.outputs.path }}
+          JAVA_21_HOME: ${{ steps.setup-java-21.outputs.path }}
+          JAVA_24_HOME: ${{ steps.setup-java-24.outputs.path }}
         run: |
           make build-playground BUILD_ALL_PLAYGROUNDS="true"
 
-      - name: Deploy Playground Petclinic Maven SB 2
+      - name: Deploy Playground Spring Petclinic Maven SB 2
+        env:
+          APP_NAME: spring-petclinic-maven-sb-2
         uses: ./.github/actions/deploy-playground
         with:
-          working-directory: playgrounds/spring-petclinic-maven-sb-2
-          cr-repository-path: ${{ vars.CR_PLAYGROUND_REPOSITORY }}/spring-petclinic-sb-2
-          image-tag: petclinic-maven-sb-2:2.7.18-SNAPSHOT
-          helm-release: petclinic-maven-sb-2
+          working-directory: playgrounds/${{ env.APP_NAME }}
+          cr-repository-path: ${{ vars.CR_PLAYGROUND_REPOSITORY }}/${{ env.APP_NAME }}
+          image-tag: ${{ env.APP_NAME }}:2.7.18-SNAPSHOT
+          helm-release: ${{ env.APP_NAME }}
+
+      - name: Deploy Playground Notification Service Gradle SB 2
+        env:
+          APP_NAME: notification-service-gradle-sb-2
+        uses: ./.github/actions/deploy-playground
+        with:
+          working-directory: playgrounds/${{ env.APP_NAME }}
+          cr-repository-path: ${{ vars.CR_PLAYGROUND_REPOSITORY }}/${{ env.APP_NAME }}
+          image-tag: ${{ env.APP_NAME }}:0.0.2-SNAPSHOT
+          helm-release: ${{ env.APP_NAME }}
 
       - name: Deploy Playground Feature Service Maven SB 3
+        env:
+          APP_NAME: feature-service-maven-sb-3
         uses: ./.github/actions/deploy-playground
         with:
-          working-directory: playgrounds/feature-service-maven-sb-3
-          cr-repository-path: ${{ vars.CR_PLAYGROUND_REPOSITORY }}/feature-service-sb-3
-          image-tag: feature-service-maven-sb-3:0.0.2-SNAPSHOT
-          helm-release: feature-service-maven-sb-3
+          working-directory: playgrounds/${{ env.APP_NAME }}
+          cr-repository-path: ${{ vars.CR_PLAYGROUND_REPOSITORY }}/${{ env.APP_NAME }}
+          image-tag: ${{ env.APP_NAME }}:0.0.2-SNAPSHOT
+          helm-release: ${{ env.APP_NAME }}
 
-  dispatch:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch' }}
-    needs: [build-deploy-source]
-    strategy:
-      matrix:
-        playground_repo: [
-          'axelixlabs/notification-service',
-          'axelixlabs/spring-petclinic',
-        ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Loading Secrets
-        uses: ./.github/actions/bitwarden
+      - name: Deploy Playground Spring Petclinic Gradle SB 3
+        env:
+          APP_NAME: spring-petclinic-gradle-sb-3
+        uses: ./.github/actions/deploy-playground
         with:
-          bw-access-token: ${{ secrets.BW_ACCESS_TOKEN }}
-
-      - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ env.GITHUB_MASTER_ACCESS_TOKEN }}
-          repository: ${{ matrix.playground_repo }}
-          event-type: monorepo-backend-updated
+          working-directory: playgrounds/${{ env.APP_NAME }}
+          cr-repository-path: ${{ vars.CR_PLAYGROUND_REPOSITORY }}/${{ env.APP_NAME }}
+          image-tag: ${{ env.APP_NAME }}:3.5.0-SNAPSHOT
+          helm-release: ${{ env.APP_NAME }}

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
-.PHONY: clean clean-all clean-playgrounds spotless publish-local build build-with-playgrounds \
-        build-playground publish-starter-sb2 build-petclinic-maven-sb2 spotless-all publish-starter-sb3 \
-        build-feature-service-maven-sb3
+.PHONY: clean clean-playgrounds clean-all build build-playground build-all spotless spotless-all \
+        publish-local publish-starter-sb-2 publish-starter-sb-3 \
+        build-spring-petclinic-maven-sb-2 build-notification-service-gradle-sb-2 \
+        build-feature-service-maven-sb-3 build-spring-petclinic-gradle-sb-3
 
-BUILD_ALL_PLAYGROUNDS ?= false
-BUILD_SB2             ?= false
-BUILD_SB3             ?= false
+BUILD_SB2             ?= true
+BUILD_SB3             ?= true
 
 clean:
 	./gradlew clean
 
 clean-playgrounds:
 	cd playgrounds/spring-petclinic-maven-sb-2 && ./mvnw clean
+	cd playgrounds/notification-service-gradle-sb-2 && ./gradlew clean
 	cd playgrounds/feature-service-maven-sb-3 && ./mvnw clean
+	cd playgrounds/spring-petclinic-gradle-sb-3 && ./gradlew clean
 
 clean-all: clean clean-playgrounds
 
@@ -19,12 +21,11 @@ spotless:
 	./gradlew spotlessApply
 
 spotless-all:
-	@echo "=== Formatting Backend Project ==="
 	./gradlew spotlessApply
-	@echo "=== Formatting Petclinic Maven SB-2 Project ==="
 	cd playgrounds/spring-petclinic-maven-sb-2 && ./mvnw spring-javaformat:apply
-	@echo "=== Formatting Feature Service Maven SB-3 Project ==="
+	cd playgrounds/notification-service-gradle-sb-2 && ./gradlew spotlessApply
 	cd playgrounds/feature-service-maven-sb-3 && ./mvnw spotless:apply
+	cd playgrounds/spring-petclinic-gradle-sb-3 && ./gradlew spotlessApply
 
 publish-local:
 	./gradlew publishToMavenLocal
@@ -34,41 +35,68 @@ build:
 	./gradlew build
 
 build-all: build
-	$(MAKE) build-playground BUILD_ALL_PLAYGROUNDS="true"
+	$(MAKE) build-playground BUILD_SB2="true" BUILD_SB3="true"
 
 # BUILD PLAYGROUND PROJECTS
 build-playground:
 
-ifeq ($(BUILD_ALL_PLAYGROUNDS),true)
-	@echo "=== Build all Playgrounds ==="
-	$(MAKE) publish-starter-sb2
-	$(MAKE) build-petclinic-maven-sb2
-	$(MAKE) publish-starter-sb3
-	$(MAKE) build-feature-service-maven-sb3
-else ifeq ($(BUILD_SB2),true)
-	@echo "=== Publish Axelix Spring boot 2 Starter ==="
-	$(MAKE) publish-starter-sb2
-	@echo "=== Build Petclinic Maven Spring boot 2 ==="
-	$(MAKE) build-petclinic-maven-sb2
-else ifeq ($(BUILD_SB3),true)
-	@echo "=== Publish Axelix Spring boot 3 Starter ==="
-	$(MAKE) publish-starter-sb3
-	@echo "=== Build Feature Service Maven Spring boot 3 ==="
-	$(MAKE) build-feature-service-maven-sb3
+ifeq ($(BUILD_SB2),true)
+	@echo "=== Publish Axelix Spring Boot 2 Starter ==="
+	$(MAKE) publish-starter-sb-2
+	@echo "=== Build Spring Petclinic Maven Spring Boot 2 ==="
+	$(MAKE) build-spring-petclinic-maven-sb-2
+	@echo "=== Build Notification Service Gradle Spring Boot 2 ==="
+	$(MAKE) build-notification-service-gradle-sb-2
+endif
+ifeq ($(BUILD_SB3),true)
+	@echo "=== Publish Axelix Spring Boot 3 Starter ==="
+	$(MAKE) publish-starter-sb-3
+	@echo "=== Build Spring Petclinic Gradle Spring Boot 3 ==="
+	$(MAKE) build-spring-petclinic-gradle-sb-3
+	@echo "=== Build Feature Service Maven Spring Boot 3 ==="
+	$(MAKE) build-feature-service-maven-sb-3
 endif
 
-publish-starter-sb2:
-	@echo "=== Compiling and publishing Spring Boot 2 Axelix Starter ==="
+LOCAL_JAVA_17 := $(firstword $(wildcard \
+    $(JAVA_17_HOME) \
+    $(HOME)/.jdks/liberica-17* \
+    $(HOME)/.jdks/temurin-17* \
+    $(HOME)/.sdkman/candidates/java/17*))
+
+LOCAL_JAVA_21 := $(firstword $(wildcard \
+    $(JAVA_21_HOME) \
+    $(HOME)/.jdks/liberica-21* \
+    $(HOME)/.jdks/temurin-21* \
+    $(HOME)/.sdkman/candidates/java/21*))
+
+LOCAL_JAVA_24 := $(firstword $(wildcard \
+    $(JAVA_24_HOME) \
+    $(HOME)/.jdks/liberica-24* \
+    $(HOME)/.jdks/temurin-24* \
+    $(HOME)/.sdkman/candidates/java/24*))
+
+# PUBLISH STARTERS
+publish-starter-sb-2:
+	@echo "=== Publishing Spring Boot 2 Axelix Starter ==="
 	./gradlew :sbs:axelix-spring-boot-2-starter:publishToMavenLocal
 
-publish-starter-sb3:
-	@echo "=== Compiling and publishing Spring Boot 3 Axelix Starter ==="
+publish-starter-sb-3:
+	@echo "=== Publishing Spring Boot 3 Axelix Starter ==="
 	./gradlew :sbs:axelix-spring-boot-3-starter:publishToMavenLocal
 
-build-petclinic-maven-sb2:
-	@echo "=== Running Maven build for Petclinic Spring boot 2 ==="
-	cd playgrounds/spring-petclinic-maven-sb-2 && ./mvnw clean package -B
+# BUILD SPECIFIC PLAYGROUNDS
+build-spring-petclinic-maven-sb-2:
+	@echo "=== Running Maven build for Petclinic Spring Boot 2 ==="
+	cd playgrounds/spring-petclinic-maven-sb-2 && JAVA_HOME=$(LOCAL_JAVA_17) ./mvnw package -B
 
-build-feature-service-maven-sb3:
-	@echo "=== Running Maven build for Feature Service Spring boot 3 ==="
-	cd playgrounds/feature-service-maven-sb-3 && ./mvnw clean package -B
+build-notification-service-gradle-sb-2:
+	@echo "=== Running Gradle build for Notification Service Spring Boot 2 ==="
+	cd playgrounds/notification-service-gradle-sb-2 && JAVA_HOME=$(LOCAL_JAVA_21) ./gradlew build
+
+build-feature-service-maven-sb-3:
+	@echo "=== Running Maven build for Feature Service Spring Boot 3 ==="
+	cd playgrounds/feature-service-maven-sb-3 && JAVA_HOME=$(LOCAL_JAVA_24) ./mvnw package -B
+
+build-spring-petclinic-gradle-sb-3:
+	@echo "=== Running Gradle build for Petclinic Spring Boot 3 ==="
+	cd playgrounds/spring-petclinic-gradle-sb-3 && JAVA_HOME=$(LOCAL_JAVA_17) ./gradlew build

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-axelixVersion=1.0.0-M2
+axelixVersion=1.0.0-SNAPSHOT
 
 # Force Kotlin plugin to not add the Kotlin Standard Library to any configurations
 # Instead we're doing it manually

--- a/playgrounds/feature-service-maven-sb-3/pom.xml
+++ b/playgrounds/feature-service-maven-sb-3/pom.xml
@@ -21,7 +21,6 @@
         <springdoc.version>2.8.9</springdoc.version>
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
         <spotless-maven-plugin.version>3.7.0</spotless-maven-plugin.version>
-        <dockerImageName>sivaprasadreddy/ft-feature-service</dockerImageName>
     </properties>
     <dependencies>
         <dependency>
@@ -85,7 +84,7 @@
         <dependency>
             <groupId>com.axelixlabs</groupId>
             <artifactId>axelix-spring-boot-3-starter</artifactId>
-            <version>1.0.0-M2</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -267,18 +266,6 @@
             <url>https://repo.spring.io/milestone</url>
             <snapshots>
                 <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>nucleon-forge-axelix</id>
-            <name>Nucleon Forge Axelix</name>
-            <url>https://${env.NEXUS_HOST_PORT}/repository/axile-monorepo/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
             </snapshots>
         </repository>
     </repositories>

--- a/playgrounds/feature-service-maven-sb-3/settings.xml
+++ b/playgrounds/feature-service-maven-sb-3/settings.xml
@@ -1,9 +1,0 @@
-<settings>
-	<servers>
-		<server>
-			<id>nucleon-forge-axelix</id>
-			<username>${env.NEXUS_USER}</username>
-			<password>${env.NEXUS_PASSWORD}</password>
-		</server>
-	</servers>
-</settings>

--- a/playgrounds/feature-service-maven-sb-3/src/test/resources/application.properties
+++ b/playgrounds/feature-service-maven-sb-3/src/test/resources/application.properties
@@ -1,0 +1,48 @@
+# AXELIX
+axelix.sbs.auth.jwt.algorithm=HMAC512
+axelix.sbs.auth.jwt.signing-key=22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
+
+###### Actuator Configuration  #########
+management.endpoints.web.exposure.include=*
+
+###### DB Configuration  #########
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL
+spring.datasource.username=sa
+spring.datasource.password=
+
+####### Flyway Migrations #########
+spring.flyway.locations=classpath:/db/migration/h2
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.show-sql=true
+
+### App Configuration ###
+ft.openapi.title=FeatureService API
+ft.openapi.description=FeatureService API Swagger Documentation
+ft.openapi.version=v1.0.0
+ft.openapi.contact.name=SivaLabs
+ft.openapi.contact.email=support@sivalabs.in
+ft.events.new-features=new_features
+ft.events.updated-features=updated_features
+ft.events.deleted-features=deleted_features
+
+####### OAuth2 Configuration  #########
+OAUTH2_SERVER_URL=http://localhost:9191
+REALM_URL=${OAUTH2_SERVER_URL}/realms/feature-tracker
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${REALM_URL}
+
+######## Kafka Configuration  #########
+KAFKA_BROKER=localhost:9092
+spring.kafka.bootstrap-servers=${KAFKA_BROKER}
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+
+spring.kafka.consumer.group-id=${spring.application.name}
+spring.kafka.consumer.auto-offset-reset=latest
+#spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+#spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+spring.kafka.consumer.properties.spring.deserializer.value.delegate.class=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.producer.properties.spring.json.add.type.headers=true
+spring.kafka.consumer.properties.spring.json.trusted.packages=*

--- a/playgrounds/notification-service-gradle-sb-2/build.gradle.kts
+++ b/playgrounds/notification-service-gradle-sb-2/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     kotlin("plugin.spring") version "2.2.20"
     id("org.springframework.boot") version "2.7.18"
     id("io.spring.dependency-management") version "1.1.7"
-    id("com.gorylenko.gradle-git-properties") version "2.5.3"
+    id("com.gorylenko.gradle-git-properties") version "4.0.1"
     id("com.diffplug.spotless") version "8.0.0"
     id("org.cyclonedx.bom") version "2.3.1"
 }
@@ -36,6 +36,7 @@ configurations {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven { url = uri("https://repo.spring.io/milestone") }
 }
@@ -48,7 +49,7 @@ extra["springCloudVersion"] = "2021.0.9"
 extra["testcontainers.version"] = "1.20.4"
 
 dependencies {
-    implementation("com.axelixlabs:axelix-spring-boot-2-starter:1.0.0-M2") {
+    implementation("com.axelixlabs:axelix-spring-boot-2-starter:1.0.0-SNAPSHOT") {
         isChanging = true
     }
     implementation("org.springframework.boot:spring-boot-starter-actuator")
@@ -67,6 +68,10 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter:${property("testcontainers.version")}")
     testImplementation("org.testcontainers:kafka:${property("testcontainers.version")}")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.bootJar {
+    archiveFileName = "notification-service-0.0.2-SNAPSHOT.jar"
 }
 
 springBoot {

--- a/playgrounds/notification-service-gradle-sb-2/gradle/wrapper/gradle-wrapper.properties
+++ b/playgrounds/notification-service-gradle-sb-2/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/playgrounds/notification-service-gradle-sb-2/settings.gradle.kts
+++ b/playgrounds/notification-service-gradle-sb-2/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "notification-service"
+rootProject.name = "notification-service-gradle-sb-2"

--- a/playgrounds/notification-service-gradle-sb-2/src/test/resources/application.properties
+++ b/playgrounds/notification-service-gradle-sb-2/src/test/resources/application.properties
@@ -1,0 +1,33 @@
+# AXELIX
+axelix.sbs.auth.jwt.algorithm=HMAC512
+axelix.sbs.auth.jwt.signing-key=22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
+
+spring.application.name=notification-service
+server.port=8080
+spring.config.import=optional:configserver:http://localhost:8888
+
+### Actuator Configuration ###
+management.endpoints.web.exposure.include=*
+
+### App Configuration ###
+ft.events.new-features=new_features
+ft.events.updated-features=updated_features
+ft.events.deleted-features=deleted_features
+
+# Disable Kafka
+spring.kafka.listener.auto-startup=false
+######## Kafka Configuration  #########
+KAFKA_BROKER=localhost:9092
+spring.kafka.bootstrap-servers=${KAFKA_BROKER}
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+
+spring.kafka.consumer.group-id=${spring.application.name}
+spring.kafka.consumer.auto-offset-reset=latest
+#spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+#spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+spring.kafka.consumer.properties.spring.deserializer.value.delegate.class=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.producer.properties.spring.json.add.type.headers=true
+spring.kafka.consumer.properties.spring.json.trusted.packages=*

--- a/playgrounds/spring-petclinic-gradle-sb-3/build.gradle.kts
+++ b/playgrounds/spring-petclinic-gradle-sb-3/build.gradle.kts
@@ -11,10 +11,11 @@ plugins {
   id("org.cyclonedx.bom") version "2.3.1"
   id("com.diffplug.spotless") version "8.6.0"
   id("io.spring.nohttp") version "0.0.11"
+  id("com.gorylenko.gradle-git-properties") version "4.0.1"
 }
 
 group = "org.springframework.samples"
-version = "3.5.0"
+version = "3.5.0-SNAPSHOT"
 
 java {
   toolchain {
@@ -23,6 +24,7 @@ java {
 }
 
 repositories {
+  mavenLocal()
   mavenCentral()
 }
 
@@ -31,12 +33,16 @@ val webjarsLocatorLiteVersion by ext("1.1.0")
 val webjarsFontawesomeVersion by ext("4.7.0")
 val webjarsBootstrapVersion by ext("5.3.6")
 
+gitProperties {
+    failOnNoGitDirectory = false
+}
+
 configurations.all {
   resolutionStrategy.cacheChangingModulesFor(0, TimeUnit.SECONDS)
 }
 
 dependencies {
-  implementation("com.axelixlabs:axelix-spring-boot-3-starter:1.0.0-M2") {
+  implementation("com.axelixlabs:axelix-spring-boot-3-starter:1.0.0-SNAPSHOT") {
     isChanging = true
   }
   implementation("org.springframework.boot:spring-boot-starter-cache")
@@ -82,6 +88,10 @@ tasks.named<Checkstyle>("checkstyleNohttp") {
 tasks.wrapper {
   gradleVersion = "8.14.3"
   distributionType = Wrapper.DistributionType.ALL
+}
+
+tasks.bootJar {
+    archiveFileName = "spring-petclinic-3.5.0-SNAPSHOT.jar"
 }
 
 spotless {

--- a/playgrounds/spring-petclinic-gradle-sb-3/docker/Dockerfile
+++ b/playgrounds/spring-petclinic-gradle-sb-3/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17
 
 WORKDIR /app
 
-COPY target/spring-petclinic-3.5.0-SNAPSHOT.jar /app/petclinic.jar
+COPY build/libs/spring-petclinic-3.5.0-SNAPSHOT.jar /app/petclinic.jar
 
 EXPOSE 8080
 

--- a/playgrounds/spring-petclinic-gradle-sb-3/src/test/resources/application-mysql.properties
+++ b/playgrounds/spring-petclinic-gradle-sb-3/src/test/resources/application-mysql.properties
@@ -1,0 +1,11 @@
+# AXELIX
+axelix.sbs.auth.jwt.algorithm=HMAC512
+axelix.sbs.auth.jwt.signing-key=22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
+
+# database init, supports mysql too
+database=mysql
+spring.datasource.url=${MYSQL_URL:jdbc:mysql://localhost/petclinic}
+spring.datasource.username=${MYSQL_USER:petclinic}
+spring.datasource.password=${MYSQL_PASS:petclinic}
+# SQL is written to be idempotent so this is safe
+spring.sql.init.mode=always

--- a/playgrounds/spring-petclinic-gradle-sb-3/src/test/resources/application-postgres.properties
+++ b/playgrounds/spring-petclinic-gradle-sb-3/src/test/resources/application-postgres.properties
@@ -1,0 +1,11 @@
+# AXELIX
+axelix.sbs.auth.jwt.algorithm=HMAC512
+axelix.sbs.auth.jwt.signing-key=22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
+
+# database init, supports postgres too
+database=postgres
+spring.datasource.url=${POSTGRES_URL:jdbc:postgresql://localhost/petclinic}
+spring.datasource.username=${POSTGRES_USER:petclinic}
+spring.datasource.password=${POSTGRES_PASS:petclinic}
+# SQL is written to be idempotent so this is safe
+spring.sql.init.mode=always

--- a/playgrounds/spring-petclinic-gradle-sb-3/src/test/resources/application.properties
+++ b/playgrounds/spring-petclinic-gradle-sb-3/src/test/resources/application.properties
@@ -1,0 +1,18 @@
+# AXELIX
+axelix.sbs.auth.jwt.algorithm=HMAC512
+axelix.sbs.auth.jwt.signing-key=22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
+
+# database init, supports mysql too
+database=h2
+spring.sql.init.schema-locations=classpath*:db/${database}/schema.sql
+spring.sql.init.data-locations=classpath*:db/${database}/data.sql
+
+# JPA
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.open-in-view=false
+
+# Internationalization
+spring.messages.basename=messages/messages
+
+# Actuator
+management.endpoints.web.exposure.include=*

--- a/playgrounds/spring-petclinic-maven-sb-2/pom.xml
+++ b/playgrounds/spring-petclinic-maven-sb-2/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>com.axelixlabs</groupId>
       <artifactId>axelix-spring-boot-2-starter</artifactId>
-      <version>1.0.0-M2</version>
+      <version>1.0.0-SNAPSHOT</version>
     </dependency>
 
     <!-- Databases - Uses H2 by default -->
@@ -331,18 +331,6 @@
       <id>spring-milestones</id>
       <name>Spring Milestones</name>
       <url>https://repo.spring.io/milestone</url>
-    </repository>
-    <repository>
-      <id>nucleon-forge-axelix</id>
-      <name>Nucleon Forge Axelix</name>
-      <url>https://${env.NEXUS_HOST_PORT}/repository/axile-monorepo/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
     </repository>
   </repositories>
   <pluginRepositories>

--- a/playgrounds/spring-petclinic-maven-sb-2/settings.xml
+++ b/playgrounds/spring-petclinic-maven-sb-2/settings.xml
@@ -1,9 +1,0 @@
-<settings>
-	<servers>
-		<server>
-			<id>nucleon-forge-axelix</id>
-			<username>${env.NEXUS_USER}</username>
-			<password>${env.NEXUS_PASSWORD}</password>
-		</server>
-	</servers>
-</settings>

--- a/playgrounds/spring-petclinic-maven-sb-2/src/test/resources/application.properties
+++ b/playgrounds/spring-petclinic-maven-sb-2/src/test/resources/application.properties
@@ -1,0 +1,18 @@
+# AXELIX
+axelix.sbs.auth.jwt.algorithm=HMAC512
+axelix.sbs.auth.jwt.signing-key=22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
+
+# database init, supports mysql too
+database=h2
+spring.sql.init.schema-locations=classpath*:db/${database}/schema.sql
+spring.sql.init.data-locations=classpath*:db/${database}/data.sql
+
+# JPA
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.open-in-view=false
+
+# Internationalization
+spring.messages.basename=messages/messages
+
+# Actuator
+management.endpoints.web.exposure.include=*


### PR DESCRIPTION
close #1320 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded coverage for additional Gradle-based playgrounds and added corresponding deploy targets.
  * Updated PR build orchestration to build Spring Boot 2/3 playgrounds together in a single run when triggered.
* **Bug Fixes**
  * Removed Nexus deployment/publishing from the master build flow and stopped injecting Nexus credentials in deploy-test builds.
* **Tests**
  * Added/extended playground test configurations (`application.properties`) including JWT, Actuator exposure, DB initialization (H2/MySQL/Postgres), and Kafka settings.
* **Chores**
  * Refreshed build orchestration (Makefile target/flag defaults), updated Gradle wrapper, and switched playground packaging/versioning to snapshot artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->