### PR TITLE
GH-1394 Hide `Conditions` endpoint implementation classes from starter public API

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpoint.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpoint.java
@@ -30,11 +30,11 @@ import com.axelixlabs.axelix.common.api.ConditionsFeed;
  * @author Sergey Cherkasov
  */
 @RestControllerEndpoint(id = "axelix-conditions")
-public class AxelixConditionsEndpoint {
+class AxelixConditionsEndpoint {
 
     private final ConditionalFeedBuilder builder;
 
-    public AxelixConditionsEndpoint(ConditionalFeedBuilder builder) {
+    AxelixConditionsEndpoint(ConditionalFeedBuilder builder) {
         this.builder = builder;
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpointAutoConfiguration.java
@@ -15,18 +15,12 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.conditions;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
-
-import com.axelixlabs.axelix.sbs.spring.core.conditions.AxelixConditionsEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalTargetUnwrapper;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalTargetUnwrapper;
 
 /**
  * Auto-configuration for the {@link AxelixConditionsEndpoint}.

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/DefaultConditionalFeedBuilder.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/DefaultConditionalFeedBuilder.java
@@ -38,13 +38,12 @@ import com.axelixlabs.axelix.common.api.ConditionsFeed.PositiveCondition;
  * @author Nikita Kirilov
  * @author Sergey Cherkasov
  */
-public class DefaultConditionalFeedBuilder implements ConditionalFeedBuilder {
+class DefaultConditionalFeedBuilder implements ConditionalFeedBuilder {
 
     private final ConditionsReportEndpoint delegate;
     private final ConditionalTargetUnwrapper targetUnwrapper;
 
-    public DefaultConditionalFeedBuilder(
-            ConfigurableApplicationContext context, ConditionalTargetUnwrapper targetUnwrapper) {
+    DefaultConditionalFeedBuilder(ConfigurableApplicationContext context, ConditionalTargetUnwrapper targetUnwrapper) {
         this.delegate = new ConditionsReportEndpoint(context);
         this.targetUnwrapper = targetUnwrapper;
     }

--- a/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,6 +1,6 @@
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.conditions.AxelixConditionsEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -24,7 +24,6 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixEnvironmentEndpointAutoConfiguration;
@@ -44,6 +43,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProvider
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.AxelixConditionsEndpointAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpointAutoConfigurationTest.java
@@ -15,14 +15,12 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.conditions;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-
-import com.axelixlabs.axelix.sbs.spring.core.conditions.AxelixConditionsEndpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpoint.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpoint.java
@@ -30,11 +30,11 @@ import com.axelixlabs.axelix.common.api.ConditionsFeed;
  * @author Sergey Cherkasov
  */
 @RestControllerEndpoint(id = "axelix-conditions")
-public class AxelixConditionsEndpoint {
+class AxelixConditionsEndpoint {
 
     private final ConditionalFeedBuilder builder;
 
-    public AxelixConditionsEndpoint(ConditionalFeedBuilder builder) {
+    AxelixConditionsEndpoint(ConditionalFeedBuilder builder) {
         this.builder = builder;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpointAutoConfiguration.java
@@ -15,18 +15,12 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.conditions;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
-
-import com.axelixlabs.axelix.sbs.spring.core.conditions.AxelixConditionsEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalTargetUnwrapper;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalTargetUnwrapper;
 
 /**
  * Auto-configuration for the {@link AxelixConditionsEndpoint}.

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/DefaultConditionalFeedBuilder.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/DefaultConditionalFeedBuilder.java
@@ -40,13 +40,12 @@ import com.axelixlabs.axelix.common.api.ConditionsFeed.PositiveCondition;
  * @author Nikita Kirilov
  * @author Sergey Cherkasov
  */
-public class DefaultConditionalFeedBuilder implements ConditionalFeedBuilder {
+class DefaultConditionalFeedBuilder implements ConditionalFeedBuilder {
 
     private final ConditionsReportEndpoint delegate;
     private final ConditionalTargetUnwrapper targetUnwrapper;
 
-    public DefaultConditionalFeedBuilder(
-            ConfigurableApplicationContext context, ConditionalTargetUnwrapper targetUnwrapper) {
+    DefaultConditionalFeedBuilder(ConfigurableApplicationContext context, ConditionalTargetUnwrapper targetUnwrapper) {
         this.delegate = new ConditionsReportEndpoint(context);
         this.targetUnwrapper = targetUnwrapper;
     }

--- a/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,6 +1,6 @@
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.conditions.AxelixConditionsEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -24,7 +24,6 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixEnvironmentEndpointAutoConfiguration;
@@ -47,6 +46,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProvider
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.AxelixConditionsEndpointAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/conditions/AxelixConditionsEndpointAutoConfigurationTest.java
@@ -15,14 +15,12 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.conditions;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-
-import com.axelixlabs.axelix.sbs.spring.core.conditions.AxelixConditionsEndpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/ConditionalFeedBuilder.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/ConditionalFeedBuilder.java
@@ -26,7 +26,7 @@ import com.axelixlabs.axelix.common.api.ConditionsFeed;
  *
  * @author Sergey Cherkasov
  */
-public interface ConditionalFeedBuilder {
+interface ConditionalFeedBuilder {
 
     /**
      * @return feed of conditions inside the given application.

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/ConditionalTargetUnwrapper.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/ConditionalTargetUnwrapper.java
@@ -23,7 +23,7 @@ package com.axelixlabs.axelix.sbs.spring.core.conditions;
  * @author Sergey Cherkasov
  * @author Nikita Kirillov
  */
-public interface ConditionalTargetUnwrapper {
+interface ConditionalTargetUnwrapper {
 
     /**
      * @param target the target condition.

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/DefaultConditionalTargetUnwrapper.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/DefaultConditionalTargetUnwrapper.java
@@ -23,7 +23,7 @@ package com.axelixlabs.axelix.sbs.spring.core.conditions;
  * @author Sergey Cherkasov
  * @author Nikita Kirillov
  */
-public class DefaultConditionalTargetUnwrapper implements ConditionalTargetUnwrapper {
+class DefaultConditionalTargetUnwrapper implements ConditionalTargetUnwrapper {
 
     // See SpringBootCondition.getClassOrMethodName method in order to understand why we're doing this.
     // https://github.com/spring-projects/spring-boot/blob/main/core/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/condition/SpringBootCondition.java#L74

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/UnwrappedTarget.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/conditions/UnwrappedTarget.java
@@ -26,7 +26,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Sergey Cherkasov
  */
-public class UnwrappedTarget {
+class UnwrappedTarget {
 
     private final String className;
 
@@ -41,7 +41,7 @@ public class UnwrappedTarget {
      *                   Guaranteed to be present.
      * @param methodName the name of the method on which the conditional annotation was put.
      */
-    public UnwrappedTarget(String className, @Nullable String methodName) {
+    UnwrappedTarget(String className, @Nullable String methodName) {
         this.className = className;
         this.methodName = methodName;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated conditional endpoint and configuration components into a single package.
  * Reduced public exposure of several internal classes and interfaces, making them package-private.
  * Updated app startup and tests to reference the new locations.
* **Bug Fixes**
  * Improved consistency in how conditional endpoint auto-configuration is discovered and excluded during startup.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->