### PR TITLE
GH-1346 Skip linked issue check for external contributors

### DIFF
--- a/.github/workflows/check_linked_issues_pull_requests.yaml
+++ b/.github/workflows/check_linked_issues_pull_requests.yaml
@@ -15,6 +15,17 @@ concurrency:
 
 jobs:
   check-linked-issues:
+    # External contributors can open PRs without targeting a specific issue.
+    #
+    # OWNER - Author is the owner of the repository.
+    # MEMBER - Author is a member of the organization that owns the repository.
+    # COLLABORATOR - Author has been invited to collaborate on the repository.
+    #
+    # see https://docs.github.com/en/graphql/reference/issues#enums
+    if: >-
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR'
     runs-on: ubuntu-latest
     steps:
       - name: Check for linked issues


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pull request validation so linked-issue checks run only for pull requests submitted by repository owners or organization members.
  * Added clearer documentation in the review process about external contributors and how they may open pull requests without linking to a specific issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->