### PR TITLE
GH-1384: Rename instanceName to instanceNamePrefix property in the starters

### DIFF
--- a/docs/docs/setting-up-master-ui/configuring-master/configuring-master.mdx
+++ b/docs/docs/setting-up-master-ui/configuring-master/configuring-master.mdx
@@ -167,7 +167,7 @@ The endpoint is `POST /api/internal/service/register`. It is gated by the same J
 
 On the Master side there are **no required overrides** — every property here has a working default. The feature is **on
 by default** (`enabled=true`), set it to `false` only if you want Master to refuse all heartbeats. The starter-side
-properties that go *into* the heartbeat (`master-url`, `instance-actuator-url`, `instance-name`) are documented in the
+properties that go *into* the heartbeat (`master-url`, `instance-actuator-url`, `instance-name-prefix`) are documented in the
 [Configuring Spring Boot Starter](../../setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx) page.
 
 <div className={styles.configTable}>

--- a/docs/docs/setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx
+++ b/docs/docs/setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx
@@ -266,7 +266,7 @@ axelix:
       auto: true
       master-url: http://master.internal:8080/api/internal/service/register
       instance-actuator-url: http://my-app.internal:8080/actuator
-      instance-name: orders-service
+      instance-name-prefix: orders-service
       heartbeat-interval: 15s
 ```
 
@@ -277,7 +277,7 @@ axelix:
 axelix.sbs.discovery.auto=true
 axelix.sbs.discovery.master-url=http://master.internal:8080/api/internal/service/register
 axelix.sbs.discovery.instance-actuator-url=http://my-app.internal:8080/actuator
-axelix.sbs.discovery.instance-name=orders-service
+axelix.sbs.discovery.instance-name-prefix=orders-service
 axelix.sbs.discovery.heartbeat-interval=15s
 ```
 
@@ -289,8 +289,9 @@ A few details that catch people out:
 - `instance-actuator-url` is the **base** URL of the service as Master will reach it from its own network — host and
   port only.
 - `master-url` is the **full** URL including `/api/internal/service/register`. The starter posts to it verbatim.
-- `instance-name` is the label Master shows for this instance in the UI and in MCP responses. Pick a name that survives
-  restarts and replicas — typically the service name, not the pod name.
+- `instance-name-prefix` is the base of the label Master shows for this instance in the UI and in MCP responses. A unique
+  postfix is appended to it to keep instance names distinct across replicas. Pick a prefix that survives restarts —
+  typically the service name, not the pod name.
 - Self-registration is accepted by Master out of the box (`axelix.master.discovery.self-registration.enabled` is `true`
   by default), set it to `false` if you want to refuse heartbeats. Master evicts an instance after
   `axelix.master.discovery.self-registration.eviction.heartbeat-timeout` of silence (`45s` by default), so keep
@@ -374,7 +375,7 @@ When `axelix.sbs.discovery.auto=true`, the following properties become **require
 
 - `axelix.sbs.discovery.master-url`
 - `axelix.sbs.discovery.instance-actuator-url`
-- `axelix.sbs.discovery.instance-name`
+- `axelix.sbs.discovery.instance-name-prefix`
 
 The Master-side receiver of these heartbeats — endpoint, eviction timeout, eviction sweep schedule — is documented on
 the Master page in [Discovery —
@@ -389,7 +390,7 @@ heartbeats are rejected with `401`.
 | `axelix.sbs.discovery.auto`                  | `false`                                                     | Master switch. Set to `true` to enable self-registration; leave `false` to rely on Master-side autodiscovery.                        |
 | `axelix.sbs.discovery.master-url`            | *(unset)* <span className={styles.required}>required</span> | Full URL of Master's self-registration endpoint, e.g. `http://master:8080/api/internal/service/register`. Required when `auto=true`. |
 | `axelix.sbs.discovery.instance-actuator-url` | *(unset)* <span className={styles.required}>required</span> | Base URL of this service as reachable from Master (It is necessary to specify the postfix `/actuator`). Required when `auto=true`.   |
-| `axelix.sbs.discovery.instance-name`         | *(unset)* <span className={styles.required}>required</span> | Display name shown in Axelix UI and MCP responses. Required when `auto=true`.                                                        |
+| `axelix.sbs.discovery.instance-name-prefix`  | *(unset)* <span className={styles.required}>required</span> | Prefix of the display name shown in Axelix UI and MCP responses; a unique postfix is appended. Required when `auto=true`.            |
 | `axelix.sbs.discovery.heartbeat-interval`    | `15s`                                                       | Interval between heartbeats. Should be smaller than Master's eviction `heartbeat-timeout`.                                           |
 
 </div>

--- a/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-master-ui/configuring-master/configuring-master.mdx
+++ b/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-master-ui/configuring-master/configuring-master.mdx
@@ -176,7 +176,7 @@ JWT, подписанный общим `axelix.master.auth.jwt.signing-key`. Mas
 На стороне Master **обязательных переопределений нет** — у каждого свойства здесь есть рабочее значение по умолчанию.
 Функция **включена по умолчанию** (`enabled=true`), установите в `false`, только если хотите, чтобы Master отказывался
 от всех heartbeat-сигналов. Свойства со стороны стартера, которые попадают *в* heartbeat-сигнал (`master-url`,
-`instance-actuator-url`, `instance-name`), описаны на странице [Настройка Spring Boot
+`instance-actuator-url`, `instance-name-prefix`), описаны на странице [Настройка Spring Boot
 Starter](../../setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx).
 
 <div className={styles.configTable}>

--- a/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx
+++ b/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx
@@ -268,7 +268,7 @@ axelix:
       auto: true
       master-url: http://master.internal:8080/api/internal/service/register
       instance-actuator-url: http://my-app.internal:8080/actuator
-      instance-name: orders-service
+      instance-name-prefix: orders-service
       heartbeat-interval: 15s
 ```
 
@@ -279,7 +279,7 @@ axelix:
 axelix.sbs.discovery.auto=true
 axelix.sbs.discovery.master-url=http://master.internal:8080/api/internal/service/register
 axelix.sbs.discovery.instance-actuator-url=http://my-app.internal:8080/actuator
-axelix.sbs.discovery.instance-name=orders-service
+axelix.sbs.discovery.instance-name-prefix=orders-service
 axelix.sbs.discovery.heartbeat-interval=15s
 ```
 
@@ -292,7 +292,7 @@ axelix.sbs.discovery.heartbeat-interval=15s
   собственной сети — только по имени хоста и порту.
 - `master-url` — это **полный** URL-адрес, включая `/api/internal/service/register`. Стартер отправляет его без
   изменений.
-- `instance-name` — это имя, которое Master показывает для этого сервиса в пользовательском интерфейсе и в MCP-ответах.
+- `instance-name-prefix` — это имя, которое Master показывает для этого сервиса в пользовательском интерфейсе и в MCP-ответах.
   Выбирайте имя, которое переживает рестарты и реплики, — как правило, имя сервиса, а не имя пода.
 - Саморегистрация принимается Master из коробки (`axelix.master.discovery.self-registration.enabled` по умолчанию
   `true`), установите её в `false`, если хотите отказаться от heartbeat-сигналов. Master выселяет сервис после
@@ -379,7 +379,7 @@ axelix.sbs.endpoints.config.sanitized-properties[2]=jwt.signing-key
 
 - `axelix.sbs.discovery.master-url`
 - `axelix.sbs.discovery.instance-actuator-url`
-- `axelix.sbs.discovery.instance-name`
+- `axelix.sbs.discovery.instance-name-prefix`
 
 Приёмник этих heartbeat-сигналов на стороне Master — эндпоинт, таймаут выселения, расписание подметания выселений —
 описан на странице Master в [Обнаружение —
@@ -394,7 +394,7 @@ heartbeat-сигналы будут отклоняться с `401`.
 | `axelix.sbs.discovery.auto`                  | `false`                                                             | Главный переключатель. Установите `true`, чтобы включить саморегистрацию; оставьте `false`, чтобы полагаться на автообнаружение на стороне Master. |
 | `axelix.sbs.discovery.master-url`            | *(не задано)* <span className={styles.required}>обязательное</span> | Полный URL-адрес эндпоинта саморегистрации на Master, например `http://master:8080/api/internal/service/register`. Обязательно при `auto=true`.    |
 | `axelix.sbs.discovery.instance-actuator-url` | *(не задано)* <span className={styles.required}>обязательное</span> | Базовый URL-адрес этого сервиса, доступный из Master (необходимо указать постфикс `/actuator`). Обязательно при `auto=true`.                       |
-| `axelix.sbs.discovery.instance-name`         | *(не задано)* <span className={styles.required}>обязательное</span> | Отображаемое имя, показываемое в Axelix UI и в MCP-ответах. Обязательно при `auto=true`.                                                           |
+| `axelix.sbs.discovery.instance-name-prefix`  | *(не задано)* <span className={styles.required}>обязательное</span> | Отображаемое имя, показываемое в Axelix UI и в MCP-ответах. Обязательно при `auto=true`.                                                           |
 | `axelix.sbs.discovery.heartbeat-interval`    | `15s`                                                               | Интервал между heartbeat-сигналами. Должен быть меньше `heartbeat-timeout` выселения на Master.                                                    |
 
 </div>

--- a/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx
+++ b/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-spring-boot-service/configuring-axelix-starter/configuring-axelix-starter.mdx
@@ -292,8 +292,9 @@ axelix.sbs.discovery.heartbeat-interval=15s
   собственной сети — только по имени хоста и порту.
 - `master-url` — это **полный** URL-адрес, включая `/api/internal/service/register`. Стартер отправляет его без
   изменений.
-- `instance-name-prefix` — это имя, которое Master показывает для этого сервиса в пользовательском интерфейсе и в MCP-ответах.
-  Выбирайте имя, которое переживает рестарты и реплики, — как правило, имя сервиса, а не имя пода.
+- `instance-name-prefix` — это основа имени, которое Master показывает для этого сервиса в пользовательском интерфейсе и в MCP-ответах.
+  К нему добавляется уникальный постфикс, чтобы имена сервисов оставались различными для разных реплик.
+  Выбирайте префикс, который переживает рестарты, — как правило, имя сервиса, а не имя пода.
 - Саморегистрация принимается Master из коробки (`axelix.master.discovery.self-registration.enabled` по умолчанию
   `true`), установите её в `false`, если хотите отказаться от heartbeat-сигналов. Master выселяет сервис после
   `axelix.master.discovery.self-registration.eviction.heartbeat-timeout` молчания (по умолчанию `45s`), поэтому держите
@@ -394,7 +395,7 @@ heartbeat-сигналы будут отклоняться с `401`.
 | `axelix.sbs.discovery.auto`                  | `false`                                                             | Главный переключатель. Установите `true`, чтобы включить саморегистрацию; оставьте `false`, чтобы полагаться на автообнаружение на стороне Master. |
 | `axelix.sbs.discovery.master-url`            | *(не задано)* <span className={styles.required}>обязательное</span> | Полный URL-адрес эндпоинта саморегистрации на Master, например `http://master:8080/api/internal/service/register`. Обязательно при `auto=true`.    |
 | `axelix.sbs.discovery.instance-actuator-url` | *(не задано)* <span className={styles.required}>обязательное</span> | Базовый URL-адрес этого сервиса, доступный из Master (необходимо указать постфикс `/actuator`). Обязательно при `auto=true`.                       |
-| `axelix.sbs.discovery.instance-name-prefix`  | *(не задано)* <span className={styles.required}>обязательное</span> | Отображаемое имя, показываемое в Axelix UI и в MCP-ответах. Обязательно при `auto=true`.                                                           |
+| `axelix.sbs.discovery.instance-name-prefix`  | *(не задано)* <span className={styles.required}>обязательное</span> | Префикс отображаемого имени, показываемого в Axelix UI и в MCP-ответах; к нему добавляется уникальный постфикс. Обязательно при `auto=true`.        |
 | `axelix.sbs.discovery.heartbeat-interval`    | `15s`                                                               | Интервал между heartbeat-сигналами. Должен быть меньше `heartbeat-timeout` выселения на Master.                                                    |
 
 </div>

--- a/playgrounds/feature-service-maven-sb-3/src/main/resources/application-local.properties
+++ b/playgrounds/feature-service-maven-sb-3/src/main/resources/application-local.properties
@@ -4,5 +4,5 @@ axelix.sbs.auth.jwt.algorithm=HMAC512
 axelix.sbs.auth.jwt.signing-key=22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
 axelix.sbs.discovery.instance-actuator-url=http://localhost:8092/actuator
 axelix.sbs.discovery.master-url=http://localhost:8080/api/internal/service/register
-axelix.sbs.discovery.instance-name=feature-service-maven-sb-3
+axelix.sbs.discovery.instance-name-prefix=feature-service-maven-sb-3
 axelix.sbs.discovery.auto=true

--- a/playgrounds/notification-service-gradle-sb-2/src/main/resources/application-local.properties
+++ b/playgrounds/notification-service-gradle-sb-2/src/main/resources/application-local.properties
@@ -4,5 +4,5 @@ axelix.sbs.auth.jwt.algorithm=HMAC512
 axelix.sbs.auth.jwt.signing-key=22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
 axelix.sbs.discovery.instance-actuator-url=http://localhost:8093/actuator
 axelix.sbs.discovery.master-url=http://localhost:8080/api/internal/service/register
-axelix.sbs.discovery.instance-name=notification-service-gradle-sb-2
+axelix.sbs.discovery.instance-name-prefix=notification-service-gradle-sb-2
 axelix.sbs.discovery.auto=true

--- a/playgrounds/spring-petclinic-gradle-sb-3/src/main/resources/application-local.properties
+++ b/playgrounds/spring-petclinic-gradle-sb-3/src/main/resources/application-local.properties
@@ -4,5 +4,5 @@ axelix.sbs.auth.jwt.algorithm=HMAC512
 axelix.sbs.auth.jwt.signing-key=22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
 axelix.sbs.discovery.instance-actuator-url=http://localhost:8094/actuator
 axelix.sbs.discovery.master-url=http://localhost:8080/api/internal/service/register
-axelix.sbs.discovery.instance-name=petclinic-gradle-sb-3
+axelix.sbs.discovery.instance-name-prefix=petclinic-gradle-sb-3
 axelix.sbs.discovery.auto=true

--- a/playgrounds/spring-petclinic-maven-sb-2/src/main/resources/application-local.properties
+++ b/playgrounds/spring-petclinic-maven-sb-2/src/main/resources/application-local.properties
@@ -4,5 +4,5 @@ axelix.sbs.auth.jwt.algorithm=HMAC512
 axelix.sbs.auth.jwt.signing-key=22573444698685aa77750b88ad6e99ef1f94a7a909bc7df63f7a80666208c201ab7a584e6e05e6c9d0aa94b723f843ff
 axelix.sbs.discovery.instance-actuator-url=http://localhost:8091/actuator
 axelix.sbs.discovery.master-url=http://localhost:8080/api/internal/service/register
-axelix.sbs.discovery.instance-name=petclinic-maven-sb-2
+axelix.sbs.discovery.instance-name-prefix=petclinic-maven-sb-2
 axelix.sbs.discovery.auto=true

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/config/SelfRegistrationConfigurationProperties.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/config/SelfRegistrationConfigurationProperties.java
@@ -43,10 +43,10 @@ public class SelfRegistrationConfigurationProperties implements Validatable {
     private String masterUrl;
 
     /**
-     * The name of the service under which it will be registered in the master and subsequently displayed
-     * in wallboard, mcp, etc.
+     * The name prefix of the service under which it will be registered in the master and subsequently displayed
+     * in wallboard, mcp, etc. A unique postfix is appended to this prefix to form the final instance name.
      */
-    private String instanceName;
+    private String instanceNamePrefix;
 
     /**
      * The URL of the service, including the postfix for the actuator path, e.g. {@code https://my-app:6061/actuator}.
@@ -68,8 +68,8 @@ public class SelfRegistrationConfigurationProperties implements Validatable {
         return instanceActuatorUrl;
     }
 
-    public String getInstanceName() {
-        return instanceName;
+    public String getInstanceNamePrefix() {
+        return instanceNamePrefix;
     }
 
     public Duration getHeartbeatInterval() {
@@ -86,8 +86,8 @@ public class SelfRegistrationConfigurationProperties implements Validatable {
         this.instanceActuatorUrl = cleanInstanceActuatorUrl(instanceActuatorUrl);
     }
 
-    public void setInstanceName(String instanceName) {
-        this.instanceName = instanceName;
+    public void setInstanceNamePrefix(String instanceNamePrefix) {
+        this.instanceNamePrefix = instanceNamePrefix;
     }
 
     public void setHeartbeatInterval(@Nullable Duration heartbeatInterval) {
@@ -100,7 +100,7 @@ public class SelfRegistrationConfigurationProperties implements Validatable {
     public void validate() {
         validateRequiredProperty(masterUrl, "axelix.sbs.discovery.master-url");
         validateRequiredProperty(instanceActuatorUrl, "axelix.sbs.discovery.instance-actuator-url");
-        validateRequiredProperty(instanceName, "axelix.sbs.discovery.instance-name");
+        validateRequiredProperty(instanceNamePrefix, "axelix.sbs.discovery.instance-name-prefix");
     }
 
     private void validateRequiredProperty(Object value, String propertyName) {

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssembler.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssembler.java
@@ -54,7 +54,8 @@ public class DefaultSelfRegistrationMetadataAssembler implements SelfRegistratio
         this.selfRegistrationConfigurationProperties = selfRegistrationConfigurationProperties;
         this.serviceMetadataAssembler = serviceMetadataAssembler;
         this.instanceId = UUID.randomUUID().toString();
-        this.instanceName = selfRegistrationConfigurationProperties.getInstanceNamePrefix() + "-" + generateNamePostfix();
+        this.instanceName =
+                selfRegistrationConfigurationProperties.getInstanceNamePrefix() + "-" + generateNamePostfix();
         this.deploymentAt = Instant.now().toString();
     }
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssembler.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssembler.java
@@ -54,7 +54,7 @@ public class DefaultSelfRegistrationMetadataAssembler implements SelfRegistratio
         this.selfRegistrationConfigurationProperties = selfRegistrationConfigurationProperties;
         this.serviceMetadataAssembler = serviceMetadataAssembler;
         this.instanceId = UUID.randomUUID().toString();
-        this.instanceName = selfRegistrationConfigurationProperties.getInstanceName() + "-" + generateNamePostfix();
+        this.instanceName = selfRegistrationConfigurationProperties.getInstanceNamePrefix() + "-" + generateNamePostfix();
         this.deploymentAt = Instant.now().toString();
     }
 

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssemblerTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultSelfRegistrationMetadataAssemblerTest.java
@@ -57,7 +57,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(classes = DefaultSelfRegistrationMetadataAssemblerTest.TestApplication.class)
 @TestPropertySource(
         properties = {
-            "axelix.sbs.discovery.instance-name=testApp",
+            "axelix.sbs.discovery.instance-name-prefix=testApp",
             "axelix.sbs.discovery.master-url=http://localhost:8080/",
             "axelix.sbs.discovery.instance-actuator-url=http://localhost:8089/actuator"
         })

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/SelfRegistrationServiceTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/SelfRegistrationServiceTest.java
@@ -67,7 +67,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 @SpringBootTest(classes = SelfRegistrationServiceTest.TestApplication.class)
 @TestPropertySource(
         properties = {
-            "axelix.sbs.discovery.instance-name=testApp",
+            "axelix.sbs.discovery.instance-name-prefix=testApp",
             "axelix.sbs.discovery.instance-actuator-url=http://localhost:8089/actuator",
             "axelix.sbs.discovery.heartbeat-interval=PT1S"
         })

--- a/website/src/components/Install/Installer/Snippets/PropertiesSnippet/index.tsx
+++ b/website/src/components/Install/Installer/Snippets/PropertiesSnippet/index.tsx
@@ -42,7 +42,7 @@ export const PropertiesSnippet = ({ refEl }: IProps) => {
                     <span className={styles.At}>axelix.sbs.discovery.auto</span>=<span className={styles.St}>true</span>
                 </span>
                 <span className={styles.Line}>
-                    <span className={styles.At}>axelix.sbs.discovery.instance-name</span>=
+                    <span className={styles.At}>axelix.sbs.discovery.instance-name-prefix</span>=
                     <span className={styles.St}>my-app</span>
                 </span>
                 <span className={styles.Line}>

--- a/website/src/components/Install/Installer/Snippets/YamlSnippet/index.tsx
+++ b/website/src/components/Install/Installer/Snippets/YamlSnippet/index.tsx
@@ -64,7 +64,7 @@ export const YamlSnippet = ({ refEl }: IProps) => {
                 </span>
                 <span className={styles.Line}>
                     {"      "}
-                    <span className={styles.At}>instance-name</span>: <span className={styles.St}>my-app</span>
+                    <span className={styles.At}>instance-name-prefix</span>: <span className={styles.St}>my-app</span>
                 </span>
                 <span className={styles.Line}>
                     {"      "}


### PR DESCRIPTION
Closes #1384

## What changed

Since #1306 (GH-1292) the configured instance name is used as a base to which a unique 8-char postfix is appended in `DefaultSelfRegistrationMetadataAssembler`:

```java
this.instanceName = selfRegistrationConfigurationProperties.getInstanceName() + "-" + generateNamePostfix();
```

So the configured value is really a **prefix**, not the full instance name. This renames the starter configuration property to reflect that:

- `axelix.sbs.discovery.instance-name` → `axelix.sbs.discovery.instance-name-prefix`

Concretely:
- `SelfRegistrationConfigurationProperties`: field, getter/setter, javadoc and the validation message are renamed to `instanceNamePrefix`.
- `DefaultSelfRegistrationMetadataAssembler`: reads `getInstanceNamePrefix()`.
- Starter tests (`SelfRegistrationServiceTest`, `DefaultSelfRegistrationMetadataAssemblerTest`) updated to the new property key.
- Playground `application-local.properties` (x4) and the docs/website snippets (EN + RU) updated.

## What did NOT change

The runtime instance name carried in the heartbeat payload (`SelfRegistrationMetadata.instanceName` and the Master-side consumers) is intentionally left as-is — that is the fully-assembled name (prefix + postfix), so `instanceName` remains the correct term there.

This is a **breaking change** to the starter configuration property, matching the `breaking-change` label on the issue.

## Verification

`./gradlew :sbs:starter-domain:test` → all 133 tests pass.

---

🤖 This PR was written with AI assistance (Claude); I reviewed and verified every change. See the `Co-Authored-By` trailer on the commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup guides (including Russian translations) to use `axelix.sbs.discovery.instance-name-prefix` instead of `instance-name`, with revised self-registration explanations.
  * Refreshed install/configuration snippets to show the new property key.

* **New Features**
  * Self-registration now supports instance naming via a prefix, with an automatically added unique suffix for each instance.

* **Bug Fixes**
  * Aligned playground configurations and automated tests to the new discovery naming property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->