### PR TITLE
GH-1356 Disallow overriding beans in `GarbageCollectionAutoConfiguration`

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/GarbageCollectionAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/GarbageCollectionAutoConfiguration.java
@@ -20,7 +20,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.gclog.ConditionalOnJcmd;
@@ -41,13 +40,11 @@ public class GarbageCollectionAutoConfiguration {
 
     @Bean
     @ConditionalOnJcmd
-    @ConditionalOnMissingBean
     public JcmdExecutor jcmdExecutor() {
         return new JcmdExecutor();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public GcLogService gcLogService(JcmdExecutor jcmdExecutor) {
         return new DefaultGcLogService(
                 jcmdExecutor, new SLF4JLogger(LoggerFactory.getLogger(DefaultGcLogService.class)));

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/GarbageCollectionAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/GarbageCollectionAutoConfigurationTest.java
@@ -18,17 +18,12 @@
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 
-import com.axelixlabs.axelix.sbs.spring.core.gclog.DefaultGcLogService;
 import com.axelixlabs.axelix.sbs.spring.core.gclog.GcLogService;
 import com.axelixlabs.axelix.sbs.spring.core.gclog.JcmdExecutor;
-import com.axelixlabs.axelix.sbs.spring.core.log.SLF4JLogger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -49,26 +44,5 @@ class GarbageCollectionAutoConfigurationTest {
             assertThat(context).hasSingleBean(JcmdExecutor.class);
             assertThat(context).hasSingleBean(GcLogService.class);
         });
-    }
-
-    @Test
-    void shouldHandleCustomBeans() {
-        contextRunner.withUserConfiguration(CustomGcLogServiceConfig.class).run(context -> {
-            assertThat(context.getBean(GcLogService.class)).isExactlyInstanceOf(CustomGcLogService.class);
-        });
-    }
-
-    @TestConfiguration
-    static class CustomGcLogServiceConfig {
-        @Bean
-        public GcLogService gcLogService(JcmdExecutor jcmdExecutor) {
-            return new CustomGcLogService(jcmdExecutor);
-        }
-    }
-
-    static class CustomGcLogService extends DefaultGcLogService {
-        public CustomGcLogService(JcmdExecutor jcmdExecutor) {
-            super(jcmdExecutor, new SLF4JLogger(LoggerFactory.getLogger(DefaultGcLogService.class)));
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/GarbageCollectionAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/GarbageCollectionAutoConfiguration.java
@@ -20,7 +20,6 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 
 import com.axelixlabs.axelix.sbs.spring.core.gclog.ConditionalOnJcmd;
@@ -40,13 +39,11 @@ public class GarbageCollectionAutoConfiguration {
 
     @Bean
     @ConditionalOnJcmd
-    @ConditionalOnMissingBean
     public JcmdExecutor jcmdExecutor() {
         return new JcmdExecutor();
     }
 
     @Bean
-    @ConditionalOnMissingBean
     public GcLogService gcLogService(JcmdExecutor jcmdExecutor) {
         return new DefaultGcLogService(
                 jcmdExecutor, new SLF4JLogger(LoggerFactory.getLogger(DefaultGcLogService.class)));

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/GarbageCollectionAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/GarbageCollectionAutoConfigurationTest.java
@@ -18,17 +18,12 @@
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Bean;
 
-import com.axelixlabs.axelix.sbs.spring.core.gclog.DefaultGcLogService;
 import com.axelixlabs.axelix.sbs.spring.core.gclog.GcLogService;
 import com.axelixlabs.axelix.sbs.spring.core.gclog.JcmdExecutor;
-import com.axelixlabs.axelix.sbs.spring.core.log.SLF4JLogger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -49,26 +44,5 @@ class GarbageCollectionAutoConfigurationTest {
             assertThat(context).hasSingleBean(JcmdExecutor.class);
             assertThat(context).hasSingleBean(GcLogService.class);
         });
-    }
-
-    @Test
-    void shouldHandleCustomBeans() {
-        contextRunner.withUserConfiguration(CustomGcLogServiceConfig.class).run(context -> {
-            assertThat(context.getBean(GcLogService.class)).isExactlyInstanceOf(CustomGcLogService.class);
-        });
-    }
-
-    @TestConfiguration
-    static class CustomGcLogServiceConfig {
-        @Bean
-        public GcLogService gcLogService(JcmdExecutor jcmdExecutor) {
-            return new CustomGcLogService(jcmdExecutor);
-        }
-    }
-
-    static class CustomGcLogService extends DefaultGcLogService {
-        public CustomGcLogService(JcmdExecutor jcmdExecutor) {
-            super(jcmdExecutor, new SLF4JLogger(LoggerFactory.getLogger(DefaultGcLogService.class)));
-        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GC monitoring components are now registered consistently when the feature is enabled, improving availability in supported Spring Boot setups.
  * Bean creation no longer depends on an existing matching component, reducing cases where GC support could be skipped unexpectedly.
* **Tests**
  * Updated coverage to reflect the new always-on registration behavior for GC-related components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->