### PR TITLE
GH-1359 Enable `GC Logging`, `AppCDS`, `AOTCache` and `CompactObjectHeaders` in playgrounds

### DIFF
--- a/.github/actions/build-master/action.yaml
+++ b/.github/actions/build-master/action.yaml
@@ -8,15 +8,20 @@ inputs:
     description: Gradle configuration cache encryption key
     required: true
 
+outputs:
+  java-25-home:
+    description: Java 25 installation path
+    value: ${{ steps.setup-java-25.outputs.path }}
+
 runs:
   using: composite
   steps:
-
     # That is the important step. Note, that:
     #   - The gradle JVM process itself run on java 25
     #   - Then on each individual gradle module (master/sbs3/sbs2) the necessary
     #     toolchain is specified per individual basis
     - name: Set up JDK 25
+      id: setup-java-25
       uses: actions/setup-java@v4
       with:
         distribution: 'liberica'

--- a/.github/workflows/backend_pull_requests.yaml
+++ b/.github/workflows/backend_pull_requests.yaml
@@ -77,11 +77,11 @@ jobs:
           java-version: '21'
           distribution: 'liberica'
 
-      - name: Set up JDK 24 for Playgrounds
+      - name: Set up JDK 25 for Playgrounds
         uses: actions/setup-java@v4
-        id: setup-java-24
+        id: setup-java-25
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'liberica'
 
       # Starting build playground projects
@@ -119,7 +119,7 @@ jobs:
 
           JAVA_17_HOME: ${{ steps.setup-java-17.outputs.path }}
           JAVA_21_HOME: ${{ steps.setup-java-21.outputs.path }}
-          JAVA_24_HOME: ${{ steps.setup-java-24.outputs.path }}
+          JAVA_25_HOME: ${{ steps.setup-java-25.outputs.path }}
         run: |
           SHOULD_BUILD_SB2="false"
           if [ "$SB2_CHANGE_TRIGGER" = "true" ] || [ "$GLOBAL_CHANGE_TRIGGER" = "true" ]; then

--- a/.github/workflows/backend_pull_requests.yaml
+++ b/.github/workflows/backend_pull_requests.yaml
@@ -58,6 +58,7 @@ jobs:
 
       # Java 25 will be installed at this step.
       - name: Build Backend
+        id: build-backend
         uses: ./.github/actions/build-master
         with:
           gradle-cache-encryption-key: ''
@@ -75,13 +76,6 @@ jobs:
         id: setup-java-21
         with:
           java-version: '21'
-          distribution: 'liberica'
-
-      - name: Set up JDK 25 for Playgrounds
-        uses: actions/setup-java@v4
-        id: setup-java-25
-        with:
-          java-version: '25'
           distribution: 'liberica'
 
       # Starting build playground projects
@@ -119,7 +113,7 @@ jobs:
 
           JAVA_17_HOME: ${{ steps.setup-java-17.outputs.path }}
           JAVA_21_HOME: ${{ steps.setup-java-21.outputs.path }}
-          JAVA_25_HOME: ${{ steps.setup-java-25.outputs.path }}
+          JAVA_25_HOME: ${{ steps.build-backend.outputs.java-25-home }}
         run: |
           SHOULD_BUILD_SB2="false"
           if [ "$SB2_CHANGE_TRIGGER" = "true" ] || [ "$GLOBAL_CHANGE_TRIGGER" = "true" ]; then

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -70,6 +70,7 @@ jobs:
 
       # Java 25 will be installed at this step.
       - name: Build Backend
+        id: build-backend
         uses: ./.github/actions/build-master
         with:
           deploy-to-nexus: true
@@ -156,19 +157,12 @@ jobs:
         with:
           java-version: '21'
           distribution: 'liberica'
-
-      - name: Set up JDK 25 for Playgrounds
-        uses: actions/setup-java@v4
-        id: setup-java-25
-        with:
-          java-version: '25'
-          distribution: 'liberica'
           
       - name: Build Playgrounds
         env:
           JAVA_17_HOME: ${{ steps.setup-java-17.outputs.path }}
           JAVA_21_HOME: ${{ steps.setup-java-21.outputs.path }}
-          JAVA_25_HOME: ${{ steps.setup-java-25.outputs.path }}
+          JAVA_25_HOME: ${{ steps.build-backend.outputs.java-25-home }}
         run: |
           make build-playground BUILD_ALL_PLAYGROUNDS="true"
 

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -157,18 +157,18 @@ jobs:
           java-version: '21'
           distribution: 'liberica'
 
-      - name: Set up JDK 24 for Playgrounds
+      - name: Set up JDK 25 for Playgrounds
         uses: actions/setup-java@v4
-        id: setup-java-24
+        id: setup-java-25
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'liberica'
           
       - name: Build Playgrounds
         env:
           JAVA_17_HOME: ${{ steps.setup-java-17.outputs.path }}
           JAVA_21_HOME: ${{ steps.setup-java-21.outputs.path }}
-          JAVA_24_HOME: ${{ steps.setup-java-24.outputs.path }}
+          JAVA_25_HOME: ${{ steps.setup-java-25.outputs.path }}
         run: |
           make build-playground BUILD_ALL_PLAYGROUNDS="true"
 

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,11 @@ LOCAL_JAVA_21 := $(firstword $(wildcard \
     $(HOME)/.jdks/temurin-21* \
     $(HOME)/.sdkman/candidates/java/21*))
 
-LOCAL_JAVA_24 := $(firstword $(wildcard \
-    $(JAVA_24_HOME) \
-    $(HOME)/.jdks/liberica-24* \
-    $(HOME)/.jdks/temurin-24* \
-    $(HOME)/.sdkman/candidates/java/24*))
+LOCAL_JAVA_25 := $(firstword $(wildcard \
+    $(JAVA_25_HOME) \
+    $(HOME)/.jdks/liberica-25* \
+    $(HOME)/.jdks/temurin-25* \
+    $(HOME)/.sdkman/candidates/java/25*))
 
 # PUBLISH STARTERS
 publish-starter-sb-2:
@@ -95,7 +95,7 @@ build-notification-service-gradle-sb-2:
 
 build-feature-service-maven-sb-3:
 	@echo "=== Running Maven build for Feature Service Spring Boot 3 ==="
-	cd playgrounds/feature-service-maven-sb-3 && JAVA_HOME=$(LOCAL_JAVA_24) ./mvnw package -B
+	cd playgrounds/feature-service-maven-sb-3 && JAVA_HOME=$(LOCAL_JAVA_25) ./mvnw package -B
 
 build-spring-petclinic-gradle-sb-3:
 	@echo "=== Running Gradle build for Petclinic Spring Boot 3 ==="

--- a/playgrounds/feature-service-maven-sb-3/docker/Dockerfile
+++ b/playgrounds/feature-service-maven-sb-3/docker/Dockerfile
@@ -1,9 +1,52 @@
-FROM eclipse-temurin:24
+# Stage: Spring Boot layer extraction for AOT-cache-friendly runtime layout
+FROM eclipse-temurin:25 AS training
 
-WORKDIR /app
+WORKDIR /application
 
-COPY target/feature-service-0.0.2-SNAPSHOT.jar /app/feature-service.jar
+COPY target/feature-service-0.0.2-SNAPSHOT.jar /application/application.jar
+
+# Extract Spring Boot layers so training and runtime use the same layout
+RUN java \
+    -Djarmode=tools \
+    -jar application.jar extract \
+    --layers \
+    --destination extracted
+
+# Stage: final runtime image
+FROM eclipse-temurin:25
+
+WORKDIR /application
+
+COPY --from=training /application/extracted/dependencies/ ./
+COPY --from=training /application/extracted/spring-boot-loader/ ./
+COPY --from=training /application/extracted/snapshot-dependencies/ ./
+COPY --from=training /application/extracted/application/ ./
+
+# Step 1: Record class loading profile
+RUN java \
+    -XX:+UseCompactObjectHeaders \
+    -XX:AOTMode=record \
+    -XX:AOTConfiguration=application.aotconf \
+    -Daxelix.sbs.auth.jwt.algorithm=HMAC256 \
+    -Daxelix.sbs.auth.jwt.signing-key=8DrZJSOJ8vkbxdjUB3sSsyeiG4Xidf1sDNmJq1Slkkn \
+    -Dspring.context.exit=onRefresh \
+    -jar /application/application.jar
+
+# Step 2: Create AOT cache from the recorded profile
+RUN java \
+    -XX:+UseCompactObjectHeaders \
+    -XX:AOTMode=create \
+    -XX:AOTConfiguration=application.aotconf \
+    -XX:AOTCache=application.aot \
+    -jar /application/application.jar
 
 EXPOSE 8080
 
-CMD ["java", "-jar", "/app/feature-service.jar"]
+# JVM options
+ENV JAVA_GC_LOG_OPTS="-Xlog:gc=info,safepoint:gc.log::filecount=1,filesize=20M"
+ENV JAVA_AOT_CACHE_OPTS="-XX:+UseCompactObjectHeaders -XX:AOTCache=/application/application.aot"
+
+ENTRYPOINT exec java \
+    $JAVA_AOT_CACHE_OPTS \
+    $JAVA_GC_LOG_OPTS \
+    -jar /application/application.jar

--- a/playgrounds/feature-service-maven-sb-3/pom.xml
+++ b/playgrounds/feature-service-maven-sb-3/pom.xml
@@ -16,7 +16,7 @@
     <name>feature-service</name>
     <description>feature-service</description>
     <properties>
-        <java.version>24</java.version>
+        <java.version>25</java.version>
         <spring-cloud.version>2025.0.0</spring-cloud.version>
         <springdoc.version>2.8.9</springdoc.version>
         <org.mapstruct.version>1.6.3</org.mapstruct.version>

--- a/playgrounds/spring-petclinic-gradle-sb-3/docker/Dockerfile
+++ b/playgrounds/spring-petclinic-gradle-sb-3/docker/Dockerfile
@@ -1,9 +1,42 @@
+# Stage: Spring Boot layer extraction for CDS-friendly runtime layout
+FROM eclipse-temurin:17 AS training
+
+WORKDIR /application
+
+COPY build/libs/spring-petclinic-3.5.0-SNAPSHOT.jar /application/application.jar
+
+# Extract Spring Boot layers so training and runtime use the same layout
+RUN java \
+    -Djarmode=tools \
+    -jar application.jar extract \
+    --layers \
+    --destination extracted
+
+# Stage: final runtime image
 FROM eclipse-temurin:17
 
-WORKDIR /app
+WORKDIR /application
 
-COPY build/libs/spring-petclinic-3.5.0-SNAPSHOT.jar /app/petclinic.jar
+COPY --from=training /application/extracted/dependencies/ ./
+COPY --from=training /application/extracted/spring-boot-loader/ ./
+COPY --from=training /application/extracted/snapshot-dependencies/ ./
+COPY --from=training /application/extracted/application/ ./
+
+# Execute the CDS training run
+RUN java \
+    -XX:ArchiveClassesAtExit=/application/application.jsa \
+    -Daxelix.sbs.auth.jwt.algorithm=HMAC256 \
+    -Daxelix.sbs.auth.jwt.signing-key=8DrZJSOJ8vkbxdjUB3sSsyeiG4Xidf1sDNmJq1Slkkn \
+    -Dspring.context.exit=onRefresh \
+    -jar /application/application.jar
 
 EXPOSE 8080
 
-CMD ["java", "-jar", "/app/petclinic.jar"]
+# JVM options
+ENV JAVA_GC_LOG_OPTS="-Xlog:gc=info,safepoint:gc.log::filecount=1,filesize=20M"
+ENV JAVA_APP_CDS_OPTS="-XX:SharedArchiveFile=/application/application.jsa"
+
+ENTRYPOINT exec java \
+    $JAVA_APP_CDS_OPTS \
+    $JAVA_GC_LOG_OPTS \
+    -jar /application/application.jar


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reworked container builds to use multi-stage, layered application packaging for faster startup.
  * Added build-time generation and runtime usage of JVM optimization artifacts (CDS/AOT cache) for improved performance.
  * Exposed service port **8080** and enabled GC logging to **/tmp/gc.log**.
* **Chores**
  * Upgraded Playgrounds and Feature Service tooling/builds to **JDK 25**, updating Maven, Docker builds, workflows, and local Java detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->