### PR TITLE
GH-1354 Implement core logic nightly E2E tests

### DIFF
--- a/.github/workflows/nightly-master-e2e-.yaml
+++ b/.github/workflows/nightly-master-e2e-.yaml
@@ -1,17 +1,47 @@
-name: Nightly Master E2E DRAFT!
+name: Nightly Master E2E
 
 on:
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'master-e2e-tests/**'
   workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
 
 env:
   KIND_CLUSTER_NAME: axelix-master-e2e
-  MASTER_IMAGE: axelix-master-e2e:local
-  PLAYGROUND_IMAGE: notification-service-e2e:local
+  MASTER_IMAGE_NAME: axelix-master
+  MASTER_IMAGE_TAG: local
+  NOTIFICATION_SERVICE_IMAGE: notification-service-gradle-sb-2:local
   JWT_SIGNING_KEY: e2e-only-dummy-signing-key-do-not-reuse-12345678901234567890
 
+permissions:
+  contents: read
+
 jobs:
-  master-e2e-single-config:
+  setup-matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.read.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Read matrix.json
+        id: read
+        run: |
+          echo "matrix<<EOF" >> $GITHUB_OUTPUT
+          cat master-e2e-tests/pict/matrix.json >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+  master-e2e:
+    needs: setup-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -34,16 +64,14 @@ jobs:
       - name: Grant execution access to the wrapper
         run: chmod +x gradlew
 
-      # TODO ./gradlew :master:bootJar --no-configuration-cache
       - name: Build Master jar
-        run: ./gradlew :master:bootJar -x test
+        run: ./gradlew :master:bootJar --no-configuration-cache --no-build-cache
 
       - name: Build Master Docker image
-        run: docker build --tag ${{ env.MASTER_IMAGE }} --file Dockerfile .
+        run: docker build --tag ${{ env.MASTER_IMAGE_NAME }}:${{ env.MASTER_IMAGE_TAG }} --file Dockerfile .
 
-      # TODO ./gradlew :sbs:axelix-spring-boot-2-starter:publishToMavenLocal --no-configuration-cache
       - name: Publish Spring Boot 2 Starter to Maven local
-        run: ./gradlew :sbs:axelix-spring-boot-2-starter:publishToMavenLocal -x test
+        run: ./gradlew :sbs:axelix-spring-boot-2-starter:publishToMavenLocal --no-configuration-cache --no-build-cache
 
       - name: Set up JDK 21 for Playground
         uses: actions/setup-java@v5
@@ -52,83 +80,229 @@ jobs:
           distribution: 'liberica'
           java-version: '21'
 
-      - name: Build Playground jar Notification Service
+      - name: Build Playground Notification Service
         working-directory: playgrounds/notification-service-gradle-sb-2
         env:
           JAVA_HOME: ${{ steps.setup-java-21.outputs.path }}
         run: |
           chmod +x gradlew
-          ./gradlew build -x test
+          ./gradlew build --no-configuration-cache --no-build-cache
 
-      - name: Build Playground Docker image
+      - name: Build Notification Service Docker image
         working-directory: playgrounds/notification-service-gradle-sb-2
-        run: docker build --tag ${{ env.PLAYGROUND_IMAGE }} --file docker/Dockerfile .
+        run: docker build --tag ${{ env.NOTIFICATION_SERVICE_IMAGE }} --file docker/Dockerfile .
 
       - name: Create KinD cluster
         uses: helm/kind-action@v1
         with:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
 
+      - name: Install ingress-nginx
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+
+          kubectl wait \
+            --namespace ingress-nginx \
+            --for=condition=ready pod \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=120s
+
       - name: Load images into KinD
         run: |
-          kind load docker-image ${{ env.MASTER_IMAGE }} --name ${{ env.KIND_CLUSTER_NAME }}
-          kind load docker-image ${{ env.PLAYGROUND_IMAGE }} --name ${{ env.KIND_CLUSTER_NAME }}
+          kind load docker-image ${{ env.MASTER_IMAGE_NAME }}:${{ env.MASTER_IMAGE_TAG }} --name ${{ env.KIND_CLUSTER_NAME }}
+          kind load docker-image ${{ env.NOTIFICATION_SERVICE_IMAGE }} --name ${{ env.KIND_CLUSTER_NAME }}
 
       - name: Setup Helm
         uses: azure/setup-helm@v5.0.1
         with:
           version: v3.14.0
 
+      - name: Compute configuration
+        run: |
+          # ---------- Database ----------
+          case "${{ matrix.db }}" in
+            SQLite)
+              echo "DB_TYPE=sqlite" >> $GITHUB_ENV
+              echo "DB_URL=jdbc:sqlite::axelix.db" >> $GITHUB_ENV
+              echo "DB_USERNAME=" >> $GITHUB_ENV
+              echo "DB_PASSWORD=" >> $GITHUB_ENV
+              ;;
+
+            Postgres)
+              echo "DB_TYPE=postgres" >> $GITHUB_ENV
+              echo "DB_URL=jdbc:postgresql://postgres:5432/axelix" >> $GITHUB_ENV
+              echo "DB_USERNAME=user" >> $GITHUB_ENV
+              echo "DB_PASSWORD=password" >> $GITHUB_ENV
+              ;;
+
+            MySQL)
+              echo "DB_TYPE=mysql" >> $GITHUB_ENV
+              echo "DB_URL=jdbc:mysql://mysql:3306/axelix" >> $GITHUB_ENV
+              echo "DB_USERNAME=user" >> $GITHUB_ENV
+              echo "DB_PASSWORD=password" >> $GITHUB_ENV
+              ;;
+          esac
+          
+          # ---------- Discovery ----------
+          case "${{ matrix.discoverymode }}" in
+            Discovery_Auto)
+              echo "DISCOVERY_AUTO=true" >> $GITHUB_ENV
+              echo "DISCOVERY_SELF_REG=false" >> $GITHUB_ENV
+              ;;
+            Discovery_SelfRegistration)
+              echo "DISCOVERY_AUTO=false" >> $GITHUB_ENV
+              echo "DISCOVERY_SELF_REG=true" >> $GITHUB_ENV
+              ;;
+            Discovery_Both)
+              echo "DISCOVERY_AUTO=true" >> $GITHUB_ENV
+              echo "DISCOVERY_SELF_REG=true" >> $GITHUB_ENV
+              ;;
+          esac
+          
+          # ---------- Authentication ----------
+          case "${{ matrix.auth }}" in
+            Auth_Local)
+              echo "AUTH_LOCAL=true" >> $GITHUB_ENV
+              echo "AUTH_OAUTH2=false" >> $GITHUB_ENV
+              ;;
+            Auth_OAuth2)
+              echo "AUTH_LOCAL=false" >> $GITHUB_ENV
+              echo "AUTH_OAUTH2=true" >> $GITHUB_ENV
+              ;;
+            Auth_Both)
+              echo "AUTH_LOCAL=true" >> $GITHUB_ENV
+              echo "AUTH_OAUTH2=true" >> $GITHUB_ENV
+              ;;
+          esac
+          
+          # ---------- MCP ----------
+          if [[ "${{ matrix.mcp }}" == "MCP_Enabled" ]]; then
+            echo "MCP_ENABLED=true" >> $GITHUB_ENV
+          else
+            echo "MCP_ENABLED=false" >> $GITHUB_ENV
+          fi
+
+      - name: Deploy database (Postgres/MySQL) if needed
+        if: matrix.db != 'SQLite'
+        run: |
+          kubectl apply -f master-e2e-tests/k8s/${DB_TYPE}.yaml
+          kubectl rollout status deployment/${DB_TYPE} --timeout=60s
+
+      # Resolve ingress and port-forward hostnames from the GitHub Actions runner.
+      - name: Configure local DNS
+        run: |
+          echo "127.0.0.1 master" | sudo tee -a /etc/hosts
+
+      - name: Prepare Master Helm set
+        id: master_set
+        run: |
+          MASTER_SET="--set image.name=$MASTER_IMAGE_NAME \
+                       --set image.ref=$MASTER_IMAGE_TAG \
+                       --set image.pullPolicy=Never \
+                       --set ingress.enabled=true \
+                       --set ingress.host=master \
+                       --set axelix.master.auth.jwt.algorithm=HMAC256 \
+                       --set axelix.master.auth.jwt.signingKey=$JWT_SIGNING_KEY \
+                       --set axelix.master.auth.cookie.secure=false \
+                       --set axelix.master.database.url=$DB_URL \
+                       --set axelix.master.database.username=$DB_USERNAME \
+                       --set axelix.master.database.password=$DB_PASSWORD \
+                       --set axelix.master.discovery.auto.enabled=$DISCOVERY_AUTO \
+                       --set axelix.master.discovery.selfRegistration.enabled=$DISCOVERY_SELF_REG \
+                       --set axelix.master.auth.options.local.enabled=$AUTH_LOCAL \
+                       --set axelix.master.auth.options.oauth2.enabled=$AUTH_OAUTH2 \
+                       --set axelix.master.mcpServer.enabled=$MCP_ENABLED"
+
+          echo "MASTER_SET=$MASTER_SET" >> $GITHUB_ENV
+
       - name: Deploy Axelix Master
         run: |
           helm upgrade --install axelix-master helm-charts/charts/axelix \
-            --set image.name=${{ env.MASTER_IMAGE }} \
-            --set image.ref=local \
-            --set image.pullPolicy=Never \
-            --set ingress.enabled=false \
-            --set axelix.master.auth.jwt.algorithm=HMAC256 \
-            --set axelix.master.auth.jwt.signingKey=${{ env.JWT_SIGNING_KEY }} \
-            --set axelix.master.auth.cookie.secure=false \
-            --set axelix.master.auth.options.local.enabled=true \
-            --set axelix.master.discovery.auto.enabled=true \
+            ${{ env.MASTER_SET }} \
             --wait --timeout 3m
 
-      - name: Deploy Playground (notification-service)
+      - name: Deploy Notification Service (Auto discovery mode)
+        if: env.DISCOVERY_AUTO == 'true'
         working-directory: playgrounds/notification-service-gradle-sb-2/chart
         run: |
-          helm upgrade --install notification-service . \
-            --set image.ref=${{ env.PLAYGROUND_IMAGE }} \
+          helm upgrade --install notification-service-automatic-discovery . \
+            --set image.ref=$NOTIFICATION_SERVICE_IMAGE \
             --set image.pullPolicy=Never \
             --set axelix.sbs.auth.jwt.algorithm=HMAC256 \
-            --set axelix.sbs.auth.jwt.signingKey=${{ env.JWT_SIGNING_KEY }} \
+            --set axelix.sbs.auth.jwt.signingKey=$JWT_SIGNING_KEY \
             --wait --timeout 3m
 
-      - name: Port-forward Axelix Master
+      - name: Deploy Notification Service (Self-Registration mode)
+        if: env.DISCOVERY_SELF_REG == 'true'
+        working-directory: playgrounds/notification-service-gradle-sb-2/chart
         run: |
-          kubectl port-forward svc/axelix-master 8080:8080 > /tmp/port-forward.log 2>&1 &
+          EXTRA_ENV=$(jq -c . <<EOF
+          [
+            {"name":"SERVER_PORT","value":"8080"},
+            {"name":"AXELIX_SBS_DISCOVERY_INSTANCE_ACTUATOR_URL","value":"http://notification-service-self-registration.selfreg.svc.cluster.local:8080/actuator"},
+            {"name":"AXELIX_SBS_DISCOVERY_MASTER_URL","value":"http://axelix-master.default.svc.cluster.local:8080/api/internal/service/register"},
+            {"name":"AXELIX_SBS_DISCOVERY_INSTANCE_NAME","value":"notification-service-self-registration"},
+            {"name":"AXELIX_SBS_DISCOVERY_AUTO","value":"true"}
+          ]
+          EOF
+          )
+
+          helm upgrade --install notification-service-self-registration . \
+            --set image.ref=$NOTIFICATION_SERVICE_IMAGE \
+            --set image.pullPolicy=Never \
+            --set axelix.sbs.auth.jwt.algorithm=HMAC256 \
+            --set axelix.sbs.auth.jwt.signingKey=$JWT_SIGNING_KEY \
+            --set-json extraEnv="$EXTRA_ENV" \
+            --namespace selfreg \
+            --create-namespace \
+            --wait --timeout 3m
 
       - name: Run Master E2E tests
-        run: >
-          ./gradlew :master-e2e-tests:e2eTest
-          -Paxelix.e2e.masterBaseUrl=http://localhost:8080
+        run: |
+          ./gradlew :master-e2e-tests:e2eTest \
+            -Paxelix.e2e.run=true \
+            -Paxelix.e2e.masterBaseUrl=http://master:8080 \
+            -Paxelix.e2e.mcpEnabled=$MCP_ENABLED \
+            -Paxelix.e2e.discoveryModeAutoEnabled=$DISCOVERY_AUTO \
+            -Paxelix.e2e.discoveryModeSelfRegEnabled=$DISCOVERY_SELF_REG \
+            -Paxelix.e2e.authModeLocalEnabled=$AUTH_LOCAL \
+            -Paxelix.e2e.authModeOAuth2Enabled=$AUTH_OAUTH2
 
-      - name: Dump cluster state on failure
-        if: failure()
+      - name: Dump cluster state
+        if: always()
         run: |
           echo "---- pods ----"
-          kubectl get pods -o wide
+          kubectl get pods -o wide --all-namespaces
+          
           echo "---- axelix-master logs ----"
           kubectl logs deploy/axelix-master --tail=300 || true
-          echo "---- notification-service logs ----"
-          kubectl logs deploy/notification-service --tail=300 || true
-          echo "---- port-forward log ----"
-          cat /tmp/port-forward.log || true
+          
+          if kubectl get deploy/notification-service-automatic-discovery &>/dev/null; then
+            echo "---- notification-service-automatic-discovery logs ----"
+            kubectl logs deploy/notification-service-automatic-discovery --tail=300 || true
+          fi
+          
+          if [[ "${{ matrix.db }}" != "SQLite" ]]; then
+            echo "---- ${DB_TYPE} database logs ----"
+            kubectl logs deploy/${DB_TYPE} --tail=200 || true
+          fi
+          
+          if kubectl get deploy/notification-service-self-registration -n selfreg &>/dev/null; then
+            echo "---- notification-service-self-registration logs ----"
+            kubectl logs deploy/notification-service-self-registration -n selfreg --tail=300 || true
+          fi
+          
+          echo "---- ingresses ----"
+          kubectl get ingress -A
+          
+          echo "---- ingress controller logs ----"
+          kubectl logs -n ingress-nginx deploy/ingress-nginx-controller --tail=300 || true
 
       - name: Upload test report
-        if: always()
-        uses: actions/upload-artifact@v7
+        if: failure()
+        uses: actions/upload-artifact@v4
         with:
-          name: master-e2e-test-report
+          name: master-e2e-test-report-${{ matrix.name }}
           path: master-e2e-tests/build/reports/tests/e2eTest
           retention-days: 3
           if-no-files-found: ignore

--- a/master-e2e-tests/build.gradle.kts
+++ b/master-e2e-tests/build.gradle.kts
@@ -1,0 +1,75 @@
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+
+plugins {
+    id("shared")
+}
+
+val restAssuredVersion = "5.5.7"
+val awaitilityVersion = "4.3.0"
+val assertjVersion = "3.27.7"
+val junitVersion = "6.1.1"
+val jsoupVersion = "1.22.2"
+
+dependencies {
+    testImplementation("io.rest-assured:rest-assured:${restAssuredVersion}")
+    testImplementation("io.rest-assured:json-path:${restAssuredVersion}")
+    testImplementation("org.awaitility:awaitility:${awaitilityVersion}")
+    testImplementation("org.assertj:assertj-core:${assertjVersion}")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:${junitVersion}")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:${junitVersion}")
+    testImplementation("org.jsoup:jsoup:${jsoupVersion}")
+
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitVersion}")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+tasks.test {
+    // enable for local testing
+    enabled = false
+    useJUnitPlatform()
+
+    systemProperty("axelix.e2e.masterBaseUrl", "http://localhost:8080")
+    systemProperty("axelix.e2e.superAdmin.username", "admin")
+    systemProperty("axelix.e2e.superAdmin.password", "admin")
+
+    systemProperty("axelix.e2e.discoveryModeAutoEnabled", "false")
+    systemProperty("axelix.e2e.discoveryModeSelfRegEnabled", "false")
+
+    systemProperty("axelix.e2e.authModeLocalEnabled", "true")
+    systemProperty("axelix.e2e.authModeOAuth2Enabled", "false")
+
+    systemProperty("axelix.e2e.mcpEnabled", "true")
+}
+
+// Comment out the lines below for local testing
+val e2eTest by tasks.registering(Test::class) {
+    testClassesDirs = tasks.test.get().testClassesDirs
+    classpath = tasks.test.get().classpath
+
+    val isRunEnabled = providers.gradleProperty("axelix.e2e.run").getOrElse("false").toBoolean()
+    enabled = isRunEnabled
+    useJUnitPlatform()
+
+    if (isRunEnabled) {
+        systemProperty("axelix.e2e.masterBaseUrl", providers.gradleProperty("axelix.e2e.masterBaseUrl").get())
+        systemProperty("axelix.e2e.superAdmin.username", providers.gradleProperty("axelix.e2e.superAdmin.username").getOrElse("admin"))
+        systemProperty("axelix.e2e.superAdmin.password", providers.gradleProperty("axelix.e2e.superAdmin.password").getOrElse("admin"))
+
+        // Discovery mode
+        systemProperty("axelix.e2e.discoveryModeAutoEnabled", providers.gradleProperty("axelix.e2e.discoveryModeAutoEnabled").get())
+        systemProperty("axelix.e2e.discoveryModeSelfRegEnabled", providers.gradleProperty("axelix.e2e.discoveryModeSelfRegEnabled").get())
+
+        // Auth mode
+        systemProperty("axelix.e2e.authModeLocalEnabled", providers.gradleProperty("axelix.e2e.authModeLocalEnabled").get())
+        systemProperty("axelix.e2e.authModeOAuth2Enabled", providers.gradleProperty("axelix.e2e.authModeOAuth2Enabled").get())
+
+        // MCP server
+        systemProperty("axelix.e2e.mcpEnabled", providers.gradleProperty("axelix.e2e.mcpEnabled").get())
+    }
+}

--- a/master-e2e-tests/k8s/mysql.yaml
+++ b/master-e2e-tests/k8s/mysql.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:latest
+          env:
+            - name: MYSQL_DATABASE
+              value: axelix
+            - name: MYSQL_USER
+              value: user
+            - name: MYSQL_PASSWORD
+              value: password
+            - name: MYSQL_ROOT_PASSWORD
+              value: password
+          ports:
+            - containerPort: 3306
+          readinessProbe:
+            tcpSocket:
+              port: 3306
+            initialDelaySeconds: 15
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+spec:
+  selector:
+    app: mysql
+  ports:
+    - port: 3306
+      targetPort: 3306

--- a/master-e2e-tests/k8s/postgres.yaml
+++ b/master-e2e-tests/k8s/postgres.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:latest
+          env:
+            - name: POSTGRES_DB
+              value: axelix
+            - name: POSTGRES_USER
+              value: user
+            - name: POSTGRES_PASSWORD
+              value: password
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "user", "-d", "axelix"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432

--- a/master-e2e-tests/pict/matrix.json
+++ b/master-e2e-tests/pict/matrix.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "mysql-discovery-both-auth-oauth2-mcp-enabled",
+    "db": "MySQL",
+    "discoverymode": "Discovery_Both",
+    "auth": "Auth_OAuth2",
+    "mcp": "MCP_Enabled"
+  },
+  {
+    "name": "mysql-discovery-auto-auth-local-mcp-disabled",
+    "db": "MySQL",
+    "discoverymode": "Discovery_Auto",
+    "auth": "Auth_Local",
+    "mcp": "MCP_Disabled"
+  },
+  {
+    "name": "sqlite-discovery-selfregistration-auth-oauth2-mcp-disabled",
+    "db": "SQLite",
+    "discoverymode": "Discovery_SelfRegistration",
+    "auth": "Auth_OAuth2",
+    "mcp": "MCP_Disabled"
+  },
+  {
+    "name": "postgres-discovery-auto-auth-oauth2-mcp-enabled",
+    "db": "Postgres",
+    "discoverymode": "Discovery_Auto",
+    "auth": "Auth_OAuth2",
+    "mcp": "MCP_Enabled"
+  },
+  {
+    "name": "sqlite-discovery-auto-auth-both-mcp-enabled",
+    "db": "SQLite",
+    "discoverymode": "Discovery_Auto",
+    "auth": "Auth_Both",
+    "mcp": "MCP_Enabled"
+  },
+  {
+    "name": "mysql-discovery-selfregistration-auth-local-mcp-enabled",
+    "db": "MySQL",
+    "discoverymode": "Discovery_SelfRegistration",
+    "auth": "Auth_Local",
+    "mcp": "MCP_Enabled"
+  },
+  {
+    "name": "mysql-discovery-both-auth-both-mcp-disabled",
+    "db": "MySQL",
+    "discoverymode": "Discovery_Both",
+    "auth": "Auth_Both",
+    "mcp": "MCP_Disabled"
+  },
+  {
+    "name": "postgres-discovery-selfregistration-auth-both-mcp-disabled",
+    "db": "Postgres",
+    "discoverymode": "Discovery_SelfRegistration",
+    "auth": "Auth_Both",
+    "mcp": "MCP_Disabled"
+  },
+  {
+    "name": "sqlite-discovery-both-auth-local-mcp-disabled",
+    "db": "SQLite",
+    "discoverymode": "Discovery_Both",
+    "auth": "Auth_Local",
+    "mcp": "MCP_Disabled"
+  },
+  {
+    "name": "postgres-discovery-both-auth-local-mcp-enabled",
+    "db": "Postgres",
+    "discoverymode": "Discovery_Both",
+    "auth": "Auth_Local",
+    "mcp": "MCP_Enabled"
+  }
+]

--- a/master-e2e-tests/pict/model.pict
+++ b/master-e2e-tests/pict/model.pict
@@ -1,0 +1,4 @@
+DB:            SQLite, Postgres, MySQL
+DiscoveryMode: Discovery_Auto, Discovery_SelfRegistration, Discovery_Both
+Auth:          Auth_Local, Auth_OAuth2, Auth_Both
+MCP:           MCP_Enabled, MCP_Disabled

--- a/master-e2e-tests/pict/pict-to-matrix.java
+++ b/master-e2e-tests/pict/pict-to-matrix.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Use "pict model.pict | java pict-to-matrix.java > matrix.json"
+ *
+ * @author Nikita Kirillov
+ */
+public class PictToMatrix {
+
+    private static final Pattern NON_ALPHANUMERIC = Pattern.compile("[^a-z0-9]+");
+
+    public static String slugify(String input) {
+        if (input == null) {
+          return "";
+        }
+        return NON_ALPHANUMERIC.matcher(input.toLowerCase())
+            .replaceAll("-")
+            .replaceAll("^-+|-+$", "");
+    }
+
+    public static void main(String[] args) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(System.in))) {
+            String headerLine = reader.readLine();
+            if (headerLine == null || headerLine.trim().isEmpty()) {
+                System.err.println("No rows read from PICT output on stdin.");
+                System.exit(1);
+            }
+
+            String[] headers = headerLine.split("\t");
+            List<Map<String, String>> matrixEntries = new ArrayList<>();
+            List<String> names = new ArrayList<>();
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                if (line.trim().isEmpty()) continue;
+                String[] values = line.split("\t");
+
+                String combinedValues = String.join("-", values);
+                String name = slugify(combinedValues);
+                names.add(name);
+
+                Map<String, String> entry = new LinkedHashMap<>();
+                entry.put("name", name);
+                for (int i = 0; i < headers.length; i++) {
+                    if (i < values.length) {
+                        entry.put(headers[i].toLowerCase(), values[i]);
+                    }
+                }
+                matrixEntries.add(entry);
+            }
+
+            if (matrixEntries.isEmpty()) {
+                System.err.println("No rows read from PICT output on stdin.");
+                System.exit(1);
+            }
+
+            Set<String> duplicates = names.stream()
+                .filter(name -> Collections.frequency(names, name) > 1)
+                .collect(Collectors.toSet());
+
+            if (!duplicates.isEmpty()) {
+                System.err.println("Slug collision(s) in generated matrix: " + duplicates);
+                System.exit(1);
+            }
+
+            System.out.println(formatJsonArray(matrixEntries));
+
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            System.exit(1);
+        }
+    }
+
+    private static String formatJsonArray(List<Map<String, String>> entries) {
+        StringBuilder json = new StringBuilder("[\n");
+        for (int i = 0; i < entries.size(); i++) {
+            json.append("  {\n");
+            Map<String, String> entry = entries.get(i);
+            int count = 0;
+            for (Map.Entry<String, String> pair : entry.entrySet()) {
+                json.append("    \"")
+                    .append(escapeJson(pair.getKey()))
+                    .append("\": \"").append(escapeJson(pair.getValue()))
+                    .append("\"");
+                if (++count < entry.size()) {
+                    json.append(",");
+                }
+                json.append("\n");
+            }
+            json.append("  }");
+            if (i < entries.size() - 1) {
+                json.append(",");
+            }
+            json.append("\n");
+        }
+        json.append("]");
+        return json.toString();
+    }
+}

--- a/playgrounds/notification-service-gradle-sb-2/chart/templates/deployment.yaml
+++ b/playgrounds/notification-service-gradle-sb-2/chart/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
               value: {{ .Values.axelix.sbs.auth.jwt.algorithm | quote }}
             - name: AXELIX_SBS_AUTH_JWT_SIGNING_KEY
               value: {{ .Values.axelix.sbs.auth.jwt.signingKey | quote }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/playgrounds/notification-service-gradle-sb-2/chart/values.yaml
+++ b/playgrounds/notification-service-gradle-sb-2/chart/values.yaml
@@ -68,3 +68,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# -- Additional container env vars, appended as-is after the chart's own fixed entries
+# (JWT algorithm/signing key). Lets e2e/CI tooling inject ad-hoc config (e.g. self-registration
+# properties) via `--set-json` without needing a chart change for every new property.
+extraEnv: []

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "axelix"
 
 include(
     ":master",
+    ":master-e2e-tests",
     ":sbs:axelix-spring-boot-2-starter",
     ":sbs:axelix-spring-boot-3-starter",
     ":sbs:axelix-spring-boot-4-starter",


### PR DESCRIPTION
close #1354 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded end-to-end testing to run across a configuration matrix (database, discovery, auth, and MCP).
  * Added a nightly/manual E2E workflow with per-matrix execution, updated image tagging, and improved Helm-driven deployments.
  * Added MySQL and PostgreSQL Kubernetes test environments; extended test environment setup/DB selection accordingly.
* **Bug Fixes**
  * Improved notification-service deployment handling for both discovery modes, including passing discovery settings via chart-configured extra environment variables.
  * Improved E2E execution, health waits, log/cluster-state collection, and report uploading (failure-only, shorter retention).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->