### PR TITLE
GH-1348 Disallow overriding AutoConfiguration beans in `JwtAuth`, `AxelixConfigurationsProperties`, and `AxelixEnvironmentEndpoint` in spring-boot-3 module

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConfigurationsPropertiesEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConfigurationsPropertiesEndpointAutoConfiguration.java
@@ -19,14 +19,10 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 
-import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
 import com.axelixlabs.axelix.sbs.spring.core.auth.RequiredAuthorityCheckService;
-import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
-import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.AxelixConfigurationPropertiesEndpoint;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesConverter;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesFlattener;
@@ -35,8 +31,6 @@ import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPro
 import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesFlattener;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesService;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
-import com.axelixlabs.axelix.sbs.spring.core.env.DefaultPropertyNameNormalizer;
-import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
 
 /**
  * Auto-configuration for the {@link AxelixConfigurationPropertiesEndpoint}.
@@ -44,53 +38,22 @@ import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
  * @since 13.11.2025
  * @author Sergey Cherkasov
  */
-@AutoConfiguration(after = EndpointsConfigurationPropertiesAutoConfiguration.class)
+@AutoConfiguration(after = EndpointPropertiesSupportAutoConfiguration.class)
 @ConditionalOnAvailableEndpoint(endpoint = AxelixConfigurationPropertiesEndpoint.class)
 public class AxelixConfigurationsPropertiesEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
     public ConfigurationPropertiesFlattener configurationPropertiesFlattener() {
         return new DefaultConfigurationPropertiesFlattener();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public ConfigurationPropertiesConverter configurationPropertiesConverter(
             ConfigurationPropertiesFlattener configurationPropertiesFlattener) {
         return new DefaultConfigurationPropertiesConverter(configurationPropertiesFlattener);
     }
 
     @Bean
-    @ConditionalOnMissingBean
-    public PropertyNameNormalizer propertyNameNormalizer() {
-        return new DefaultPropertyNameNormalizer();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public SmartSanitizingFunction smartSanitizingFunction(
-            EndpointsConfigurationProperties endpointsConfigurationProperties,
-            PropertyNameNormalizer propertyNameNormalizer) {
-        return new SmartSanitizingFunction(
-                endpointsConfigurationProperties.getSanitizedProperties(), propertyNameNormalizer);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public SecurityContextExecutor securityContextExecutor() {
-        return new ThreadLocalSecurityContextExecutor();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public RequiredAuthorityCheckService requiredAuthorityCheckService(
-            SecurityContextExecutor securityContextExecutor) {
-        return new RequiredAuthorityCheckService(securityContextExecutor);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
     public ConfigurationPropertiesService configurationPropertiesService(
             SmartSanitizingFunction smartSanitizingFunction,
             ApplicationContext applicationContext,
@@ -104,7 +67,6 @@ public class AxelixConfigurationsPropertiesEndpointAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixConfigurationPropertiesEndpoint axelixConfigurationPropertiesEndpoint(
             ConfigurationPropertiesService configurationPropertiesService) {
         return new AxelixConfigurationPropertiesEndpoint(configurationPropertiesService);

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixEnvironmentEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixEnvironmentEndpointAutoConfiguration.java
@@ -20,22 +20,18 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 
 import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
 import com.axelixlabs.axelix.sbs.spring.core.auth.RequiredAuthorityCheckService;
-import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
-import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesService;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
 import com.axelixlabs.axelix.sbs.spring.core.env.AxelixEnvironmentEndpoint;
 import com.axelixlabs.axelix.sbs.spring.core.env.DefaultEnvPropertyEnricher;
 import com.axelixlabs.axelix.sbs.spring.core.env.DefaultEnvironmentService;
 import com.axelixlabs.axelix.sbs.spring.core.env.DefaultPropertyMetadataExtractor;
-import com.axelixlabs.axelix.sbs.spring.core.env.DefaultPropertyNameNormalizer;
 import com.axelixlabs.axelix.sbs.spring.core.env.EnvPropertyEnricher;
 import com.axelixlabs.axelix.sbs.spring.core.env.EnvironmentService;
 import com.axelixlabs.axelix.sbs.spring.core.env.PropertyMetadataExtractor;
@@ -49,40 +45,17 @@ import com.axelixlabs.axelix.sbs.spring.core.env.ValueInjectionTrackerBeanPostPr
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  */
-@AutoConfiguration(after = EndpointsConfigurationPropertiesAutoConfiguration.class)
+@AutoConfiguration(after = EndpointPropertiesSupportAutoConfiguration.class)
 @ConditionalOnAvailableEndpoint(endpoint = AxelixEnvironmentEndpoint.class)
 public class AxelixEnvironmentEndpointAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
-    public PropertyNameNormalizer propertyNameNormalizer() {
-        return new DefaultPropertyNameNormalizer();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
     public PropertyMetadataExtractor propertyMetadataExtractor(
             ConfigurableEnvironment configurableEnvironment, PropertyNameNormalizer propertyNameNormalizer) {
         return new DefaultPropertyMetadataExtractor(configurableEnvironment, propertyNameNormalizer);
     }
 
     @Bean
-    @ConditionalOnMissingBean
-    public SmartSanitizingFunction smartSanitizingFunction(
-            EndpointsConfigurationProperties endpointsConfigurationProperties,
-            PropertyNameNormalizer propertyNameNormalizer) {
-        return new SmartSanitizingFunction(
-                endpointsConfigurationProperties.getSanitizedProperties(), propertyNameNormalizer);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public SecurityContextExecutor securityContextExecutor() {
-        return new ThreadLocalSecurityContextExecutor();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
     public EnvPropertyEnricher envPropertyEnricher(
             Environment environment,
             PropertyNameNormalizer propertyNameNormalizer,
@@ -98,21 +71,12 @@ public class AxelixEnvironmentEndpointAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public ValueInjectionTrackerBeanPostProcessor valueInjectionTrackerBeanPostProcessor(
             PropertyNameNormalizer propertyNameNormalizer, SecurityContextExecutor securityContextExecutor) {
         return new ValueInjectionTrackerBeanPostProcessor(propertyNameNormalizer);
     }
 
     @Bean
-    @ConditionalOnMissingBean
-    public RequiredAuthorityCheckService requiredAuthorityCheckService(
-            SecurityContextExecutor securityContextExecutor) {
-        return new RequiredAuthorityCheckService(securityContextExecutor);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
     public EnvironmentService environmentService(
             Environment environment,
             SmartSanitizingFunction smartSanitizingFunction,
@@ -123,7 +87,6 @@ public class AxelixEnvironmentEndpointAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public AxelixEnvironmentEndpoint axelixEnvironmentEndpoint(EnvironmentService environmentService) {
         return new AxelixEnvironmentEndpoint(environmentService);
     }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/EndpointPropertiesSupportAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/EndpointPropertiesSupportAutoConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
+import com.axelixlabs.axelix.sbs.spring.core.auth.RequiredAuthorityCheckService;
+import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
+import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
+import com.axelixlabs.axelix.sbs.spring.core.env.DefaultPropertyNameNormalizer;
+import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
+
+/**
+ * Auto-configuration for shared endpoint properties support beans.
+ *
+ * @author Sergey Cherkasov
+ */
+@AutoConfiguration(
+        after = {EndpointsConfigurationPropertiesAutoConfiguration.class, SecurityContextExecutorAutoConfiguration.class
+        })
+public class EndpointPropertiesSupportAutoConfiguration {
+
+    @Bean
+    public PropertyNameNormalizer propertyNameNormalizer() {
+        return new DefaultPropertyNameNormalizer();
+    }
+
+    @Bean
+    public SmartSanitizingFunction smartSanitizingFunction(
+            EndpointsConfigurationProperties endpointsConfigurationProperties,
+            PropertyNameNormalizer propertyNameNormalizer) {
+        return new SmartSanitizingFunction(
+                endpointsConfigurationProperties.getSanitizedProperties(), propertyNameNormalizer);
+    }
+
+    @Bean
+    public RequiredAuthorityCheckService requiredAuthorityCheckService(
+            SecurityContextExecutor securityContextExecutor) {
+        return new RequiredAuthorityCheckService(securityContextExecutor);
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/JwtAuthAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/JwtAuthAutoConfiguration.java
@@ -19,7 +19,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -40,7 +39,6 @@ import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
 import com.axelixlabs.axelix.common.auth.service.WebIdentityAccessManager;
 import com.axelixlabs.axelix.sbs.spring.core.auth.DefaultAuthorityResolver;
 import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthorizationFilter;
-import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
 import com.axelixlabs.axelix.sbs.spring.core.config.AuthProperties;
 
 /**
@@ -50,7 +48,7 @@ import com.axelixlabs.axelix.sbs.spring.core.config.AuthProperties;
  * @author Mikhail Polivakha
  * @since 22.07.2025
  */
-@AutoConfiguration(after = ValidationListenerAutoConfiguration.class)
+@AutoConfiguration(after = {SecurityContextExecutorAutoConfiguration.class, ValidationListenerAutoConfiguration.class})
 @EnableConfigurationProperties(WebEndpointProperties.class)
 public class JwtAuthAutoConfiguration {
 
@@ -91,12 +89,6 @@ public class JwtAuthAutoConfiguration {
     public WebIdentityAccessManager webIdentityAccessManager(
             JwtDecoderService jwtDecoderService, AuthorityResolver authorityResolver, Authorizer authorizer) {
         return new DefaultWebIdentityAccessManager(jwtDecoderService, authorityResolver, authorizer);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public SecurityContextExecutor securityContextExecutor() {
-        return new ThreadLocalSecurityContextExecutor();
     }
 
     @Bean

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/SecurityContextExecutorAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/SecurityContextExecutorAutoConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
+import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
+
+/**
+ * Auto-configuration for the {@link SecurityContextExecutor}.
+ *
+ * @author Sergey Cherkasov
+ */
+@AutoConfiguration
+public class SecurityContextExecutorAutoConfiguration {
+
+    @Bean
+    public SecurityContextExecutor securityContextExecutor() {
+        return new ThreadLocalSecurityContextExecutor();
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -9,6 +9,7 @@ com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoCon
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.GarbageCollectionAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointPropertiesSupportAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsPublisherAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.GitInformationProviderAutoConfiguration
@@ -20,4 +21,5 @@ com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointA
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixFeignEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointsConfigurationPropertiesAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.autoconfiguration.SecurityContextExecutorAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConfigurationsPropertiesEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixConfigurationsPropertiesEndpointAutoConfigurationTest.java
@@ -17,29 +17,17 @@
  */
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
-import java.util.Collection;
-import java.util.function.Supplier;
-
 import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.actuate.context.properties.ConfigurationPropertiesReportEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
 
-import com.axelixlabs.axelix.common.api.ConfigurationPropertiesFeed;
 import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
 import com.axelixlabs.axelix.sbs.spring.core.auth.RequiredAuthorityCheckService;
-import com.axelixlabs.axelix.sbs.spring.core.auth.ThreadLocalSecurityContextExecutor;
-import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.AxelixConfigurationPropertiesEndpoint;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesConverter;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesFlattener;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.ConfigurationPropertiesService;
-import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesFlattener;
-import com.axelixlabs.axelix.sbs.spring.core.configprops.DefaultConfigurationPropertiesService;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
 import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
 
@@ -56,6 +44,8 @@ class AxelixConfigurationsPropertiesEndpointAutoConfigurationTest {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(
                     AxelixConfigurationsPropertiesEndpointAutoConfiguration.class,
+                    EndpointPropertiesSupportAutoConfiguration.class,
+                    SecurityContextExecutorAutoConfiguration.class,
                     EndpointsConfigurationPropertiesAutoConfiguration.class))
             .withPropertyValues("management.endpoints.web.exposure.include=axelix-configprops");
 
@@ -81,12 +71,8 @@ class AxelixConfigurationsPropertiesEndpointAutoConfigurationTest {
                     assertThat(context).doesNotHaveBean(AxelixConfigurationsPropertiesEndpointAutoConfiguration.class);
                     assertThat(context).doesNotHaveBean(AxelixConfigurationPropertiesEndpoint.class);
                     assertThat(context).doesNotHaveBean(ConfigurationPropertiesService.class);
-                    assertThat(context).doesNotHaveBean(SmartSanitizingFunction.class);
-                    assertThat(context).doesNotHaveBean(PropertyNameNormalizer.class);
                     assertThat(context).doesNotHaveBean(ConfigurationPropertiesConverter.class);
                     assertThat(context).doesNotHaveBean(ConfigurationPropertiesFlattener.class);
-                    assertThat(context).doesNotHaveBean(SecurityContextExecutor.class);
-                    assertThat(context).doesNotHaveBean(RequiredAuthorityCheckService.class);
                 });
     }
 
@@ -107,173 +93,5 @@ class AxelixConfigurationsPropertiesEndpointAutoConfigurationTest {
             assertThat(context).doesNotHaveBean(SecurityContextExecutor.class);
             assertThat(context).doesNotHaveBean(RequiredAuthorityCheckService.class);
         });
-    }
-
-    @Test
-    void shouldHandleMultipleCustomBeans() {
-        contextRunner
-                .withUserConfiguration(
-                        CustomConfigurationPropertiesConverterConfig.class,
-                        CustomConfigurationPropertiesFlattenerConfig.class,
-                        CustomPropertyNameNormalizerConfig.class,
-                        CustomSmartSanitizingFunctionConfig.class,
-                        CustomConfigurationPropertiesServiceConfig.class,
-                        CustomAxelixConfigurationPropertiesEndpointConfig.class,
-                        CustomSecurityContextExecutorConfig.class,
-                        CustomRequiredAuthorityCheckService.class)
-                .run(context -> {
-                    assertThat(context.getBean(ConfigurationPropertiesConverter.class))
-                            .isExactlyInstanceOf(CustomConfigurationPropertiesConverter.class);
-                    assertThat(context.getBean(PropertyNameNormalizer.class))
-                            .isExactlyInstanceOf(CustomPropertyNameNormalizer.class);
-                    assertThat(context.getBean(SmartSanitizingFunction.class))
-                            .isExactlyInstanceOf(CustomSmartSanitizingFunction.class);
-                    assertThat(context.getBean(DefaultConfigurationPropertiesService.class))
-                            .isExactlyInstanceOf(CustomConfigurationPropertiesService.class);
-                    assertThat(context.getBean(AxelixConfigurationPropertiesEndpoint.class))
-                            .isExactlyInstanceOf(CustomAxelixConfigurationPropertiesEndpoint.class);
-                    assertThat(context.getBean(ConfigurationPropertiesFlattener.class))
-                            .isExactlyInstanceOf(CustomConfigurationPropertiesFlattener.class);
-                    assertThat(context.getBean(SecurityContextExecutor.class))
-                            .isExactlyInstanceOf(CustomSecurityContextExecutor.class);
-                    assertThat(context.getBean(RequiredAuthorityCheckService.class))
-                            .isExactlyInstanceOf(CustomRequiredAuthorityCheckService.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomConfigurationPropertiesConverterConfig {
-        @Bean
-        public ConfigurationPropertiesConverter configurationPropertiesConverter() {
-            return new CustomConfigurationPropertiesConverter();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomPropertyNameNormalizerConfig {
-        @Bean
-        public PropertyNameNormalizer propertyNameNormalizer() {
-            return new CustomPropertyNameNormalizer();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomSmartSanitizingFunctionConfig {
-        @Bean
-        public SmartSanitizingFunction smartSanitizingFunction(
-                EndpointsConfigurationProperties endpointsConfigurationProperties,
-                PropertyNameNormalizer propertyNameNormalizer) {
-            return new CustomSmartSanitizingFunction(endpointsConfigurationProperties, propertyNameNormalizer);
-        }
-    }
-
-    @TestConfiguration
-    static class CustomConfigurationPropertiesServiceConfig {
-        @Bean
-        public ConfigurationPropertiesService configurationPropertiesService(
-                SmartSanitizingFunction smartSanitizingFunction,
-                ApplicationContext applicationContext,
-                ConfigurationPropertiesConverter configurationPropertiesConverter,
-                RequiredAuthorityCheckService requiredAuthorityCheckService) {
-            return new CustomConfigurationPropertiesService(
-                    smartSanitizingFunction,
-                    applicationContext,
-                    configurationPropertiesConverter,
-                    requiredAuthorityCheckService);
-        }
-    }
-
-    @TestConfiguration
-    static class CustomAxelixConfigurationPropertiesEndpointConfig {
-        @Bean
-        public AxelixConfigurationPropertiesEndpoint axelixConfigurationPropertiesEndpoint(
-                DefaultConfigurationPropertiesService configurationPropertiesService) {
-            return new CustomAxelixConfigurationPropertiesEndpoint(configurationPropertiesService);
-        }
-    }
-
-    @TestConfiguration
-    static class CustomConfigurationPropertiesFlattenerConfig {
-        @Bean
-        public ConfigurationPropertiesFlattener configurationPropertiesFlattener() {
-            return new CustomConfigurationPropertiesFlattener();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomSecurityContextExecutorConfig {
-        @Bean
-        public SecurityContextExecutor securityContextExecutor() {
-            return new CustomSecurityContextExecutor();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomRequiredAuthorityCheckServiceConfig {
-        @Bean
-        public RequiredAuthorityCheckService configurationPropertiesFlattener(
-                SecurityContextExecutor securityContextExecutor) {
-            return new CustomRequiredAuthorityCheckService(securityContextExecutor);
-        }
-    }
-
-    static class CustomConfigurationPropertiesConverter implements ConfigurationPropertiesConverter {
-        @Override
-        public ConfigurationPropertiesFeed convert(
-                ConfigurationPropertiesReportEndpoint.ConfigurationPropertiesDescriptor originalDescriptor) {
-            return null;
-        }
-    }
-
-    static class CustomSecurityContextExecutor extends ThreadLocalSecurityContextExecutor {}
-
-    static class CustomRequiredAuthorityCheckService extends RequiredAuthorityCheckService {
-        public CustomRequiredAuthorityCheckService(SecurityContextExecutor securityContextExecutor) {
-            super(securityContextExecutor);
-        }
-    }
-
-    static class CustomConfigurationPropertiesFlattener extends DefaultConfigurationPropertiesFlattener {}
-
-    static class CustomPropertyNameNormalizer implements PropertyNameNormalizer {
-
-        @Override
-        public String normalize(String propertyName) {
-            return "";
-        }
-
-        @Override
-        public <C extends Collection<String>> C normalizeAll(C propertyNames, Supplier<C> collectionFactory) {
-            return null;
-        }
-    }
-
-    static class CustomSmartSanitizingFunction extends SmartSanitizingFunction {
-        public CustomSmartSanitizingFunction(
-                EndpointsConfigurationProperties endpointsConfigurationProperties,
-                PropertyNameNormalizer propertyNameNormalizer) {
-            super(endpointsConfigurationProperties.getSanitizedProperties(), propertyNameNormalizer);
-        }
-    }
-
-    static class CustomConfigurationPropertiesService extends DefaultConfigurationPropertiesService {
-        public CustomConfigurationPropertiesService(
-                SmartSanitizingFunction smartSanitizingFunction,
-                ApplicationContext applicationContext,
-                ConfigurationPropertiesConverter configurationPropertiesConverter,
-                RequiredAuthorityCheckService requiredAuthorityCheckService) {
-            super(
-                    smartSanitizingFunction,
-                    applicationContext,
-                    configurationPropertiesConverter,
-                    requiredAuthorityCheckService);
-        }
-    }
-
-    static class CustomAxelixConfigurationPropertiesEndpoint extends AxelixConfigurationPropertiesEndpoint {
-        public CustomAxelixConfigurationPropertiesEndpoint(
-                DefaultConfigurationPropertiesService configurationPropertiesService) {
-            super(configurationPropertiesService);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixEnvironmentEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixEnvironmentEndpointAutoConfigurationTest.java
@@ -17,28 +17,16 @@
  */
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
-import java.util.Collection;
-import java.util.function.Supplier;
-
-import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.actuate.env.EnvironmentEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.env.Environment;
 
-import com.axelixlabs.axelix.common.api.env.EnvironmentFeed;
-import com.axelixlabs.axelix.common.auth.core.SecurityContextExecutor;
 import com.axelixlabs.axelix.sbs.spring.core.auth.RequiredAuthorityCheckService;
 import com.axelixlabs.axelix.sbs.spring.core.configprops.SmartSanitizingFunction;
 import com.axelixlabs.axelix.sbs.spring.core.env.AxelixEnvironmentEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.env.DefaultEnvironmentService;
 import com.axelixlabs.axelix.sbs.spring.core.env.EnvPropertyEnricher;
 import com.axelixlabs.axelix.sbs.spring.core.env.EnvironmentService;
-import com.axelixlabs.axelix.sbs.spring.core.env.PropertyMetadata;
 import com.axelixlabs.axelix.sbs.spring.core.env.PropertyMetadataExtractor;
 import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
 import com.axelixlabs.axelix.sbs.spring.core.env.ValueInjectionTrackerBeanPostProcessor;
@@ -58,6 +46,8 @@ class AxelixEnvironmentEndpointAutoConfigurationTest {
             .withPropertyValues("management.endpoints.web.exposure.include=axelix-env")
             .withConfiguration(AutoConfigurations.of(
                     AxelixEnvironmentEndpointAutoConfiguration.class,
+                    EndpointPropertiesSupportAutoConfiguration.class,
+                    SecurityContextExecutorAutoConfiguration.class,
                     EndpointsConfigurationPropertiesAutoConfiguration.class));
 
     @Test
@@ -78,162 +68,18 @@ class AxelixEnvironmentEndpointAutoConfigurationTest {
     void shouldNotActivateAutoConfigurationWithoutRequiredProperty() {
         new ApplicationContextRunner()
                 .withPropertyValues("management.endpoints.web.exposure.exclude=axelix-env")
-                .withConfiguration(AutoConfigurations.of(AxelixEnvironmentEndpointAutoConfiguration.class))
+                .withConfiguration(AutoConfigurations.of(
+                        AxelixEnvironmentEndpointAutoConfiguration.class,
+                        EndpointPropertiesSupportAutoConfiguration.class,
+                        SecurityContextExecutorAutoConfiguration.class,
+                        EndpointsConfigurationPropertiesAutoConfiguration.class))
                 .run(context -> {
                     assertThat(context).doesNotHaveBean(AxelixEnvironmentEndpointAutoConfiguration.class);
-                    assertThat(context).doesNotHaveBean(PropertyNameNormalizer.class);
                     assertThat(context).doesNotHaveBean(PropertyMetadataExtractor.class);
                     assertThat(context).doesNotHaveBean(EnvPropertyEnricher.class);
-                    assertThat(context).doesNotHaveBean(SmartSanitizingFunction.class);
                     assertThat(context).doesNotHaveBean(AxelixEnvironmentEndpoint.class);
                     assertThat(context).doesNotHaveBean(ValueInjectionTrackerBeanPostProcessor.class);
                     assertThat(context).doesNotHaveBean(EnvironmentService.class);
-                    assertThat(context).doesNotHaveBean(RequiredAuthorityCheckService.class);
                 });
-    }
-
-    @Test
-    void shouldHandleMultipleCustomBeans() {
-        contextRunner
-                .withUserConfiguration(
-                        CustomPropertyMetadataExtractorConfig.class,
-                        CustomEnvPropertyEnricherConfig.class,
-                        CustomPropertyNameNormalizerConfig.class,
-                        CustomAxelixEnvironmentEndpointConfig.class,
-                        CustomValueInjectionTrackerBeanPostProcessorConfig.class,
-                        CustomRequiredAuthorityCheckServiceConfig.class,
-                        CustomEnvironmentServiceConfig.class)
-                .run(context -> {
-                    assertThat(context.getBean(PropertyMetadataExtractor.class))
-                            .isExactlyInstanceOf(CustomPropertyMetadataExtractor.class);
-                    assertThat(context.getBean(EnvPropertyEnricher.class))
-                            .isExactlyInstanceOf(CustomEnvPropertyEnricher.class);
-                    assertThat(context.getBean(PropertyNameNormalizer.class))
-                            .isExactlyInstanceOf(CustomPropertyNameNormalizer.class);
-                    assertThat(context.getBean(AxelixEnvironmentEndpoint.class))
-                            .isExactlyInstanceOf(CustomAxelixEnvironmentEndpoint.class);
-                    assertThat(context.getBean(ValueInjectionTrackerBeanPostProcessor.class))
-                            .isExactlyInstanceOf(CustomValueInjectionTrackerBeanPostProcessor.class);
-                    assertThat(context.getBean(RequiredAuthorityCheckService.class))
-                            .isExactlyInstanceOf(CustomRequiredAuthorityCheckService.class);
-                    assertThat(context.getBean(EnvironmentService.class))
-                            .isExactlyInstanceOf(CustomEnvironmentService.class);
-                });
-    }
-
-    @TestConfiguration
-    static class CustomPropertyMetadataExtractorConfig {
-        @Bean
-        public PropertyMetadataExtractor propertyMetadataExtractor() {
-            return new CustomPropertyMetadataExtractor();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomEnvPropertyEnricherConfig {
-        @Bean
-        public EnvPropertyEnricher envPropertyEnricher() {
-            return new CustomEnvPropertyEnricher();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomPropertyNameNormalizerConfig {
-        @Bean
-        public PropertyNameNormalizer propertyNameNormalizer() {
-            return new CustomPropertyNameNormalizer();
-        }
-    }
-
-    @TestConfiguration
-    static class CustomAxelixEnvironmentEndpointConfig {
-        @Bean
-        public AxelixEnvironmentEndpoint axelixEnvironmentEndpoint(EnvironmentService environmentService) {
-            return new CustomAxelixEnvironmentEndpoint(environmentService);
-        }
-    }
-
-    @TestConfiguration
-    static class CustomValueInjectionTrackerBeanPostProcessorConfig {
-        @Bean
-        public ValueInjectionTrackerBeanPostProcessor valueInjectionTrackerBeanPostProcessor() {
-            return new CustomValueInjectionTrackerBeanPostProcessor(null);
-        }
-    }
-
-    @TestConfiguration
-    static class CustomRequiredAuthorityCheckServiceConfig {
-        @Bean
-        public RequiredAuthorityCheckService requiredAuthorityCheckService(
-                SecurityContextExecutor securityContextExecutor) {
-            return new CustomRequiredAuthorityCheckService(securityContextExecutor);
-        }
-    }
-
-    @TestConfiguration
-    static class CustomEnvironmentServiceConfig {
-        @Bean
-        public EnvironmentService environmentService(
-                Environment environment,
-                SmartSanitizingFunction smartSanitizingFunction,
-                EnvPropertyEnricher envPropertyEnricher,
-                RequiredAuthorityCheckService requiredAuthorityCheckService) {
-            return new CustomEnvironmentService(
-                    environment, smartSanitizingFunction, envPropertyEnricher, requiredAuthorityCheckService);
-        }
-    }
-
-    static class CustomPropertyMetadataExtractor implements PropertyMetadataExtractor {
-        @Override
-        public @Nullable PropertyMetadata getMetadata(String propertyName) {
-            return null;
-        }
-    }
-
-    static class CustomEnvPropertyEnricher implements EnvPropertyEnricher {
-        @Override
-        public EnvironmentFeed enrich(EnvironmentEndpoint.EnvironmentDescriptor originalDescriptor) {
-            return null;
-        }
-    }
-
-    static class CustomPropertyNameNormalizer implements PropertyNameNormalizer {
-        @Override
-        public String normalize(String propertyName) {
-            return propertyName;
-        }
-
-        @Override
-        public <C extends Collection<String>> C normalizeAll(C propertyNames, Supplier<C> collectionFactory) {
-            return null;
-        }
-    }
-
-    static class CustomAxelixEnvironmentEndpoint extends AxelixEnvironmentEndpoint {
-        public CustomAxelixEnvironmentEndpoint(EnvironmentService environmentService) {
-            super(environmentService);
-        }
-    }
-
-    static class CustomValueInjectionTrackerBeanPostProcessor extends ValueInjectionTrackerBeanPostProcessor {
-        public CustomValueInjectionTrackerBeanPostProcessor(PropertyNameNormalizer propertyNameNormalizer) {
-            super(propertyNameNormalizer);
-        }
-    }
-
-    static class CustomRequiredAuthorityCheckService extends RequiredAuthorityCheckService {
-        public CustomRequiredAuthorityCheckService(SecurityContextExecutor securityContextExecutor) {
-            super(securityContextExecutor);
-        }
-    }
-
-    static class CustomEnvironmentService extends DefaultEnvironmentService {
-        public CustomEnvironmentService(
-                Environment environment,
-                SmartSanitizingFunction smartSanitizingFunction,
-                EnvPropertyEnricher envPropertyEnricher,
-                RequiredAuthorityCheckService requiredAuthorityCheckService) {
-            super(environment, smartSanitizingFunction, envPropertyEnricher, requiredAuthorityCheckService);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/JwtAuthAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/JwtAuthAutoConfigurationTest.java
@@ -47,7 +47,8 @@ class JwtAuthAutoConfigurationTest {
                     "axelix.sbs.auth.jwt",
                     "axelix.sbs.auth.jwt.algorithm=HMAC512",
                     "axelix.sbs.auth.jwt.signing-key=secret")
-            .withConfiguration(AutoConfigurations.of(JwtAuthAutoConfiguration.class));
+            .withConfiguration(AutoConfigurations.of(
+                    JwtAuthAutoConfiguration.class, SecurityContextExecutorAutoConfiguration.class));
 
     @Test
     void shouldCreateAllBeansInDefaultScenario() {
@@ -68,7 +69,8 @@ class JwtAuthAutoConfigurationTest {
         new ApplicationContextRunner()
                 // "axelix.sbs.auth.jwt.algorithm" is missing
                 .withPropertyValues("axelix.sbs.auth.jwt", "axelix.sbs.auth.jwt.signing-key=secret")
-                .withConfiguration(AutoConfigurations.of(JwtAuthAutoConfiguration.class))
+                .withConfiguration(AutoConfigurations.of(
+                        JwtAuthAutoConfiguration.class, SecurityContextExecutorAutoConfiguration.class))
                 .run(context -> {
                     assertThat(context).hasFailed();
                     assertThat(context.getStartupFailure()).isInstanceOf(BeanCreationException.class);
@@ -80,7 +82,8 @@ class JwtAuthAutoConfigurationTest {
         new ApplicationContextRunner()
                 // "axelix.sbs.auth.jwt.signing-key" is missing
                 .withPropertyValues("axelix.sbs.auth.jwt", "axelix.sbs.auth.jwt.algorithm=HMAC512")
-                .withConfiguration(AutoConfigurations.of(JwtAuthAutoConfiguration.class))
+                .withConfiguration(AutoConfigurations.of(
+                        JwtAuthAutoConfiguration.class, SecurityContextExecutorAutoConfiguration.class))
                 .run(context -> {
                     assertThat(context).hasFailed();
                     assertThat(context.getStartupFailure()).isInstanceOf(BeanCreationException.class);
@@ -95,7 +98,8 @@ class JwtAuthAutoConfigurationTest {
                         "axelix.sbs.auth.jwt",
                         "axelix.sbs.auth.jwt.algorithm=RSA512",
                         "axelix.sbs.auth.jwt.signing-key=secret")
-                .withConfiguration(AutoConfigurations.of(JwtAuthAutoConfiguration.class))
+                .withConfiguration(AutoConfigurations.of(
+                        JwtAuthAutoConfiguration.class, SecurityContextExecutorAutoConfiguration.class))
                 .run(context -> {
                     assertThat(context).hasFailed();
                     assertThat(context.getStartupFailure()).isInstanceOf(BeanCreationException.class);

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -35,11 +35,13 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointA
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsPublisherAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointPropertiesSupportAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointsConfigurationPropertiesAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.GarbageCollectionAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.GitInformationProviderAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.JwtAuthAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ScheduledTaskManagementAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.SecurityContextExecutorAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.SelfRegistrationAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProviderAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
@@ -76,6 +78,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAuto
             TransactionMonitoringAutoConfiguration.class,
             EndpointsConfigurationPropertiesAutoConfiguration.class,
             AxelixLoggersEndpointAutoConfiguration.class,
+            SecurityContextExecutorAutoConfiguration.class,
             ValidationListenerAutoConfiguration.class
         })
 @EnableCaching

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -77,6 +77,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAuto
             ThreadDumpManagementEndpointAutoConfiguration.class,
             TransactionMonitoringAutoConfiguration.class,
             EndpointsConfigurationPropertiesAutoConfiguration.class,
+            EndpointPropertiesSupportAutoConfiguration.class,
             AxelixLoggersEndpointAutoConfiguration.class,
             SecurityContextExecutorAutoConfiguration.class,
             ValidationListenerAutoConfiguration.class


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared Spring Boot auto-configuration for endpoint properties support and security context executor handling.
  * Automatically registers the supporting components needed for endpoint/environment/JWT flows.

* **Bug Fixes**
  * Adjusted auto-configuration ordering so endpoint properties support loads earlier and security context executor is always available when required.
  * Simplified bean creation rules to ensure consistent wiring and prevent missing/duplicate components.

* **Tests**
  * Updated starter tests to match the expanded default auto-configuration set.
  * Removed outdated custom-bean override scenarios and adjusted bean assertions for disabled/active cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->