### PR TITLE
(sbs3) Support ignoring architecture tests with @IgnoreArchitectureTest annotation

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/IgnoreArchitectureTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/IgnoreArchitectureTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The annotation must be applied to the test class
+ * to indicate that the arch unit check should ignore this test class.
+ * <p>
+ * When this annotation is applied, the {@link TestContextArchitectureTest} begins to ignore this test class.
+ *
+ * @see TestContextArchitectureTest
+ *
+ * @author Artemiy Degtyarev
+ */
+@Documented
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.CLASS)
+public @interface IgnoreArchitectureTest {}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/TestContextArchitectureTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/TestContextArchitectureTest.java
@@ -17,6 +17,9 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core;
 
+import java.lang.annotation.Annotation;
+import java.util.List;
+
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.autoconfigure.data.cassandra.AutoConfigureDataCassandra;
@@ -64,9 +67,6 @@ import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import java.lang.annotation.Annotation;
-import java.util.List;
-
 /**
  * Tests that check for context pollution in Spring Boot tests
  *
@@ -85,51 +85,50 @@ public class TestContextArchitectureTest {
      * not used in places where they would compromise context reuse or isolation.
      */
     public static final List<Class<? extends Annotation>> RESTRICTED_TYPE_ANNOTATIONS = List.of(
-        ContextConfiguration.class,
-        ActiveProfiles.class,
-        ContextHierarchy.class,
-        TestPropertySource.class,
-        WebAppConfiguration.class,
-        SpringBootTest.class,
-        Import.class,
-        AutoConfigureMockMvc.class,
-        WebMvcTest.class,
-        AutoConfigureWebTestClient.class,
-        DirtiesContext.class,
-        AutoConfigureObservability.class,
-        JsonTest.class,
-        AutoConfigureJsonTesters.class,
-        WebFluxTest.class,
-        GraphQlTest.class,
-        AutoConfigureGraphQlTester.class,
-        DataCassandraTest.class,
-        AutoConfigureDataCassandra.class,
-        DataCouchbaseTest.class,
-        AutoConfigureDataCouchbase.class,
-        DataElasticsearchTest.class,
-        AutoConfigureDataElasticsearch.class,
-        DataJpaTest.class,
-        AutoConfigureDataJpa.class,
-        DataJdbcTest.class,
-        AutoConfigureDataJdbc.class,
-        JdbcTest.class,
-        AutoConfigureJdbc.class,
-        DataR2dbcTest.class,
-        AutoConfigureDataR2dbc.class,
-        JooqTest.class,
-        AutoConfigureJooq.class,
-        DataMongoTest.class,
-        AutoConfigureDataMongo.class,
-        DataNeo4jTest.class,
-        AutoConfigureDataNeo4j.class,
-        DataRedisTest.class,
-        AutoConfigureDataRedis.class,
-        DataLdapTest.class,
-        AutoConfigureDataLdap.class,
-        RestClientTest.class,
-        AutoConfigureMockRestServiceServer.class,
-        AutoConfigureRestDocs.class,
-        WebServiceClientTest.class,
-        ImportAutoConfiguration.class
-    );
+            ContextConfiguration.class,
+            ActiveProfiles.class,
+            ContextHierarchy.class,
+            TestPropertySource.class,
+            WebAppConfiguration.class,
+            SpringBootTest.class,
+            Import.class,
+            AutoConfigureMockMvc.class,
+            WebMvcTest.class,
+            AutoConfigureWebTestClient.class,
+            DirtiesContext.class,
+            AutoConfigureObservability.class,
+            JsonTest.class,
+            AutoConfigureJsonTesters.class,
+            WebFluxTest.class,
+            GraphQlTest.class,
+            AutoConfigureGraphQlTester.class,
+            DataCassandraTest.class,
+            AutoConfigureDataCassandra.class,
+            DataCouchbaseTest.class,
+            AutoConfigureDataCouchbase.class,
+            DataElasticsearchTest.class,
+            AutoConfigureDataElasticsearch.class,
+            DataJpaTest.class,
+            AutoConfigureDataJpa.class,
+            DataJdbcTest.class,
+            AutoConfigureDataJdbc.class,
+            JdbcTest.class,
+            AutoConfigureJdbc.class,
+            DataR2dbcTest.class,
+            AutoConfigureDataR2dbc.class,
+            JooqTest.class,
+            AutoConfigureJooq.class,
+            DataMongoTest.class,
+            AutoConfigureDataMongo.class,
+            DataNeo4jTest.class,
+            AutoConfigureDataNeo4j.class,
+            DataRedisTest.class,
+            AutoConfigureDataRedis.class,
+            DataLdapTest.class,
+            AutoConfigureDataLdap.class,
+            RestClientTest.class,
+            AutoConfigureMockRestServiceServer.class,
+            AutoConfigureRestDocs.class,
+            WebServiceClientTest.class,
+            ImportAutoConfiguration.class);
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
@@ -58,6 +58,7 @@ import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.common.auth.core.User;
 import com.axelixlabs.axelix.common.auth.service.DefaultJwtEncoderService;
 import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
+import com.axelixlabs.axelix.sbs.spring.core.IgnoreArchitectureTest;
 import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthorizationFilterTest.JwtAuthorizationFilterTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpoint;
 import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
@@ -103,6 +104,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     EnvironmentTestConfig.class,
     JwtAuthTestConfiguration.class
 })
+@IgnoreArchitectureTest
 class JwtAuthorizationFilterTest {
 
     private static final String USER_NAME = "testUser";

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
@@ -51,6 +51,7 @@ import org.springframework.http.ResponseEntity;
 import com.axelixlabs.axelix.common.api.caches.CachesFeed;
 import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheDto;
 import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheManagerDto;
+import com.axelixlabs.axelix.sbs.spring.core.IgnoreArchitectureTest;
 import com.axelixlabs.axelix.sbs.spring.core.Main;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
@@ -78,6 +79,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     DefaultCacheOperationsDispatcher.class,
     AxelixCachesEndpointTest.CacheDispatcherEndpointTestConfiguration.class
 })
+@IgnoreArchitectureTest
 class AxelixCachesEndpointTest {
 
     // Cache names under test

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpointTest.java
@@ -32,6 +32,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import com.axelixlabs.axelix.common.api.ConditionsFeed;
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.IgnoreArchitectureTest;
 import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
@@ -46,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"axelix.prop.test.name=axelix-beans", "axelix.conditions.test.flag=enabled"})
 @Import(JwtAuthTestConfiguration.class)
+@IgnoreArchitectureTest
 public class AxelixConditionsEndpointTest {
 
     @Autowired

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/gclog/AxelixGcEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/gclog/AxelixGcEndpointTest.java
@@ -40,6 +40,7 @@ import org.springframework.http.ResponseEntity;
 import com.axelixlabs.axelix.common.api.gclog.GcLogEnableRequest;
 import com.axelixlabs.axelix.common.api.gclog.GcLogStatus;
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.IgnoreArchitectureTest;
 import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.gclog.AxelixGcEndpointTest.AxelixGcEndpointTestTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.log.SLF4JLogger;
@@ -50,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import({AxelixGcEndpointTestTestConfiguration.class, JwtAuthTestConfiguration.class})
+@IgnoreArchitectureTest
 class AxelixGcEndpointTest {
 
     @Autowired

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/integrations/feign/AxelixFeignEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/integrations/feign/AxelixFeignEndpointTest.java
@@ -44,6 +44,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.axelixlabs.axelix.common.api.integration.FeignIntegration;
 import com.axelixlabs.axelix.common.domain.http.HttpVersion;
+import com.axelixlabs.axelix.sbs.spring.core.IgnoreArchitectureTest;
 import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.integrations.feign.AxelixFeignEndpointTest.AxelixFeignEndpointTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
@@ -60,6 +61,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         properties = "management.endpoints.web.exposure.include=axelix-feign")
 @Import({AxelixFeignEndpointTestConfiguration.class, JwtAuthTestConfiguration.class})
+@IgnoreArchitectureTest
 public class AxelixFeignEndpointTest {
 
     private static final String SERVICE_WITH_PATH_IN_FEIGN_ANNOTATION = "service-1";

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/loggers/AxelixLoggersEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/loggers/AxelixLoggersEndpointTest.java
@@ -47,6 +47,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import com.axelixlabs.axelix.common.api.loggers.SingleLoggerProfile;
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.IgnoreArchitectureTest;
 import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.loggers.AxelixLoggersEndpointTest.AxelixLoggersEndpointTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
@@ -70,6 +71,7 @@ import static org.assertj.core.api.Assertions.assertThat;
             "logging.level.a.b.c.d.e=DEBUG"
         })
 @Import({AxelixLoggersEndpointTestConfiguration.class, JwtAuthTestConfiguration.class})
+@IgnoreArchitectureTest
 public class AxelixLoggersEndpointTest {
 
     @Autowired

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpointTest.java
@@ -51,6 +51,7 @@ import com.axelixlabs.axelix.common.api.scheduledtask.ScheduledTaskExecuteReques
 import com.axelixlabs.axelix.common.api.scheduledtask.ScheduledTaskIntervalModifyRequest;
 import com.axelixlabs.axelix.common.api.scheduledtask.ScheduledTaskToggleRequest;
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.IgnoreArchitectureTest;
 import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpointTest.AxelixScheduledTasksEndpointTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
@@ -71,6 +72,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"management.endpoints.web.exposure.include=axelix-scheduled-tasks"})
 @Import({AxelixScheduledTasksEndpointTestConfiguration.class, JwtAuthTestConfiguration.class})
+@IgnoreArchitectureTest
 class AxelixScheduledTasksEndpointTest {
 
     // Cron

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskServiceTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskServiceTest.java
@@ -43,6 +43,8 @@ import org.springframework.scheduling.config.IntervalTask;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.scheduling.support.CronTrigger;
 
+import com.axelixlabs.axelix.sbs.spring.core.IgnoreArchitectureTest;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -54,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringBootTest
 @Import(ScheduledTaskServiceTest.ScheduledTaskServiceTestConfiguration.class)
+@IgnoreArchitectureTest
 class ScheduledTaskServiceTest {
 
     // Cron

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistryTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistryTest.java
@@ -43,6 +43,8 @@ import org.springframework.scheduling.config.ScheduledTask;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.scheduling.config.TriggerTask;
 
+import com.axelixlabs.axelix.sbs.spring.core.IgnoreArchitectureTest;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -53,6 +55,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringBootTest
 @Import(ScheduledTasksRegistryTest.ScheduledTaskRegistryTestConfiguration.class)
+@IgnoreArchitectureTest
 class ScheduledTasksRegistryTest {
 
     private static final String CRON_TASK_ID = ScheduledTaskRegistryTestConfiguration.class.getName() + ".testCronTask";

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpointTest.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
 
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
+import com.axelixlabs.axelix.sbs.spring.core.IgnoreArchitectureTest;
 import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.utils.auth.ProtectedEndpointTests;
@@ -44,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(JwtAuthTestConfiguration.class)
+@IgnoreArchitectureTest
 public class ThreadDumpManagementEndpointTest {
 
     @Autowired


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated several test suites so they’re excluded from architecture checks, helping prevent unrelated test failures and improving overall build reliability.
* **Chores**
  * Added a new test-only annotation to make these exclusions easier to apply consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->