### PR TITLE
GH-1325 Disallow overriding beans in `AxelixLoggersEndpointAutoConfiguration`

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixLoggersEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixLoggersEndpointAutoConfiguration.java
@@ -18,9 +18,9 @@
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.logging.LoggingApplicationListener;
 import org.springframework.boot.logging.LoggerGroups;
 import org.springframework.boot.logging.LoggingSystem;
@@ -37,10 +37,10 @@ import com.axelixlabs.axelix.sbs.spring.core.loggers.LoggersService;
  */
 @AutoConfiguration
 @ConditionalOnBean(LoggingSystem.class)
+@ConditionalOnAvailableEndpoint(endpoint = AxelixLoggersEndpoint.class)
 public class AxelixLoggersEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixLoggersEndpoint axelixLoggersEndpoint(LoggersService loggersService) {
         return new AxelixLoggersEndpoint(loggersService);
     }
@@ -49,7 +49,6 @@ public class AxelixLoggersEndpointAutoConfiguration {
      * {@link LoggingSystem} and {@link LoggerGroups} beans are registered dynamically in {@link LoggingApplicationListener}.
      */
     @Bean
-    @ConditionalOnMissingBean
     public LoggersService loggersService(LoggingSystem loggingSystem, ObjectProvider<LoggerGroups> loggerGroups) {
         return new DefaultLoggersService(loggingSystem, loggerGroups.getIfAvailable(LoggerGroups::new));
     }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixLoggersEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixLoggersEndpointAutoConfigurationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.logging.LoggingSystem;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import com.axelixlabs.axelix.sbs.spring.core.loggers.AxelixLoggersEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.loggers.LoggersService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AxelixLoggersEndpointAutoConfiguration}.
+ *
+ * @since 01.07.2026
+ * @author Sergey Cherkasov
+ */
+class AxelixLoggersEndpointAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-loggers")
+            .withBean(LoggingSystem.class, () -> LoggingSystem.get(getClass().getClassLoader()))
+            .withConfiguration(AutoConfigurations.of(AxelixLoggersEndpointAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(AxelixLoggersEndpointAutoConfiguration.class);
+            assertThat(context).hasSingleBean(AxelixLoggersEndpoint.class);
+            assertThat(context).hasSingleBean(LoggersService.class);
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
+        new ApplicationContextRunner()
+                .withBean(
+                        LoggingSystem.class, () -> LoggingSystem.get(getClass().getClassLoader()))
+                .withConfiguration(AutoConfigurations.of(AxelixLoggersEndpointAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixLoggersEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixLoggersEndpoint.class);
+                    assertThat(context).doesNotHaveBean(LoggersService.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutLoggingSystem() {
+        new ApplicationContextRunner()
+                .withPropertyValues("management.endpoints.web.exposure.include=axelix-loggers")
+                .withConfiguration(AutoConfigurations.of(AxelixLoggersEndpointAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixLoggersEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixLoggersEndpoint.class);
+                    assertThat(context).doesNotHaveBean(LoggersService.class);
+                });
+    }
+}

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -30,6 +30,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointA
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixEnvironmentEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointsConfigurationPropertiesAutoConfiguration;
@@ -69,7 +70,8 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringA
             ShortBuildInfoProviderAutoConfiguration.class,
             ThreadDumpManagementEndpointAutoConfiguration.class,
             TransactionMonitoringAutoConfiguration.class,
-            EndpointsConfigurationPropertiesAutoConfiguration.class
+            EndpointsConfigurationPropertiesAutoConfiguration.class,
+            AxelixLoggersEndpointAutoConfiguration.class
         })
 @EnableCaching
 @EnableFeignClients

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixLoggersEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixLoggersEndpointAutoConfiguration.java
@@ -18,9 +18,9 @@
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.logging.LoggingApplicationListener;
 import org.springframework.boot.logging.LoggerGroups;
 import org.springframework.boot.logging.LoggingSystem;
@@ -37,10 +37,10 @@ import com.axelixlabs.axelix.sbs.spring.core.loggers.LoggersService;
  */
 @AutoConfiguration
 @ConditionalOnBean(LoggingSystem.class)
+@ConditionalOnAvailableEndpoint(endpoint = AxelixLoggersEndpoint.class)
 public class AxelixLoggersEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixLoggersEndpoint axelixLoggersEndpoint(LoggersService loggersService) {
         return new AxelixLoggersEndpoint(loggersService);
     }
@@ -49,7 +49,6 @@ public class AxelixLoggersEndpointAutoConfiguration {
      * {@link LoggingSystem} and {@link LoggerGroups} beans are registered dynamically in {@link LoggingApplicationListener}.
      */
     @Bean
-    @ConditionalOnMissingBean
     public LoggersService loggersService(LoggingSystem loggingSystem, ObjectProvider<LoggerGroups> loggerGroups) {
         return new DefaultLoggersService(loggingSystem, loggerGroups.getIfAvailable(LoggerGroups::new));
     }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixLoggersEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixLoggersEndpointAutoConfigurationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.logging.LoggingSystem;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import com.axelixlabs.axelix.sbs.spring.core.loggers.AxelixLoggersEndpoint;
+import com.axelixlabs.axelix.sbs.spring.core.loggers.LoggersService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link AxelixLoggersEndpointAutoConfiguration}.
+ *
+ * @author Sergey Cherkasov
+ */
+class AxelixLoggersEndpointAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=axelix-loggers")
+            .withBean(LoggingSystem.class, () -> LoggingSystem.get(getClass().getClassLoader()))
+            .withConfiguration(AutoConfigurations.of(AxelixLoggersEndpointAutoConfiguration.class));
+
+    @Test
+    void shouldCreateAllBeansInDefaultScenario() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(AxelixLoggersEndpointAutoConfiguration.class);
+            assertThat(context).hasSingleBean(AxelixLoggersEndpoint.class);
+            assertThat(context).hasSingleBean(LoggersService.class);
+        });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
+        new ApplicationContextRunner()
+                .withBean(
+                        LoggingSystem.class, () -> LoggingSystem.get(getClass().getClassLoader()))
+                .withConfiguration(AutoConfigurations.of(AxelixLoggersEndpointAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixLoggersEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixLoggersEndpoint.class);
+                    assertThat(context).doesNotHaveBean(LoggersService.class);
+                });
+    }
+
+    @Test
+    void shouldNotActivateAutoConfigurationWithoutLoggingSystem() {
+        new ApplicationContextRunner()
+                .withPropertyValues("management.endpoints.web.exposure.include=axelix-loggers")
+                .withConfiguration(AutoConfigurations.of(AxelixLoggersEndpointAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(AxelixLoggersEndpointAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(AxelixLoggersEndpoint.class);
+                    assertThat(context).doesNotHaveBean(LoggersService.class);
+                });
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -31,6 +31,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixEnvironmentEndpo
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixFeignEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointsConfigurationPropertiesAutoConfiguration;
@@ -70,7 +71,8 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringA
             ShortBuildInfoProviderAutoConfiguration.class,
             ThreadDumpManagementEndpointAutoConfiguration.class,
             TransactionMonitoringAutoConfiguration.class,
-            EndpointsConfigurationPropertiesAutoConfiguration.class
+            EndpointsConfigurationPropertiesAutoConfiguration.class,
+            AxelixLoggersEndpointAutoConfiguration.class
         })
 @EnableCaching
 @EnableFeignClients


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic availability of the loggers endpoint so it only appears when the endpoint is exposed and logging support is present.

* **Bug Fixes**
  * Prevented the loggers endpoint and related service from loading in contexts where the endpoint is not enabled.
  * Added coverage for enabled and disabled startup scenarios to ensure consistent behavior.

* **Tests**
  * Added integration tests for Spring Boot 2 and 3 starter behavior around endpoint exposure and logging system availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->