### PR TITLE
GH-1376 Hide `Caches` endpoint implementation classes from starter public API

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpoint.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpoint.java
@@ -35,11 +35,11 @@ import com.axelixlabs.axelix.common.api.caches.SingleCache;
  * @author Sergey Cherkasov
  */
 @RestControllerEndpoint(id = "axelix-caches")
-public class AxelixCachesEndpoint {
+class AxelixCachesEndpoint {
 
     private final CacheOperationsDispatcher dispatcher;
 
-    public AxelixCachesEndpoint(CacheOperationsDispatcher dispatcher) {
+    AxelixCachesEndpoint(CacheOperationsDispatcher dispatcher) {
         this.dispatcher = dispatcher;
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointAutoConfiguration.java
@@ -15,43 +15,48 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import java.util.Map;
 
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 
-import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheManagerBeanPostProcessor;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheOperationsDispatcher;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
-import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheOperationsDispatcher;
-import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheSizeProvider;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
-
 /**
- * Auto-configuration class for the caches custom actuator endpoint.
+ * {@code CacheDispatcherAutoConfiguration} provides auto-configuration
+ * for cache dispatching and exposing cache-related operations via a custom Actuator endpoint.
+ *
+ * <p>This configuration registers the following beans if they are not already defined in the context:
+ * <ul>
+ *     <li>{@link DefaultCacheOperationsDispatcher} — dispatcher that coordinates cache operations across
+ *  *     all registered {@link CacheManager} beans,</li>
+ *     <li>{@link AxelixCachesEndpoint} — a custom Spring Boot Actuator endpoint for cache management.</li>
+ * </ul>
+ * <p>Auto-configuration is only activated if a {@link CacheManager}
+ * bean is available in the application context.
+ *
+ * <p>This class is intended to be registered via Spring Boot's auto-configuration mechanism,
+ * {@code META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports}
+ * (for Spring Boot 3.x+).
  *
  * @since 24.06.2025
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
  */
-@AutoConfiguration(after = {CacheAutoConfiguration.class, AxelixMetricsPublisherAutoConfiguration.class})
+@AutoConfiguration(after = {CacheAutoConfiguration.class})
 @ConditionalOnAvailableEndpoint(endpoint = AxelixCachesEndpoint.class)
 public class AxelixCachesEndpointAutoConfiguration {
 
     @Bean
-    public CacheSizeProvider cacheSizeProvider() {
+    CacheSizeProvider cacheSizeProvider() {
         return new DefaultCacheSizeProvider();
     }
 
     @Bean
-    public CacheOperationsDispatcher cacheOperationsDispatcher(
+    CacheOperationsDispatcher cacheOperationsDispatcher(
             // we have to inject here by CacheManager rather than by EnhancedCacheManager, since the bean definition
             // in spring for the EnhancedCacheManager still has CacheManager type.
             Map<String, CacheManager> managerMap, CacheSizeProvider cacheSizeProvider) {
@@ -59,13 +64,12 @@ public class AxelixCachesEndpointAutoConfiguration {
     }
 
     @Bean
-    public AxelixCachesEndpoint axelixCachesEndpoint(CacheOperationsDispatcher dispatcher) {
+    AxelixCachesEndpoint axelixCachesEndpoint(CacheOperationsDispatcher dispatcher) {
         return new AxelixCachesEndpoint(dispatcher);
     }
 
     @Bean
-    public CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
-            ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider) {
-        return new CacheManagerBeanPostProcessor(metricsPublisherObjectProvider);
+    CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor() {
+        return new CacheManagerBeanPostProcessor();
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -34,7 +34,7 @@ import org.springframework.cache.CacheManager;
  * @author Nikita Kirillov
  * @author Artemiy Degtyarev
  */
-public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
+class CacheManagerBeanPostProcessor implements BeanPostProcessor {
 
     @Override
     public Object postProcessAfterInitialization(@NonNull Object bean, @NonNull String beanName) throws BeansException {

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcher.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcher.java
@@ -43,12 +43,12 @@ import com.axelixlabs.axelix.common.api.caches.SingleCache;
 //  We need to migrate to more recent versions of NullAway. Current version incorrectly
 //  reports the nullability issue with type-use annotations on generics
 @SuppressWarnings("NullAway")
-public class DefaultCacheOperationsDispatcher implements CacheOperationsDispatcher {
+class DefaultCacheOperationsDispatcher implements CacheOperationsDispatcher {
 
     private final Map<String, EnhancedCacheManager> cacheManagers;
     private final CacheSizeProvider cacheSizeProvider;
 
-    public DefaultCacheOperationsDispatcher(Map<String, CacheManager> managers, CacheSizeProvider cacheSizeProvider) {
+    DefaultCacheOperationsDispatcher(Map<String, CacheManager> managers, CacheSizeProvider cacheSizeProvider) {
         this.cacheManagers = onlyEnhancedCacheManagers(managers);
         this.cacheSizeProvider = cacheSizeProvider;
     }
@@ -145,13 +145,13 @@ public class DefaultCacheOperationsDispatcher implements CacheOperationsDispatch
         execute(cacheManagerName, adapter -> adapter.disable(cacheName));
     }
 
-    public <T> T get(String cacheManagerName, Function<EnhancedCacheManager, @Nullable T> providerFunction) {
+    <T> T get(String cacheManagerName, Function<EnhancedCacheManager, @Nullable T> providerFunction) {
         EnhancedCacheManager enhancedCacheManager = findCacheManager(cacheManagerName);
 
         return providerFunction.apply(enhancedCacheManager);
     }
 
-    public <T> void execute(String cacheManagerName, Consumer<EnhancedCacheManager> action) {
+    <T> void execute(String cacheManagerName, Consumer<EnhancedCacheManager> action) {
         EnhancedCacheManager enhancedCacheManager = findCacheManager(cacheManagerName);
 
         action.accept(enhancedCacheManager);

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheSizeProvider.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheSizeProvider.java
@@ -28,7 +28,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Sergey Cherkasov
  */
-public class DefaultCacheSizeProvider implements CacheSizeProvider {
+class DefaultCacheSizeProvider implements CacheSizeProvider {
     private static final ClassLoader CLASS_LOADER = DefaultCacheSizeProvider.class.getClassLoader();
 
     private static final boolean CAFFEINE_CACHE_PRESENT =

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCache.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCache.java
@@ -37,13 +37,13 @@ import com.axelixlabs.axelix.sbs.spring.core.SlidingWindow;
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
  */
-public class DefaultEnhancedCache implements EnhancedCache {
+class DefaultEnhancedCache implements EnhancedCache {
 
     private final Cache delegate;
     private final AtomicBoolean enabled;
     private final SlidingWindow<CacheLookup> cacheLookupHistory;
 
-    public DefaultEnhancedCache(@NonNull Cache delegate) {
+    DefaultEnhancedCache(@NonNull Cache delegate) {
         this.delegate = delegate;
         this.enabled = new AtomicBoolean(true);
         // TODO: We need to find a way to allow for configuring those values

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
@@ -39,13 +39,13 @@ import org.springframework.cache.CacheManager;
  * @author Sergey Cherkasov
  * @author Artemiy Degtyarev
  */
-public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
+class DefaultEnhancedCacheManager implements EnhancedCacheManager {
 
     private final String cacheManagerBeanName;
     private final CacheManager delegate;
     private final Map<String, EnhancedCache> caches = new ConcurrentHashMap<>();
 
-    public DefaultEnhancedCacheManager(String cacheManagerBeanName, CacheManager delegate) {
+    DefaultEnhancedCacheManager(String cacheManagerBeanName, CacheManager delegate) {
         this.delegate = delegate;
         this.cacheManagerBeanName = cacheManagerBeanName;
     }

--- a/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,5 +1,5 @@
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -23,7 +23,6 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration;
@@ -44,6 +43,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProvider
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpointAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -62,12 +61,8 @@ import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
 import com.axelixlabs.axelix.sbs.spring.core.beans.BeansFeedBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeanMetaInfoExtractor;
 import com.axelixlabs.axelix.sbs.spring.core.beans.QualifiersPersistencePostProcessor;
-import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheManagerBeanPostProcessor;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
-import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheOperationsDispatcher;
-import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheSizeProvider;
 import com.axelixlabs.axelix.sbs.spring.core.cache.EnhancedCacheManager;
+import com.axelixlabs.axelix.sbs.spring.core.cache.TestCachesEndpointConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRefBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
@@ -91,11 +86,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(
         properties = {
             "axelix.prop.test.name=axelix-beans",
+            "management.endpoints.web.exposure.include=axelix-caches,axelix-beans,health",
         })
 @Import({
     JwtAuthorizationFilterTestConfiguration.class,
-    AxelixCachesEndpoint.class,
-    DefaultCacheOperationsDispatcher.class,
+    TestCachesEndpointConfiguration.class,
     EnvironmentTestConfig.class,
     JwtAuthTestConfiguration.class
 })
@@ -438,17 +433,6 @@ class JwtAuthorizationFilterTest {
         public SmartSanitizingFunction smartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
             return new SmartSanitizingFunction(
                     List.of("axelix.env.test.toBeSanitized", "AXELIX_FOR_SANITIZATION"), propertyNameNormalizer);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public CacheSizeProvider cacheSizeProvider() {
-            return new DefaultCacheSizeProvider();
-        }
-
-        @Bean
-        public static CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor() {
-            return new CacheManagerBeanPostProcessor();
         }
 
         @Bean(name = MAIN_CACHE_MANAGER)

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointAutoConfigurationTest.java
@@ -15,17 +15,12 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-
-import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheManagerBeanPostProcessor;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheOperationsDispatcher;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cache.Cache;
@@ -69,10 +68,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since 24.06.2025
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Main.class)
-@Import({
-    AxelixCachesEndpoint.class,
-    DefaultCacheOperationsDispatcher.class,
-    AxelixCachesEndpointTest.CacheDispatcherEndpointTestConfiguration.class
+@Import({TestCachesEndpointConfiguration.class, AxelixCachesEndpointTest.CacheDispatcherEndpointTestConfiguration.class
 })
 class AxelixCachesEndpointTest {
 
@@ -519,17 +515,6 @@ class AxelixCachesEndpointTest {
 
     @TestConfiguration
     public static class CacheDispatcherEndpointTestConfiguration {
-
-        @Bean
-        @ConditionalOnMissingBean
-        public CacheSizeProvider cacheSizeProvider() {
-            return new DefaultCacheSizeProvider();
-        }
-
-        @Bean
-        public static CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor() {
-            return new CacheManagerBeanPostProcessor();
-        }
 
         @Bean(name = MAIN_CACHE_MANAGER)
         @Primary

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/TestCachesEndpointConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/TestCachesEndpointConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.cache;
+
+import java.util.Map;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Test-only configuration that wires the {@link AxelixCachesEndpoint} without importing production auto-configuration.
+ *
+ * @author Sergey Cherkasov
+ */
+@TestConfiguration
+public class TestCachesEndpointConfiguration {
+
+    @Bean
+    CacheSizeProvider cacheSizeProvider() {
+        return new DefaultCacheSizeProvider();
+    }
+
+    @Bean
+    CacheOperationsDispatcher cacheOperationsDispatcher(
+            Map<String, CacheManager> managerMap, CacheSizeProvider cacheSizeProvider) {
+        return new DefaultCacheOperationsDispatcher(managerMap, cacheSizeProvider);
+    }
+
+    @Bean
+    AxelixCachesEndpoint axelixCachesEndpoint(CacheOperationsDispatcher dispatcher) {
+        return new AxelixCachesEndpoint(dispatcher);
+    }
+
+    @Bean
+    CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor() {
+        return new CacheManagerBeanPostProcessor();
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/concurrencyTest/kotlin/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheTest.kt
+++ b/sbs/axelix-spring-boot-3-starter/src/concurrencyTest/kotlin/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheTest.kt
@@ -34,7 +34,7 @@ import java.util.concurrent.ConcurrentHashMap
 @Param(name = "key", gen = StringGen::class, conf = "1:3")
 class DefaultEnhancedCacheTest {
 
-    val delegate = DefaultEnhancedCache(ConcurrentMapCache("test-cache", ConcurrentHashMap(3), true), null)
+    private val delegate = DefaultEnhancedCache(ConcurrentMapCache("test-cache", ConcurrentHashMap(3), true), null)
 
     @Operation fun getValueWrapper(@Param(name = "key") key: Any) = delegate.get(key)?.get()
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpoint.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpoint.java
@@ -35,11 +35,11 @@ import com.axelixlabs.axelix.common.api.caches.SingleCache;
  * @author Sergey Cherkasov
  */
 @RestControllerEndpoint(id = "axelix-caches")
-public class AxelixCachesEndpoint {
+class AxelixCachesEndpoint {
 
     private final CacheOperationsDispatcher dispatcher;
 
-    public AxelixCachesEndpoint(CacheOperationsDispatcher dispatcher) {
+    AxelixCachesEndpoint(CacheOperationsDispatcher dispatcher) {
         this.dispatcher = dispatcher;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointAutoConfiguration.java
@@ -15,55 +15,38 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import java.util.Map;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 
-import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheManagerBeanPostProcessor;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheOperationsDispatcher;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
-import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheOperationsDispatcher;
-import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheSizeProvider;
+import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsPublisherAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
 
 /**
- * {@code CacheDispatcherAutoConfiguration} provides auto-configuration
- * for cache dispatching and exposing cache-related operations via a custom Actuator endpoint.
- *
- * <p>This configuration registers the following beans if they are not already defined in the context:
- * <ul>
- *     <li>{@link DefaultCacheOperationsDispatcher} — dispatcher that coordinates cache operations across
- *  *     all registered {@link CacheManager} beans,</li>
- *     <li>{@link AxelixCachesEndpoint} — a custom Spring Boot Actuator endpoint for cache management.</li>
- * </ul>
- * <p>Auto-configuration is only activated if a {@link CacheManager}
- * bean is available in the application context.
- *
- * <p>This class is intended to be registered via Spring Boot's auto-configuration mechanism,
- * {@code META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports}
- * (for Spring Boot 3.x+).
+ * Auto-configuration class for the caches custom actuator endpoint.
  *
  * @since 24.06.2025
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
  */
-@AutoConfiguration(after = {CacheAutoConfiguration.class})
+@AutoConfiguration(after = {CacheAutoConfiguration.class, AxelixMetricsPublisherAutoConfiguration.class})
 @ConditionalOnAvailableEndpoint(endpoint = AxelixCachesEndpoint.class)
 public class AxelixCachesEndpointAutoConfiguration {
 
     @Bean
-    public CacheSizeProvider cacheSizeProvider() {
+    CacheSizeProvider cacheSizeProvider() {
         return new DefaultCacheSizeProvider();
     }
 
     @Bean
-    public CacheOperationsDispatcher cacheOperationsDispatcher(
+    CacheOperationsDispatcher cacheOperationsDispatcher(
             // we have to inject here by CacheManager rather than by EnhancedCacheManager, since the bean definition
             // in spring for the EnhancedCacheManager still has CacheManager type.
             Map<String, CacheManager> managerMap, CacheSizeProvider cacheSizeProvider) {
@@ -71,12 +54,13 @@ public class AxelixCachesEndpointAutoConfiguration {
     }
 
     @Bean
-    public AxelixCachesEndpoint axelixCachesEndpoint(CacheOperationsDispatcher dispatcher) {
+    AxelixCachesEndpoint axelixCachesEndpoint(CacheOperationsDispatcher dispatcher) {
         return new AxelixCachesEndpoint(dispatcher);
     }
 
     @Bean
-    public CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor() {
-        return new CacheManagerBeanPostProcessor();
+    CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
+            ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider) {
+        return new CacheManagerBeanPostProcessor(metricsPublisherObjectProvider);
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerBeanPostProcessor.java
@@ -36,11 +36,11 @@ import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
  * @author Nikita Kirillov
  * @author Artemiy Degtyarev
  */
-public class CacheManagerBeanPostProcessor implements BeanPostProcessor {
+class CacheManagerBeanPostProcessor implements BeanPostProcessor {
 
     private final ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider;
 
-    public CacheManagerBeanPostProcessor(ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider) {
+    CacheManagerBeanPostProcessor(ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider) {
         this.metricsPublisherObjectProvider = metricsPublisherObjectProvider;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcher.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcher.java
@@ -43,12 +43,12 @@ import com.axelixlabs.axelix.common.api.caches.SingleCache;
 //  We need to migrate to more recent versions of jspecify. Current version incorrectly
 //  reports the nullability issue with type-use annotations on generics
 @SuppressWarnings("NullAway")
-public class DefaultCacheOperationsDispatcher implements CacheOperationsDispatcher {
+class DefaultCacheOperationsDispatcher implements CacheOperationsDispatcher {
 
     private final Map<String, EnhancedCacheManager> cacheManagers;
     private final CacheSizeProvider cacheSizeProvider;
 
-    public DefaultCacheOperationsDispatcher(Map<String, CacheManager> managers, CacheSizeProvider cacheSizeProvider) {
+    DefaultCacheOperationsDispatcher(Map<String, CacheManager> managers, CacheSizeProvider cacheSizeProvider) {
         this.cacheManagers = onlyEnhancedCacheManagers(managers);
         this.cacheSizeProvider = cacheSizeProvider;
     }
@@ -153,14 +153,14 @@ public class DefaultCacheOperationsDispatcher implements CacheOperationsDispatch
         execute(cacheManagerName, adapter -> adapter.disable(cacheName));
     }
 
-    public <T> T extractFromCacheManager(
+    <T> T extractFromCacheManager(
             String cacheManagerName, Function<EnhancedCacheManager, @Nullable T> providerFunction) {
         EnhancedCacheManager enhancedCacheManager = findCacheManager(cacheManagerName);
 
         return providerFunction.apply(enhancedCacheManager);
     }
 
-    public <T> void execute(String cacheManagerName, Consumer<EnhancedCacheManager> action) {
+    <T> void execute(String cacheManagerName, Consumer<EnhancedCacheManager> action) {
         EnhancedCacheManager enhancedCacheManager = findCacheManager(cacheManagerName);
 
         action.accept(enhancedCacheManager);

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheSizeProvider.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheSizeProvider.java
@@ -28,7 +28,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Sergey Cherkasov
  */
-public class DefaultCacheSizeProvider implements CacheSizeProvider {
+class DefaultCacheSizeProvider implements CacheSizeProvider {
     private static final ClassLoader CLASS_LOADER = DefaultCacheSizeProvider.class.getClassLoader();
 
     private static final boolean CAFFEINE_CACHE_PRESENT =

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCache.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCache.java
@@ -39,7 +39,7 @@ import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
  */
-public class DefaultEnhancedCache implements EnhancedCache {
+class DefaultEnhancedCache implements EnhancedCache {
 
     private final Cache delegate;
     private final AtomicBoolean enabled;
@@ -47,7 +47,7 @@ public class DefaultEnhancedCache implements EnhancedCache {
 
     private final @Nullable AxelixMetricsPublisher metricsPublisher;
 
-    public DefaultEnhancedCache(@NonNull Cache delegate, @Nullable AxelixMetricsPublisher metricsPublisher) {
+    DefaultEnhancedCache(@NonNull Cache delegate, @Nullable AxelixMetricsPublisher metricsPublisher) {
         this.delegate = delegate;
         this.enabled = new AtomicBoolean(true);
         // TODO: We need to find a way to allow for configuring those values

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheManager.java
@@ -41,14 +41,14 @@ import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
  * @author Sergey Cherkasov
  * @author Artemiy Degtyarev
  */
-public class DefaultEnhancedCacheManager implements EnhancedCacheManager {
+class DefaultEnhancedCacheManager implements EnhancedCacheManager {
 
     private final String cacheManagerBeanName;
     private final CacheManager delegate;
     private final Map<String, EnhancedCache> caches = new ConcurrentHashMap<>();
     private final @Nullable AxelixMetricsPublisher metricsPublisher;
 
-    public DefaultEnhancedCacheManager(
+    DefaultEnhancedCacheManager(
             String cacheManagerBeanName, CacheManager delegate, @Nullable AxelixMetricsPublisher metricsPublisher) {
         this.delegate = delegate;
         this.cacheManagerBeanName = cacheManagerBeanName;

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerIntroduction.java
@@ -40,7 +40,7 @@ final class EnhancedCacheManagerIntroduction implements IntroductionInterceptor 
     private final EnhancedCacheManager delegate;
     private final Map<Method, Method> delegateMethods = new ConcurrentHashMap<>();
 
-    public EnhancedCacheManagerIntroduction(EnhancedCacheManager delegate) {
+    EnhancedCacheManagerIntroduction(EnhancedCacheManager delegate) {
         this.delegate = delegate;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,5 +1,5 @@
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -23,7 +23,6 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration;
@@ -47,6 +46,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProvider
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpointAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
@@ -29,10 +29,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -65,12 +63,8 @@ import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
 import com.axelixlabs.axelix.sbs.spring.core.beans.BeansFeedBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeanMetaInfoExtractor;
 import com.axelixlabs.axelix.sbs.spring.core.beans.QualifiersPersistencePostProcessor;
-import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheManagerBeanPostProcessor;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
-import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheOperationsDispatcher;
-import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheSizeProvider;
 import com.axelixlabs.axelix.sbs.spring.core.cache.EnhancedCacheManager;
+import com.axelixlabs.axelix.sbs.spring.core.cache.TestCachesEndpointConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRefBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.config.EndpointsConfigurationProperties;
@@ -99,11 +93,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(
         properties = {
             "axelix.prop.test.name=axelix-beans",
+            "management.endpoints.web.exposure.include=axelix-caches,axelix-env,axelix-beans,health",
         })
 @Import({
     JwtAuthorizationFilterTestConfiguration.class,
-    AxelixCachesEndpoint.class,
-    DefaultCacheOperationsDispatcher.class,
+    TestCachesEndpointConfiguration.class,
     EnvironmentTestConfig.class,
     JwtAuthTestConfiguration.class
 })
@@ -449,18 +443,6 @@ class JwtAuthorizationFilterTest {
         public SmartSanitizingFunction smartSanitizingFunction(PropertyNameNormalizer propertyNameNormalizer) {
             return new SmartSanitizingFunction(
                     List.of("axelix.env.test.toBeSanitized", "AXELIX_FOR_SANITIZATION"), propertyNameNormalizer);
-        }
-
-        @Bean
-        @ConditionalOnMissingBean
-        public CacheSizeProvider cacheSizeProvider() {
-            return new DefaultCacheSizeProvider();
-        }
-
-        @Bean
-        public static CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
-                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
-            return new CacheManagerBeanPostProcessor(axelixMetricsPublisherObjectProvider);
         }
 
         @Bean

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointAutoConfigurationTest.java
@@ -15,17 +15,12 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.cache;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-
-import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheManagerBeanPostProcessor;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheOperationsDispatcher;
-import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
@@ -29,10 +29,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.cache.Cache;
@@ -77,10 +75,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since 24.06.2025
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Main.class)
-@Import({
-    AxelixCachesEndpoint.class,
-    DefaultCacheOperationsDispatcher.class,
-    AxelixCachesEndpointTest.CacheDispatcherEndpointTestConfiguration.class
+@Import({TestCachesEndpointConfiguration.class, AxelixCachesEndpointTest.CacheDispatcherEndpointTestConfiguration.class
 })
 @IgnoreTestContextArchitecture(reason = POTENTIAL_CONTEXT_MUTATION)
 class AxelixCachesEndpointTest {
@@ -530,20 +525,8 @@ class AxelixCachesEndpointTest {
     public static class CacheDispatcherEndpointTestConfiguration {
 
         @Bean
-        @ConditionalOnMissingBean
-        public CacheSizeProvider cacheSizeProvider() {
-            return new DefaultCacheSizeProvider();
-        }
-
-        @Bean
         public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
             return new DefaultAxelixMetricsPublisher(meterRegistry);
-        }
-
-        @Bean
-        public static CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
-                ObjectProvider<AxelixMetricsPublisher> axelixMetricsPublisherObjectProvider) {
-            return new CacheManagerBeanPostProcessor(axelixMetricsPublisherObjectProvider);
         }
 
         @Bean(name = MAIN_CACHE_MANAGER)

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/TestCachesEndpointConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/TestCachesEndpointConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.cache;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+
+/**
+ * Test-only configuration that wires the {@link AxelixCachesEndpoint} without importing production auto-configuration.
+ *
+ * @author Sergey Cherkasov
+ */
+@TestConfiguration
+public class TestCachesEndpointConfiguration {
+
+    @Bean
+    CacheSizeProvider cacheSizeProvider() {
+        return new DefaultCacheSizeProvider();
+    }
+
+    @Bean
+    CacheOperationsDispatcher cacheOperationsDispatcher(
+            Map<String, CacheManager> managerMap, CacheSizeProvider cacheSizeProvider) {
+        return new DefaultCacheOperationsDispatcher(managerMap, cacheSizeProvider);
+    }
+
+    @Bean
+    AxelixCachesEndpoint axelixCachesEndpoint(CacheOperationsDispatcher dispatcher) {
+        return new AxelixCachesEndpoint(dispatcher);
+    }
+
+    @Bean
+    CacheManagerBeanPostProcessor cacheManagerBeanPostProcessor(
+            ObjectProvider<AxelixMetricsPublisher> metricsPublisherObjectProvider) {
+        return new CacheManagerBeanPostProcessor(metricsPublisherObjectProvider);
+    }
+}

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerNotFoundException.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheManagerNotFoundException.java
@@ -23,9 +23,9 @@ package com.axelixlabs.axelix.sbs.spring.core.cache;
  * @since 25.11.2025
  * @author Nikita Kirillov
  */
-public class CacheManagerNotFoundException extends RuntimeException {
+class CacheManagerNotFoundException extends RuntimeException {
 
-    public CacheManagerNotFoundException(String message) {
+    CacheManagerNotFoundException(String message) {
         super(message);
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheNotFoundException.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheNotFoundException.java
@@ -23,9 +23,9 @@ package com.axelixlabs.axelix.sbs.spring.core.cache;
  * @since 25.11.2025
  * @author Mikhail Polivakha
  */
-public class CacheNotFoundException extends RuntimeException {
+class CacheNotFoundException extends RuntimeException {
 
-    public CacheNotFoundException(String cacheName, String cacheManagerName) {
+    CacheNotFoundException(String cacheName, String cacheManagerName) {
         super(String.format("Cache '%s' is not found inside the cache manager '%s'", cacheName, cacheManagerName));
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheOperationsDispatcher.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheOperationsDispatcher.java
@@ -29,7 +29,7 @@ import com.axelixlabs.axelix.common.api.caches.SingleCache;
  * @author Sergey Cherkasov
  * @author Mikhail Polivakha
  */
-public interface CacheOperationsDispatcher {
+interface CacheOperationsDispatcher {
 
     /**
      * Get the profile of the specific cache.

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheSizeProvider.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/cache/CacheSizeProvider.java
@@ -24,7 +24,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Sergey Cherkasov
  */
-public interface CacheSizeProvider {
+interface CacheSizeProvider {
 
     /**
      * @param nativeCache the underlying native cache provider.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache actuator endpoint auto-configuration loading by updating which module provides the cache endpoint setup for Spring Boot 2 and 3.
* **Tests**
  * Refreshed cache-related test wiring to use shared test cache endpoint configuration and adjusted exposed actuator endpoints accordingly.
* **Chores**
  * Reduced the publicly exposed surface area of cache components and tightened encapsulation by limiting visibility and consolidating cache auto-configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->