### PR TITLE
GH-1333 Disallow overriding beans in `AxelixGcEndpointAutoConfiguration` and `ScheduledTaskManagementAutoConfiguration`

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixGcEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixGcEndpointAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.gclog.AxelixGcEndpoint;
@@ -39,7 +38,6 @@ import com.axelixlabs.axelix.sbs.spring.core.gclog.GcLogService;
 public class AxelixGcEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixGcEndpoint axelixGcEndpoint(GcLogService gcLogService) {
         return new AxelixGcEndpoint(gcLogService);
     }

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -24,7 +24,6 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -52,13 +51,11 @@ import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskReschedul
 public class ScheduledTaskManagementAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public ScheduledTasksRegistry scheduledTasksRegistry(ObjectProvider<ScheduledTaskHolder> taskHolders) {
         return new ScheduledTasksRegistry(taskHolders.orderedStream().collect(Collectors.toList()));
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public ScheduledTaskService scheduledTaskService(
             ScheduledTasksRegistry scheduledTasksRegistry,
             List<TaskRescheduler> taskReschedulers,
@@ -82,14 +79,12 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixScheduledTasksEndpoint axelixScheduledTasksEndpoint(
             ScheduledTaskService service, ScheduledTasksAssembler scheduledTasksAssembler) {
         return new AxelixScheduledTasksEndpoint(service, scheduledTasksAssembler);
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public ScheduledTasksAssembler scheduledTasksAssembler(ScheduledTasksRegistry scheduledTasksRegistry) {
         return new DefaultScheduledTasksAssembler(scheduledTasksRegistry);
     }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixGcEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixGcEndpointAutoConfigurationTest.java
@@ -18,18 +18,13 @@
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.gclog.AxelixGcEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.gclog.DefaultGcLogService;
 import com.axelixlabs.axelix.sbs.spring.core.gclog.GcLogService;
 import com.axelixlabs.axelix.sbs.spring.core.gclog.JcmdExecutor;
-import com.axelixlabs.axelix.sbs.spring.core.log.SLF4JLogger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -78,58 +73,5 @@ class AxelixGcEndpointAutoConfigurationTest {
                     assertThat(context).hasSingleBean(JcmdExecutor.class);
                     assertThat(context).hasSingleBean(GcLogService.class);
                 });
-    }
-
-    @Test
-    void shouldHandleMultipleCustomBeans() {
-        contextRunner
-                .withUserConfiguration(
-                        CustomJcmdExecutorConfig.class,
-                        CustomGcLogServiceConfig.class,
-                        CustomAxelixGcEndpointConfig.class)
-                .run(context -> {
-                    assertThat(context.getBean(JcmdExecutor.class)).isExactlyInstanceOf(CustomJcmdExecutor.class);
-                    assertThat(context.getBean(GcLogService.class)).isExactlyInstanceOf(CustomGcLogService.class);
-                    assertThat(context.getBean(AxelixGcEndpoint.class))
-                            .isExactlyInstanceOf(CustomAxelixGcEndpoint.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomJcmdExecutorConfig {
-        @Bean
-        public JcmdExecutor jcmdExecutor() {
-            return new CustomJcmdExecutor();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomGcLogServiceConfig {
-        @Bean
-        public GcLogService gcLogService(JcmdExecutor jcmdExecutor) {
-            return new CustomGcLogService(jcmdExecutor);
-        }
-    }
-
-    @TestConfiguration
-    static class CustomAxelixGcEndpointConfig {
-        @Bean
-        public AxelixGcEndpoint axelixGcEndpoint(GcLogService gcLogService) {
-            return new CustomAxelixGcEndpoint(gcLogService);
-        }
-    }
-
-    static class CustomJcmdExecutor extends JcmdExecutor {}
-
-    static class CustomGcLogService extends DefaultGcLogService {
-        public CustomGcLogService(JcmdExecutor jcmdExecutor) {
-            super(jcmdExecutor, new SLF4JLogger(LoggerFactory.getLogger(DefaultGcLogService.class)));
-        }
-    }
-
-    static class CustomAxelixGcEndpoint extends AxelixGcEndpoint {
-        public CustomAxelixGcEndpoint(GcLogService gcLogService) {
-            super(gcLogService);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -17,12 +17,8 @@
  */
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -30,10 +26,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.scheduling.config.ScheduledTaskHolder;
 
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.DefaultScheduledTasksAssembler;
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.IntervalBasedTaskRescheduler;
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTaskService;
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksAssembler;
@@ -100,23 +94,6 @@ class ScheduledTaskManagementAutoConfigurationTest {
                 });
     }
 
-    @Test
-    void shouldHandleMultipleCustomBeans() {
-        contextRunner
-                .withUserConfiguration(
-                        CustomAxelixScheduledTasksEndpointConfig.class,
-                        CustomScheduledTasksAssemblerConfig.class,
-                        CustomScheduledTasksRegistryConfig.class)
-                .run(context -> {
-                    assertThat(context.getBean(ScheduledTasksRegistry.class))
-                            .isExactlyInstanceOf(CustomScheduledTasksRegistry.class);
-                    assertThat(context.getBean(ScheduledTasksAssembler.class))
-                            .isExactlyInstanceOf(CustomScheduledTasksAssembler.class);
-                    assertThat(context.getBean(AxelixScheduledTasksEndpoint.class))
-                            .isExactlyInstanceOf(CustomAxelixScheduledTasksEndpoint.class);
-                });
-    }
-
     @TestConfiguration
     @EnableScheduling
     static class EnableSchedulingConfig {
@@ -124,49 +101,6 @@ class ScheduledTaskManagementAutoConfigurationTest {
         @Bean
         public TaskScheduler taskScheduler() {
             return new ThreadPoolTaskScheduler();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomScheduledTasksRegistryConfig {
-        @Bean
-        public ScheduledTasksRegistry scheduledTasksRegistry(ObjectProvider<ScheduledTaskHolder> taskHolders) {
-            return new CustomScheduledTasksRegistry(taskHolders.orderedStream().collect(Collectors.toList()));
-        }
-    }
-
-    @TestConfiguration
-    static class CustomScheduledTasksAssemblerConfig {
-        @Bean
-        public ScheduledTasksAssembler scheduledTasksAssembler(ScheduledTasksRegistry registry) {
-            return new CustomScheduledTasksAssembler(registry);
-        }
-    }
-
-    @TestConfiguration
-    static class CustomAxelixScheduledTasksEndpointConfig {
-        @Bean
-        public AxelixScheduledTasksEndpoint axelixScheduledTasksEndpoint(
-                ScheduledTaskService service, ScheduledTasksAssembler assembler) {
-            return new CustomAxelixScheduledTasksEndpoint(service, assembler);
-        }
-    }
-
-    static class CustomScheduledTasksRegistry extends ScheduledTasksRegistry {
-        public CustomScheduledTasksRegistry(List<ScheduledTaskHolder> taskHolders) {
-            super(taskHolders);
-        }
-    }
-
-    static class CustomScheduledTasksAssembler extends DefaultScheduledTasksAssembler {
-        public CustomScheduledTasksAssembler(ScheduledTasksRegistry registry) {
-            super(registry);
-        }
-    }
-
-    static class CustomAxelixScheduledTasksEndpoint extends AxelixScheduledTasksEndpoint {
-        public CustomAxelixScheduledTasksEndpoint(ScheduledTaskService service, ScheduledTasksAssembler assembler) {
-            super(service, assembler);
         }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixGcEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixGcEndpointAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.gclog.AxelixGcEndpoint;
@@ -39,7 +38,6 @@ import com.axelixlabs.axelix.sbs.spring.core.gclog.GcLogService;
 public class AxelixGcEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixGcEndpoint axelixGcEndpoint(GcLogService gcLogService) {
         return new AxelixGcEndpoint(gcLogService);
     }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -51,13 +50,11 @@ import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskReschedul
 public class ScheduledTaskManagementAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public ScheduledTasksRegistry scheduledTasksRegistry(ObjectProvider<ScheduledTaskHolder> taskHolders) {
         return new ScheduledTasksRegistry(taskHolders.orderedStream().toList());
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public ScheduledTaskService scheduledTaskService(
             ScheduledTasksRegistry scheduledTasksRegistry,
             List<TaskRescheduler> taskReschedulers,
@@ -81,14 +78,12 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixScheduledTasksEndpoint axelixScheduledTasksEndpoint(
             ScheduledTaskService service, ScheduledTasksAssembler scheduledTasksAssembler) {
         return new AxelixScheduledTasksEndpoint(service, scheduledTasksAssembler);
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public ScheduledTasksAssembler scheduledTasksAssembler(ScheduledTasksRegistry scheduledTasksRegistry) {
         return new DefaultScheduledTasksAssembler(scheduledTasksRegistry);
     }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixGcEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixGcEndpointAutoConfigurationTest.java
@@ -18,18 +18,13 @@
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.gclog.AxelixGcEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.gclog.DefaultGcLogService;
 import com.axelixlabs.axelix.sbs.spring.core.gclog.GcLogService;
 import com.axelixlabs.axelix.sbs.spring.core.gclog.JcmdExecutor;
-import com.axelixlabs.axelix.sbs.spring.core.log.SLF4JLogger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -78,58 +73,5 @@ class AxelixGcEndpointAutoConfigurationTest {
                     assertThat(context).hasSingleBean(JcmdExecutor.class);
                     assertThat(context).hasSingleBean(GcLogService.class);
                 });
-    }
-
-    @Test
-    void shouldHandleMultipleCustomBeans() {
-        contextRunner
-                .withUserConfiguration(
-                        CustomJcmdExecutorConfig.class,
-                        CustomGcLogServiceConfig.class,
-                        CustomAxelixGcEndpointConfig.class)
-                .run(context -> {
-                    assertThat(context.getBean(JcmdExecutor.class)).isExactlyInstanceOf(CustomJcmdExecutor.class);
-                    assertThat(context.getBean(GcLogService.class)).isExactlyInstanceOf(CustomGcLogService.class);
-                    assertThat(context.getBean(AxelixGcEndpoint.class))
-                            .isExactlyInstanceOf(CustomAxelixGcEndpoint.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomJcmdExecutorConfig {
-        @Bean
-        public JcmdExecutor jcmdExecutor() {
-            return new CustomJcmdExecutor();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomGcLogServiceConfig {
-        @Bean
-        public GcLogService gcLogService(JcmdExecutor jcmdExecutor) {
-            return new CustomGcLogService(jcmdExecutor);
-        }
-    }
-
-    @TestConfiguration
-    static class CustomAxelixGcEndpointConfig {
-        @Bean
-        public AxelixGcEndpoint axelixGcEndpoint(GcLogService gcLogService) {
-            return new CustomAxelixGcEndpoint(gcLogService);
-        }
-    }
-
-    static class CustomJcmdExecutor extends JcmdExecutor {}
-
-    static class CustomGcLogService extends DefaultGcLogService {
-        public CustomGcLogService(JcmdExecutor jcmdExecutor) {
-            super(jcmdExecutor, new SLF4JLogger(LoggerFactory.getLogger(DefaultGcLogService.class)));
-        }
-    }
-
-    static class CustomAxelixGcEndpoint extends AxelixGcEndpoint {
-        public CustomAxelixGcEndpoint(GcLogService gcLogService) {
-            super(gcLogService);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -17,11 +17,8 @@
  */
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -29,10 +26,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.scheduling.config.ScheduledTaskHolder;
 
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.DefaultScheduledTasksAssembler;
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.IntervalBasedTaskRescheduler;
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTaskService;
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksAssembler;
@@ -99,23 +94,6 @@ class ScheduledTaskManagementAutoConfigurationTest {
                 });
     }
 
-    @Test
-    void shouldHandleMultipleCustomBeans() {
-        contextRunner
-                .withUserConfiguration(
-                        CustomAxelixScheduledTasksEndpointConfig.class,
-                        CustomScheduledTasksAssemblerConfig.class,
-                        CustomScheduledTasksRegistryConfig.class)
-                .run(context -> {
-                    assertThat(context.getBean(ScheduledTasksRegistry.class))
-                            .isExactlyInstanceOf(CustomScheduledTasksRegistry.class);
-                    assertThat(context.getBean(ScheduledTasksAssembler.class))
-                            .isExactlyInstanceOf(CustomScheduledTasksAssembler.class);
-                    assertThat(context.getBean(AxelixScheduledTasksEndpoint.class))
-                            .isExactlyInstanceOf(CustomAxelixScheduledTasksEndpoint.class);
-                });
-    }
-
     @TestConfiguration
     @EnableScheduling
     static class EnableSchedulingConfig {
@@ -123,49 +101,6 @@ class ScheduledTaskManagementAutoConfigurationTest {
         @Bean
         public TaskScheduler taskScheduler() {
             return new ThreadPoolTaskScheduler();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomScheduledTasksRegistryConfig {
-        @Bean
-        public ScheduledTasksRegistry scheduledTasksRegistry(ObjectProvider<ScheduledTaskHolder> taskHolders) {
-            return new CustomScheduledTasksRegistry(taskHolders.orderedStream().toList());
-        }
-    }
-
-    @TestConfiguration
-    static class CustomScheduledTasksAssemblerConfig {
-        @Bean
-        public ScheduledTasksAssembler scheduledTasksAssembler(ScheduledTasksRegistry registry) {
-            return new CustomScheduledTasksAssembler(registry);
-        }
-    }
-
-    @TestConfiguration
-    static class CustomAxelixScheduledTasksEndpointConfig {
-        @Bean
-        public AxelixScheduledTasksEndpoint axelixScheduledTasksEndpoint(
-                ScheduledTaskService service, ScheduledTasksAssembler assembler) {
-            return new CustomAxelixScheduledTasksEndpoint(service, assembler);
-        }
-    }
-
-    static class CustomScheduledTasksRegistry extends ScheduledTasksRegistry {
-        public CustomScheduledTasksRegistry(List<ScheduledTaskHolder> taskHolders) {
-            super(taskHolders);
-        }
-    }
-
-    static class CustomScheduledTasksAssembler extends DefaultScheduledTasksAssembler {
-        public CustomScheduledTasksAssembler(ScheduledTasksRegistry registry) {
-            super(registry);
-        }
-    }
-
-    static class CustomAxelixScheduledTasksEndpoint extends AxelixScheduledTasksEndpoint {
-        public CustomAxelixScheduledTasksEndpoint(ScheduledTaskService service, ScheduledTasksAssembler assembler) {
-            super(service, assembler);
         }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/TestContextArchitectureTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/TestContextArchitectureTest.java
@@ -17,6 +17,9 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core;
 
+import java.lang.annotation.Annotation;
+import java.util.List;
+
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.autoconfigure.data.cassandra.AutoConfigureDataCassandra;
@@ -64,9 +67,6 @@ import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import java.lang.annotation.Annotation;
-import java.util.List;
-
 /**
  * Tests that check for context pollution in Spring Boot tests
  *
@@ -85,51 +85,50 @@ public class TestContextArchitectureTest {
      * not used in places where they would compromise context reuse or isolation.
      */
     public static final List<Class<? extends Annotation>> RESTRICTED_TYPE_ANNOTATIONS = List.of(
-        ContextConfiguration.class,
-        ActiveProfiles.class,
-        ContextHierarchy.class,
-        TestPropertySource.class,
-        WebAppConfiguration.class,
-        SpringBootTest.class,
-        Import.class,
-        AutoConfigureMockMvc.class,
-        WebMvcTest.class,
-        AutoConfigureWebTestClient.class,
-        DirtiesContext.class,
-        AutoConfigureObservability.class,
-        JsonTest.class,
-        AutoConfigureJsonTesters.class,
-        WebFluxTest.class,
-        GraphQlTest.class,
-        AutoConfigureGraphQlTester.class,
-        DataCassandraTest.class,
-        AutoConfigureDataCassandra.class,
-        DataCouchbaseTest.class,
-        AutoConfigureDataCouchbase.class,
-        DataElasticsearchTest.class,
-        AutoConfigureDataElasticsearch.class,
-        DataJpaTest.class,
-        AutoConfigureDataJpa.class,
-        DataJdbcTest.class,
-        AutoConfigureDataJdbc.class,
-        JdbcTest.class,
-        AutoConfigureJdbc.class,
-        DataR2dbcTest.class,
-        AutoConfigureDataR2dbc.class,
-        JooqTest.class,
-        AutoConfigureJooq.class,
-        DataMongoTest.class,
-        AutoConfigureDataMongo.class,
-        DataNeo4jTest.class,
-        AutoConfigureDataNeo4j.class,
-        DataRedisTest.class,
-        AutoConfigureDataRedis.class,
-        DataLdapTest.class,
-        AutoConfigureDataLdap.class,
-        RestClientTest.class,
-        AutoConfigureMockRestServiceServer.class,
-        AutoConfigureRestDocs.class,
-        WebServiceClientTest.class,
-        ImportAutoConfiguration.class
-    );
+            ContextConfiguration.class,
+            ActiveProfiles.class,
+            ContextHierarchy.class,
+            TestPropertySource.class,
+            WebAppConfiguration.class,
+            SpringBootTest.class,
+            Import.class,
+            AutoConfigureMockMvc.class,
+            WebMvcTest.class,
+            AutoConfigureWebTestClient.class,
+            DirtiesContext.class,
+            AutoConfigureObservability.class,
+            JsonTest.class,
+            AutoConfigureJsonTesters.class,
+            WebFluxTest.class,
+            GraphQlTest.class,
+            AutoConfigureGraphQlTester.class,
+            DataCassandraTest.class,
+            AutoConfigureDataCassandra.class,
+            DataCouchbaseTest.class,
+            AutoConfigureDataCouchbase.class,
+            DataElasticsearchTest.class,
+            AutoConfigureDataElasticsearch.class,
+            DataJpaTest.class,
+            AutoConfigureDataJpa.class,
+            DataJdbcTest.class,
+            AutoConfigureDataJdbc.class,
+            JdbcTest.class,
+            AutoConfigureJdbc.class,
+            DataR2dbcTest.class,
+            AutoConfigureDataR2dbc.class,
+            JooqTest.class,
+            AutoConfigureJooq.class,
+            DataMongoTest.class,
+            AutoConfigureDataMongo.class,
+            DataNeo4jTest.class,
+            AutoConfigureDataNeo4j.class,
+            DataRedisTest.class,
+            AutoConfigureDataRedis.class,
+            DataLdapTest.class,
+            AutoConfigureDataLdap.class,
+            RestClientTest.class,
+            AutoConfigureMockRestServiceServer.class,
+            AutoConfigureRestDocs.class,
+            WebServiceClientTest.class,
+            ImportAutoConfiguration.class);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint auto-configuration so the GC endpoint is created consistently when the app supports it.
  * Simplified test coverage and formatting for better maintainability without changing behavior.

* **Tests**
  * Updated automated tests to focus on the core default, disabled, and missing-property scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->