### PR TITLE
GH-1380 Hide `HeapDump` endpoint implementation classes from starter public API

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/heapdump/AxelixHeapDumpEndpoint.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/heapdump/AxelixHeapDumpEndpoint.java
@@ -30,11 +30,11 @@ import org.springframework.lang.Nullable;
  * @author Sergey Cherkasov
  */
 @Endpoint(id = "axelix-heap-dump")
-public class AxelixHeapDumpEndpoint {
+class AxelixHeapDumpEndpoint {
 
     private final HeapDumpWebEndpoint delegate;
 
-    public AxelixHeapDumpEndpoint() {
+    AxelixHeapDumpEndpoint() {
         this.delegate = new HeapDumpWebEndpoint();
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/heapdump/AxelixHeapDumpEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/heapdump/AxelixHeapDumpEndpointAutoConfiguration.java
@@ -15,13 +15,11 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.heapdump;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
-
-import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
 
 /**
  * Auto-configuration for the {@link AxelixHeapDumpEndpoint}.
@@ -33,7 +31,7 @@ import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
 public class AxelixHeapDumpEndpointAutoConfiguration {
 
     @Bean
-    public AxelixHeapDumpEndpoint axelixHeapDumpEndpoint() {
+    AxelixHeapDumpEndpoint axelixHeapDumpEndpoint() {
         return new AxelixHeapDumpEndpoint();
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -5,7 +5,7 @@ com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertie
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixEnvironmentEndpointAutoConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.GarbageCollectionAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -29,7 +29,6 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPr
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixEnvironmentEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration;
@@ -43,6 +42,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProvider
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpointAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/heapdump/AxelixHeapDumpEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/heapdump/AxelixHeapDumpEndpointAutoConfigurationTest.java
@@ -15,14 +15,12 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.heapdump;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-
-import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/heapdump/AxelixHeapDumpEndpoint.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/heapdump/AxelixHeapDumpEndpoint.java
@@ -30,11 +30,11 @@ import org.springframework.lang.Nullable;
  * @author Sergey Cherkasov
  */
 @Endpoint(id = "axelix-heap-dump")
-public class AxelixHeapDumpEndpoint {
+class AxelixHeapDumpEndpoint {
 
     private final HeapDumpWebEndpoint delegate;
 
-    public AxelixHeapDumpEndpoint() {
+    AxelixHeapDumpEndpoint() {
         this.delegate = new HeapDumpWebEndpoint();
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/heapdump/AxelixHeapDumpEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/heapdump/AxelixHeapDumpEndpointAutoConfiguration.java
@@ -15,13 +15,11 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.heapdump;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
-
-import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
 
 /**
  * Auto-configuration for the {@link AxelixHeapDumpEndpoint}.
@@ -33,7 +31,7 @@ import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
 public class AxelixHeapDumpEndpointAutoConfiguration {
 
     @Bean
-    public AxelixHeapDumpEndpoint axelixHeapDumpEndpoint() {
+    AxelixHeapDumpEndpoint axelixHeapDumpEndpoint() {
         return new AxelixHeapDumpEndpoint();
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -5,7 +5,7 @@ com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertie
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixEnvironmentEndpointAutoConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.GarbageCollectionAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -30,7 +30,6 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointA
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixEnvironmentEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixFeignEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration;
@@ -46,6 +45,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProvider
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpointAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/heapdump/AxelixHeapDumpEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/heapdump/AxelixHeapDumpEndpointAutoConfigurationTest.java
@@ -15,14 +15,12 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.heapdump;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-
-import com.axelixlabs.axelix.sbs.spring.core.heapdump.AxelixHeapDumpEndpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the heap dump endpoint integration into a new package structure for both Spring Boot 2 and 3 starter modules.
  * Adjusted configuration and startup wiring so the heap dump endpoint continues to load correctly.

* **Tests**
  * Updated test package references and imports to match the new endpoint location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->