### PR TITLE
GH-1385 Hide `Scheduled Tasks` endpoint implementation classes from starter public API

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpoint.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpoint.java
@@ -40,13 +40,12 @@ import com.axelixlabs.axelix.common.api.scheduledtask.ScheduledTaskToggleRequest
  * @author Sergey Cherkasov
  */
 @RestControllerEndpoint(id = "axelix-scheduled-tasks")
-public class AxelixScheduledTasksEndpoint {
+class AxelixScheduledTasksEndpoint {
 
     private final ScheduledTaskService taskService;
     private final ScheduledTasksAssembler scheduledTasksAssembler;
 
-    public AxelixScheduledTasksEndpoint(
-            ScheduledTaskService taskService, ScheduledTasksAssembler scheduledTasksAssembler) {
+    AxelixScheduledTasksEndpoint(ScheduledTaskService taskService, ScheduledTasksAssembler scheduledTasksAssembler) {
         this.taskService = taskService;
         this.scheduledTasksAssembler = scheduledTasksAssembler;
     }

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/DefaultScheduledTasksAssembler.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/DefaultScheduledTasksAssembler.java
@@ -34,11 +34,11 @@ import com.axelixlabs.axelix.common.api.ServiceScheduledTasks;
  * @author Sergey Cherkasov
  * @author Mikhail Polivakha
  */
-public class DefaultScheduledTasksAssembler implements ScheduledTasksAssembler {
+class DefaultScheduledTasksAssembler implements ScheduledTasksAssembler {
 
     private final ScheduledTasksRegistry registry;
 
-    public DefaultScheduledTasksAssembler(ScheduledTasksRegistry registry) {
+    DefaultScheduledTasksAssembler(ScheduledTasksRegistry registry) {
         this.registry = registry;
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/IntervalBasedTaskRescheduler.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/IntervalBasedTaskRescheduler.java
@@ -34,11 +34,11 @@ import org.springframework.scheduling.config.Task;
  * @author Mikhail Polivakha
  * @author Sergey Chaerkasov
  */
-public final class IntervalBasedTaskRescheduler implements TaskRescheduler {
+final class IntervalBasedTaskRescheduler implements TaskRescheduler {
 
     private final TaskScheduler taskScheduler;
 
-    public IntervalBasedTaskRescheduler(TaskScheduler taskScheduler) {
+    IntervalBasedTaskRescheduler(TaskScheduler taskScheduler) {
         this.taskScheduler = taskScheduler;
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ManagedScheduledTask.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ManagedScheduledTask.java
@@ -39,7 +39,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Mikhail Polivakha
  * @author Sergey Chaerkasov
  */
-public class ManagedScheduledTask {
+class ManagedScheduledTask {
 
     /**
      * Reflection field access to the package-private 'future' field in {@link ScheduledTask}.
@@ -65,7 +65,7 @@ public class ManagedScheduledTask {
         }
     }
 
-    public ManagedScheduledTask(String id, ScheduledTask scheduledTask) {
+    ManagedScheduledTask(String id, ScheduledTask scheduledTask) {
         this.id = id;
         this.scheduledTask = scheduledTask;
     }

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskManagementAutoConfiguration.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.scheduled;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,15 +28,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.config.ScheduledTaskHolder;
-
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.DefaultScheduledTasksAssembler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.IntervalBasedTaskRescheduler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTaskService;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksAssembler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksRegistry;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.TaskRescheduler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskRescheduler;
 
 /**
  * Auto-configuration for scheduled task management functionality.

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskService.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskService.java
@@ -41,7 +41,7 @@ import org.springframework.scheduling.support.CronTrigger;
  * @author Mikhail Polivakha
  * @author Sergey Chaerkasov
  */
-public final class ScheduledTaskService {
+final class ScheduledTaskService {
 
     private static final Logger log = LoggerFactory.getLogger(ScheduledTaskService.class);
 
@@ -49,7 +49,7 @@ public final class ScheduledTaskService {
     private final List<TaskRescheduler> taskReschedulers;
     private final ThreadPoolTaskExecutor taskExecutor;
 
-    public ScheduledTaskService(
+    ScheduledTaskService(
             ScheduledTasksRegistry registry,
             List<TaskRescheduler> taskReschedulers,
             ThreadPoolTaskExecutor taskExecutor) {

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistry.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistry.java
@@ -41,7 +41,7 @@ import org.springframework.scheduling.config.Task;
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  */
-public class ScheduledTasksRegistry implements ApplicationListener<ContextRefreshedEvent> {
+class ScheduledTasksRegistry implements ApplicationListener<ContextRefreshedEvent> {
 
     private static final Logger log = LoggerFactory.getLogger(ScheduledTasksRegistry.class);
 
@@ -49,7 +49,7 @@ public class ScheduledTasksRegistry implements ApplicationListener<ContextRefres
 
     private final Collection<ScheduledTaskHolder> scheduledTaskHolders;
 
-    public ScheduledTasksRegistry(Collection<ScheduledTaskHolder> scheduledTaskHolders) {
+    ScheduledTasksRegistry(Collection<ScheduledTaskHolder> scheduledTaskHolders) {
         this.scheduledTaskHolders = scheduledTaskHolders;
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/TaskRescheduler.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/TaskRescheduler.java
@@ -44,7 +44,7 @@ import org.springframework.scheduling.config.Task;
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
  */
-public interface TaskRescheduler {
+interface TaskRescheduler {
 
     /**
      * Re-schedules the provided Axelix's {@link ManagedScheduledTask}, in accordance to the rules provided by the new provided

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/TriggerBasedTaskRescheduler.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/TriggerBasedTaskRescheduler.java
@@ -33,11 +33,11 @@ import org.springframework.util.Assert;
  * @author Mikhail Polivakha
  * @author Sergey Chaerkasov
  */
-public final class TriggerBasedTaskRescheduler implements TaskRescheduler {
+final class TriggerBasedTaskRescheduler implements TaskRescheduler {
 
     private final TaskScheduler taskScheduler;
 
-    public TriggerBasedTaskRescheduler(TaskScheduler taskScheduler) {
+    TriggerBasedTaskRescheduler(TaskScheduler taskScheduler) {
         this.taskScheduler = taskScheduler;
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -15,7 +15,7 @@ com.axelixlabs.axelix.sbs.spring.autoconfiguration.GitInformationProviderAutoCon
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.JwtAuthAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.LibraryInformationProviderAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.SelfRegistrationAutoConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.ScheduledTaskManagementAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTaskManagementAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProviderAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -38,12 +38,12 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.GarbageCollectionAutoC
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.GitInformationProviderAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.JwtAuthAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.LibraryInformationProviderAutoConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ScheduledTaskManagementAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.SecurityContextExecutorAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProviderAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTaskManagementAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskManagementAutoConfigurationTest.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.scheduled;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,14 +26,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.IntervalBasedTaskRescheduler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTaskService;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksAssembler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksRegistry;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.TaskRescheduler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskRescheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpoint.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/AxelixScheduledTasksEndpoint.java
@@ -42,13 +42,12 @@ import com.axelixlabs.axelix.common.api.scheduledtask.ScheduledTaskToggleRequest
  * @author Sergey Cherkasov
  */
 @RestControllerEndpoint(id = "axelix-scheduled-tasks")
-public class AxelixScheduledTasksEndpoint {
+class AxelixScheduledTasksEndpoint {
 
     private final ScheduledTaskService taskService;
     private final ScheduledTasksAssembler scheduledTasksAssembler;
 
-    public AxelixScheduledTasksEndpoint(
-            ScheduledTaskService taskService, ScheduledTasksAssembler scheduledTasksAssembler) {
+    AxelixScheduledTasksEndpoint(ScheduledTaskService taskService, ScheduledTasksAssembler scheduledTasksAssembler) {
         this.taskService = taskService;
         this.scheduledTasksAssembler = scheduledTasksAssembler;
     }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/DefaultScheduledTasksAssembler.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/DefaultScheduledTasksAssembler.java
@@ -34,11 +34,11 @@ import com.axelixlabs.axelix.common.api.ServiceScheduledTasks;
  * @author Sergey Cherkasov
  * @author Mikhail Polivakha
  */
-public class DefaultScheduledTasksAssembler implements ScheduledTasksAssembler {
+class DefaultScheduledTasksAssembler implements ScheduledTasksAssembler {
 
     private final ScheduledTasksRegistry registry;
 
-    public DefaultScheduledTasksAssembler(ScheduledTasksRegistry registry) {
+    DefaultScheduledTasksAssembler(ScheduledTasksRegistry registry) {
         this.registry = registry;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/IntervalBasedTaskRescheduler.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/IntervalBasedTaskRescheduler.java
@@ -32,11 +32,11 @@ import org.springframework.scheduling.config.Task;
  * @author Mikhail Polivakha
  * @author Sergey Chaerkasov
  */
-public final class IntervalBasedTaskRescheduler implements TaskRescheduler {
+final class IntervalBasedTaskRescheduler implements TaskRescheduler {
 
     private final TaskScheduler taskScheduler;
 
-    public IntervalBasedTaskRescheduler(TaskScheduler taskScheduler) {
+    IntervalBasedTaskRescheduler(TaskScheduler taskScheduler) {
         this.taskScheduler = taskScheduler;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ManagedScheduledTask.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ManagedScheduledTask.java
@@ -39,7 +39,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Mikhail Polivakha
  * @author Sergey Chaerkasov
  */
-public class ManagedScheduledTask {
+class ManagedScheduledTask {
 
     /**
      * Reflection field access to the package-private 'future' field in {@link ScheduledTask}.
@@ -65,7 +65,7 @@ public class ManagedScheduledTask {
         }
     }
 
-    public ManagedScheduledTask(String id, ScheduledTask scheduledTask) {
+    ManagedScheduledTask(String id, ScheduledTask scheduledTask) {
         this.id = id;
         this.scheduledTask = scheduledTask;
     }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskManagementAutoConfiguration.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.scheduled;
 
 import java.util.List;
 
@@ -27,15 +27,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.config.ScheduledTaskHolder;
-
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.DefaultScheduledTasksAssembler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.IntervalBasedTaskRescheduler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTaskService;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksAssembler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksRegistry;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.TaskRescheduler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskRescheduler;
 
 /**
  * Auto-configuration for scheduled task management functionality.

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskService.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskService.java
@@ -42,7 +42,7 @@ import org.springframework.scheduling.support.CronTrigger;
  * @author Mikhail Polivakha
  * @author Sergey Chaerkasov
  */
-public final class ScheduledTaskService {
+final class ScheduledTaskService {
 
     private static final Logger log = LoggerFactory.getLogger(ScheduledTaskService.class);
 
@@ -50,7 +50,7 @@ public final class ScheduledTaskService {
     private final List<TaskRescheduler> taskReschedulers;
     private final ThreadPoolTaskExecutor taskExecutor;
 
-    public ScheduledTaskService(
+    ScheduledTaskService(
             ScheduledTasksRegistry registry,
             List<TaskRescheduler> taskReschedulers,
             ThreadPoolTaskExecutor taskExecutor) {

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistry.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistry.java
@@ -41,7 +41,7 @@ import org.springframework.scheduling.config.Task;
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  */
-public class ScheduledTasksRegistry implements ApplicationListener<ContextRefreshedEvent> {
+class ScheduledTasksRegistry implements ApplicationListener<ContextRefreshedEvent> {
 
     private static final Logger log = LoggerFactory.getLogger(ScheduledTasksRegistry.class);
 
@@ -49,7 +49,7 @@ public class ScheduledTasksRegistry implements ApplicationListener<ContextRefres
 
     private final Collection<ScheduledTaskHolder> scheduledTaskHolders;
 
-    public ScheduledTasksRegistry(Collection<ScheduledTaskHolder> scheduledTaskHolders) {
+    ScheduledTasksRegistry(Collection<ScheduledTaskHolder> scheduledTaskHolders) {
         this.scheduledTaskHolders = scheduledTaskHolders;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/TaskRescheduler.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/TaskRescheduler.java
@@ -44,7 +44,7 @@ import org.springframework.scheduling.config.Task;
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
  */
-public interface TaskRescheduler {
+interface TaskRescheduler {
 
     /**
      * Re-schedules the provided Axelix's {@link ManagedScheduledTask}, in accordance to the rules provided by the new provided

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/TriggerBasedTaskRescheduler.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/TriggerBasedTaskRescheduler.java
@@ -33,11 +33,11 @@ import org.springframework.util.Assert;
  * @author Mikhail Polivakha
  * @author Sergey Chaerkasov
  */
-public final class TriggerBasedTaskRescheduler implements TaskRescheduler {
+final class TriggerBasedTaskRescheduler implements TaskRescheduler {
 
     private final TaskScheduler taskScheduler;
 
-    public TriggerBasedTaskRescheduler(TaskScheduler taskScheduler) {
+    TriggerBasedTaskRescheduler(TaskScheduler taskScheduler) {
         this.taskScheduler = taskScheduler;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -15,7 +15,7 @@ com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoConfigura
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.GitInformationProviderAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.JwtAuthAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.LibraryInformationProviderAutoConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.ScheduledTaskManagementAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTaskManagementAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.SelfRegistrationAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProviderAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -40,13 +40,13 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.GarbageCollectionAutoC
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.GitInformationProviderAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.JwtAuthAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.LibraryInformationProviderAutoConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ScheduledTaskManagementAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.SecurityContextExecutorAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.SelfRegistrationAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProviderAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTaskManagementAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskManagementAutoConfigurationTest.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.scheduled;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,14 +26,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.IntervalBasedTaskRescheduler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTaskService;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksAssembler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksRegistry;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.TaskRescheduler;
-import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskRescheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskNotFoundException.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskNotFoundException.java
@@ -24,8 +24,8 @@ package com.axelixlabs.axelix.sbs.spring.core.scheduled;
  * @since 14.10.2025
  * @author Nikita Kirillov
  */
-public class ScheduledTaskNotFoundException extends RuntimeException {
-    public ScheduledTaskNotFoundException(String message) {
+class ScheduledTaskNotFoundException extends RuntimeException {
+    ScheduledTaskNotFoundException(String message) {
         super(message);
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksAssembler.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksAssembler.java
@@ -24,7 +24,7 @@ import com.axelixlabs.axelix.common.api.ServiceScheduledTasks;
  *
  * @author Sergey Cherkasov
  */
-public interface ScheduledTasksAssembler {
+interface ScheduledTasksAssembler {
 
     /**
      * @return assembled {@link ServiceScheduledTasks}.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Tightened access to several scheduled-task management components and relocated the auto-configuration to match the new package structure.
  * Updated the application to load the scheduled-task management auto-configuration from its new location.
* **Bug Fixes**
  * No functional behavior changes were introduced; scheduled-task endpoints and scheduling actions remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->