### PR TITLE
GH-1388 Hide `Thread Dump` endpoint implementation classes from starterpublic API

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpoint.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpoint.java
@@ -33,13 +33,13 @@ import com.axelixlabs.axelix.common.api.ThreadDumpFeed;
  * @author Sergey Cherkasov
  */
 @RestControllerEndpoint(id = "axelix-thread-dump")
-public class ThreadDumpManagementEndpoint {
+class ThreadDumpManagementEndpoint {
 
     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
     private final ThreadDumpContentionMonitoringManagement management;
 
-    public ThreadDumpManagementEndpoint(ThreadDumpContentionMonitoringManagement management) {
+    ThreadDumpManagementEndpoint(ThreadDumpContentionMonitoringManagement management) {
         this.management = management;
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpointAutoConfiguration.java
@@ -15,15 +15,11 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.threaddump;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
-
-import com.axelixlabs.axelix.sbs.spring.core.threaddump.DefaultThreadDumpContentionMonitoringManagement;
-import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpContentionMonitoringManagement;
-import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpManagementEndpoint;
 
 /**
  * Auto-configuration for Thread Dump management functionality.

--- a/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -17,7 +17,7 @@ com.axelixlabs.axelix.sbs.spring.autoconfiguration.LibraryInformationProviderAut
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.SelfRegistrationAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ScheduledTaskManagementAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProviderAutoConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpManagementEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.SecurityContextExecutorAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -41,9 +41,9 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.LibraryInformationProv
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ScheduledTaskManagementAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.SecurityContextExecutorAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProviderAutoConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpManagementEndpointAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpointAutoConfigurationTest.java
@@ -15,16 +15,12 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.threaddump;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-
-import com.axelixlabs.axelix.sbs.spring.core.threaddump.DefaultThreadDumpContentionMonitoringManagement;
-import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpContentionMonitoringManagement;
-import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpManagementEndpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpoint.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpoint.java
@@ -33,13 +33,13 @@ import com.axelixlabs.axelix.common.api.ThreadDumpFeed;
  * @author Sergey Cherkasov
  */
 @RestControllerEndpoint(id = "axelix-thread-dump")
-public class ThreadDumpManagementEndpoint {
+class ThreadDumpManagementEndpoint {
 
     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
     private final ThreadDumpContentionMonitoringManagement management;
 
-    public ThreadDumpManagementEndpoint(ThreadDumpContentionMonitoringManagement management) {
+    ThreadDumpManagementEndpoint(ThreadDumpContentionMonitoringManagement management) {
         this.management = management;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpointAutoConfiguration.java
@@ -15,15 +15,11 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.threaddump;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
-
-import com.axelixlabs.axelix.sbs.spring.core.threaddump.DefaultThreadDumpContentionMonitoringManagement;
-import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpContentionMonitoringManagement;
-import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpManagementEndpoint;
 
 /**
  * Auto-configuration for Thread Dump management functionality.

--- a/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -18,7 +18,7 @@ com.axelixlabs.axelix.sbs.spring.autoconfiguration.LibraryInformationProviderAut
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ScheduledTaskManagementAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.SelfRegistrationAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProviderAutoConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpManagementEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixFeignEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.SecurityContextExecutorAutoConfiguration

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -44,9 +44,9 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ScheduledTaskManagemen
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.SecurityContextExecutorAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.SelfRegistrationAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProviderAutoConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpManagementEndpointAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpManagementEndpointAutoConfigurationTest.java
@@ -15,16 +15,12 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.threaddump;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-
-import com.axelixlabs.axelix.sbs.spring.core.threaddump.DefaultThreadDumpContentionMonitoringManagement;
-import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpContentionMonitoringManagement;
-import com.axelixlabs.axelix.sbs.spring.core.threaddump.ThreadDumpManagementEndpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/DefaultThreadDumpContentionMonitoringManagement.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/DefaultThreadDumpContentionMonitoringManagement.java
@@ -24,7 +24,7 @@ import java.lang.management.ManagementFactory;
  *
  * @author Sergey Cherkasov
  */
-public class DefaultThreadDumpContentionMonitoringManagement implements ThreadDumpContentionMonitoringManagement {
+class DefaultThreadDumpContentionMonitoringManagement implements ThreadDumpContentionMonitoringManagement {
 
     @Override
     public void enable() {

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpContentionMonitoringManagement.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/threaddump/ThreadDumpContentionMonitoringManagement.java
@@ -25,7 +25,7 @@ package com.axelixlabs.axelix.sbs.spring.core.threaddump;
  *
  * @author Sergey Cherkasov
  */
-public interface ThreadDumpContentionMonitoringManagement {
+interface ThreadDumpContentionMonitoringManagement {
 
     /**
      * Enables thread contention monitoring.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized thread dump management components into a new package structure for clearer module separation.
  * Updated auto-configuration references so Spring Boot loads the relocated thread dump setup correctly.

* **Bug Fixes**
  * Improved endpoint and support class visibility to reduce unintended external access while keeping thread dump controls available.
  * Test support paths were aligned with the new package layout to keep coverage consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->