### PR TITLE
GH-1337 Disallow overriding beans in  `ThreadDumpManagementEndpoint`, `AxelixFeignEndpoint` and  `EndpointsConfigurationPropertiesAutoConfiguratio`

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/EndpointsConfigurationPropertiesAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/EndpointsConfigurationPropertiesAutoConfiguration.java
@@ -18,7 +18,6 @@
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
@@ -33,7 +32,6 @@ import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProper
 public class EndpointsConfigurationPropertiesAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     @ConfigurationProperties(prefix = "axelix.sbs.endpoints.config")
     public EndpointsConfigurationProperties endpointsConfigurationProperties() {
         return new EndpointsConfigurationProperties();

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ThreadDumpManagementEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ThreadDumpManagementEndpointAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.threaddump.DefaultThreadDumpContentionMonitoringManagement;
@@ -36,13 +35,11 @@ import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpManagementEndp
 public class ThreadDumpManagementEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement() {
         return new DefaultThreadDumpContentionMonitoringManagement();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public ThreadDumpManagementEndpoint threadDumpManagementEndpoint(
             ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement) {
         return new ThreadDumpManagementEndpoint(threadDumpContentionMonitoringManagement);

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ThreadDumpManagementEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ThreadDumpManagementEndpointAutoConfigurationTest.java
@@ -20,9 +20,7 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.threaddump.DefaultThreadDumpContentionMonitoringManagement;
 import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpContentionMonitoringManagement;
@@ -73,62 +71,5 @@ class ThreadDumpManagementEndpointAutoConfigurationTest {
                     assertThat(context).doesNotHaveBean(ThreadDumpContentionMonitoringManagement.class);
                     assertThat(context).doesNotHaveBean(ThreadDumpManagementEndpoint.class);
                 });
-    }
-
-    @Test
-    void shouldNotCreateDefaultThreadDumpContentionMonitoringManagement_whenCustomBeanProvided() {
-        contextRunner
-                .withUserConfiguration(CustomThreadDumpManagementConfig.class)
-                .run(context -> {
-                    assertThat(context).hasSingleBean(ThreadDumpContentionMonitoringManagement.class);
-                    assertThat(context.getBean(ThreadDumpContentionMonitoringManagement.class))
-                            .isExactlyInstanceOf(CustomThreadDumpContentionMonitoringManagement.class);
-
-                    // Endpoint should still be created with custom management bean
-                    assertThat(context).hasSingleBean(ThreadDumpManagementEndpoint.class);
-                });
-    }
-
-    @Test
-    void shouldNotCreateDefaultThreadDumpManagementEndpoint_whenCustomBeanProvided() {
-        contextRunner
-                .withUserConfiguration(CustomThreadDumpEndpointConfig.class)
-                .run(context -> {
-                    assertThat(context).hasSingleBean(ThreadDumpManagementEndpoint.class);
-                    assertThat(context.getBean(ThreadDumpManagementEndpoint.class))
-                            .isExactlyInstanceOf(CustomThreadDumpManagementEndpoint.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomThreadDumpManagementConfig {
-        @Bean
-        public ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement() {
-            return new CustomThreadDumpContentionMonitoringManagement();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomThreadDumpEndpointConfig {
-        @Bean
-        public ThreadDumpManagementEndpoint threadDumpManagementEndpoint(
-                ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement) {
-            return new CustomThreadDumpManagementEndpoint(threadDumpContentionMonitoringManagement);
-        }
-    }
-
-    static class CustomThreadDumpContentionMonitoringManagement implements ThreadDumpContentionMonitoringManagement {
-        @Override
-        public void enable() {}
-
-        @Override
-        public void disable() {}
-    }
-
-    static class CustomThreadDumpManagementEndpoint extends ThreadDumpManagementEndpoint {
-        public CustomThreadDumpManagementEndpoint(
-                ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement) {
-            super(threadDumpContentionMonitoringManagement);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixFeignEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixFeignEndpointAutoConfiguration.java
@@ -24,7 +24,6 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.condition.Conditi
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.cloud.openfeign.FeignClientFactoryBean;
@@ -50,7 +49,6 @@ import com.axelixlabs.axelix.sbs.spring.core.integrations.feign.NoOpDiscoveryCli
 public class AxelixFeignEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public FeignClientIntegrationDiscoverer feignClientIntegrationDiscoverer(
             ApplicationContext applicationContext, ObjectProvider<DiscoveryClient> discoveryClientProvider) {
         DiscoveryClient discoveryClient = discoveryClientProvider.getIfAvailable(NoOpDiscoveryClient::new);
@@ -58,7 +56,6 @@ public class AxelixFeignEndpointAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixFeignEndpoint axelixFeignEndpoint(FeignClientIntegrationDiscoverer discoverer) {
         return new AxelixFeignEndpoint(discoverer);
     }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/EndpointsConfigurationPropertiesAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/EndpointsConfigurationPropertiesAutoConfiguration.java
@@ -18,7 +18,6 @@
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
@@ -33,7 +32,6 @@ import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProper
 public class EndpointsConfigurationPropertiesAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     @ConfigurationProperties(prefix = "axelix.sbs.endpoints.config")
     public EndpointsConfigurationProperties endpointsConfigurationProperties() {
         return new EndpointsConfigurationProperties();

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ThreadDumpManagementEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ThreadDumpManagementEndpointAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.threaddump.DefaultThreadDumpContentionMonitoringManagement;
@@ -36,13 +35,11 @@ import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpManagementEndp
 public class ThreadDumpManagementEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement() {
         return new DefaultThreadDumpContentionMonitoringManagement();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public ThreadDumpManagementEndpoint threadDumpManagementEndpoint(
             ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement) {
         return new ThreadDumpManagementEndpoint(threadDumpContentionMonitoringManagement);

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixFeignEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixFeignEndpointAutoConfigurationTest.java
@@ -17,20 +17,14 @@
  */
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
-import java.util.List;
-
 import feign.Feign;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.openfeign.FeignClientFactoryBean;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.axelixlabs.axelix.sbs.spring.core.integrations.feign.AxelixFeignEndpoint;
@@ -103,66 +97,5 @@ class AxelixFeignEndpointAutoConfigurationTest {
             assertThat(context).doesNotHaveBean(AxelixFeignEndpoint.class);
             assertThat(context).doesNotHaveBean(FeignClientIntegrationDiscoverer.class);
         });
-    }
-
-    @Test
-    void shouldHandleMultipleCustomBeans() {
-        contextRunner
-                .withUserConfiguration(
-                        CustomFeignClientIntegrationDiscovererConfig.class, CustomAxelixFeignEndpointConfig.class)
-                .run(context -> {
-                    assertThat(context.getBean(FeignClientIntegrationDiscoverer.class))
-                            .isExactlyInstanceOf(
-                                    AxelixFeignEndpointAutoConfigurationTest.CustomFeignClientIntegrationDiscoverer
-                                            .class);
-                    assertThat(context.getBean(AxelixFeignEndpoint.class))
-                            .isExactlyInstanceOf(
-                                    AxelixFeignEndpointAutoConfigurationTest.CustomAxelixFeignEndpoint.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomFeignClientIntegrationDiscovererConfig {
-        @Bean
-        public FeignClientIntegrationDiscoverer customFeignClientIntegrationDiscoverer(ApplicationContext context) {
-            return new CustomFeignClientIntegrationDiscoverer(context, new NoOpTestDiscoveryClient());
-        }
-    }
-
-    @TestConfiguration
-    static class CustomAxelixFeignEndpointConfig {
-        @Bean
-        public AxelixFeignEndpoint customAxelixFeignEndpoint(FeignClientIntegrationDiscoverer discoverer) {
-            return new CustomAxelixFeignEndpoint(discoverer);
-        }
-    }
-
-    static final class CustomAxelixFeignEndpoint extends AxelixFeignEndpoint {
-        CustomAxelixFeignEndpoint(FeignClientIntegrationDiscoverer discoverer) {
-            super(discoverer);
-        }
-    }
-
-    static final class CustomFeignClientIntegrationDiscoverer extends FeignClientIntegrationDiscoverer {
-        CustomFeignClientIntegrationDiscoverer(ApplicationContext context, DiscoveryClient discoveryClient) {
-            super(context, discoveryClient);
-        }
-    }
-
-    static final class NoOpTestDiscoveryClient implements DiscoveryClient {
-        @Override
-        public String description() {
-            return "test";
-        }
-
-        @Override
-        public List<ServiceInstance> getInstances(String serviceId) {
-            return List.of();
-        }
-
-        @Override
-        public List<String> getServices() {
-            return List.of();
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ThreadDumpManagementEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ThreadDumpManagementEndpointAutoConfigurationTest.java
@@ -20,9 +20,7 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.threaddump.DefaultThreadDumpContentionMonitoringManagement;
 import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpContentionMonitoringManagement;
@@ -73,62 +71,5 @@ class ThreadDumpManagementEndpointAutoConfigurationTest {
                     assertThat(context).doesNotHaveBean(ThreadDumpContentionMonitoringManagement.class);
                     assertThat(context).doesNotHaveBean(ThreadDumpManagementEndpoint.class);
                 });
-    }
-
-    @Test
-    void shouldNotCreateDefaultThreadDumpContentionMonitoringManagement_whenCustomBeanProvided() {
-        contextRunner
-                .withUserConfiguration(CustomThreadDumpManagementConfig.class)
-                .run(context -> {
-                    assertThat(context).hasSingleBean(ThreadDumpContentionMonitoringManagement.class);
-                    assertThat(context.getBean(ThreadDumpContentionMonitoringManagement.class))
-                            .isExactlyInstanceOf(CustomThreadDumpContentionMonitoringManagement.class);
-
-                    // Endpoint should still be created with custom management bean
-                    assertThat(context).hasSingleBean(ThreadDumpManagementEndpoint.class);
-                });
-    }
-
-    @Test
-    void shouldNotCreateDefaultThreadDumpManagementEndpoint_whenCustomBeanProvided() {
-        contextRunner
-                .withUserConfiguration(CustomThreadDumpEndpointConfig.class)
-                .run(context -> {
-                    assertThat(context).hasSingleBean(ThreadDumpManagementEndpoint.class);
-                    assertThat(context.getBean(ThreadDumpManagementEndpoint.class))
-                            .isExactlyInstanceOf(CustomThreadDumpManagementEndpoint.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomThreadDumpManagementConfig {
-        @Bean
-        public ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement() {
-            return new CustomThreadDumpContentionMonitoringManagement();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomThreadDumpEndpointConfig {
-        @Bean
-        public ThreadDumpManagementEndpoint threadDumpManagementEndpoint(
-                ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement) {
-            return new CustomThreadDumpManagementEndpoint(threadDumpContentionMonitoringManagement);
-        }
-    }
-
-    static class CustomThreadDumpContentionMonitoringManagement implements ThreadDumpContentionMonitoringManagement {
-        @Override
-        public void enable() {}
-
-        @Override
-        public void disable() {}
-    }
-
-    static class CustomThreadDumpManagementEndpoint extends ThreadDumpManagementEndpoint {
-        public CustomThreadDumpManagementEndpoint(
-                ThreadDumpContentionMonitoringManagement threadDumpContentionMonitoringManagement) {
-            super(threadDumpContentionMonitoringManagement);
-        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thread dump management is now consistently available when the endpoint is enabled, even if a custom implementation exists.
  * Updated the behavior across supported Spring Boot starter versions for more predictable endpoint activation.

* **Tests**
  * Simplified test coverage around thread dump auto-configuration.
  * Removed obsolete scenarios and retained the core activation and disabled-endpoint checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->