### PR TITLE
GH-1400 Hide `Metrics` endpoint implementation classes from starter public API

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsAutoConfiguration.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.metrics;
 
 import java.util.Set;
 
@@ -32,9 +32,6 @@ import com.axelixlabs.axelix.common.api.transform.BaseUnitParser;
 import com.axelixlabs.axelix.common.api.transform.BaseUnitValueTransformer;
 import com.axelixlabs.axelix.common.api.transform.BytesMemoryBaseUnitValueTransformer;
 import com.axelixlabs.axelix.common.api.transform.KilobytesMemoryBaseUnitValueTransformer;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultServiceMetricsGroupsAssembler;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.ServiceMetricsGroupsAssembler;
 
 /**
  * Auto-configuration for the {@link AxelixMetricsEndpoint}.

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsEndpoint.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsEndpoint.java
@@ -53,7 +53,7 @@ import com.axelixlabs.axelix.common.api.transform.units.BaseUnit;
  * @author Mikhail Polivakha
  */
 @Endpoint(id = "axelix-metrics")
-public class AxelixMetricsEndpoint {
+class AxelixMetricsEndpoint {
 
     private final MetricsEndpoint delegate;
     private final MeterRegistry registry;
@@ -64,7 +64,7 @@ public class AxelixMetricsEndpoint {
     private static final Set<Statistic> ACTUAL_VALUE_STATISTICS =
             Set.of(Statistic.VALUE, Statistic.TOTAL, Statistic.COUNT);
 
-    public AxelixMetricsEndpoint(
+    AxelixMetricsEndpoint(
             MeterRegistry registry,
             BaseUnitParser baseUnitParser,
             ServiceMetricsGroupsAssembler defaultMetricsGroupsAssembler,

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultServiceMetricsGroupsAssembler.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultServiceMetricsGroupsAssembler.java
@@ -34,13 +34,13 @@ import com.axelixlabs.axelix.common.api.metrics.MetricsGroupsFeed.MetricsGroup.M
  *
  * @author Sergey Cherkasov
  */
-public class DefaultServiceMetricsGroupsAssembler implements ServiceMetricsGroupsAssembler {
+class DefaultServiceMetricsGroupsAssembler implements ServiceMetricsGroupsAssembler {
 
     public static final String OTHER_GROUP_NAME = "Others";
 
     private final MeterRegistry registry;
 
-    public DefaultServiceMetricsGroupsAssembler(MeterRegistry registry) {
+    DefaultServiceMetricsGroupsAssembler(MeterRegistry registry) {
         this.registry = registry;
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -8,7 +8,7 @@ com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixEnvironmentEndpointAuto
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.GarbageCollectionAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointPropertiesSupportAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.GitInformationProviderAutoConfiguration

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -32,7 +32,6 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoCo
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointPropertiesSupportAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.GarbageCollectionAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.GitInformationProviderAutoConfiguration;
@@ -44,6 +43,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProvider
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsAutoConfigurationTest.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.metrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -28,8 +28,6 @@ import com.axelixlabs.axelix.common.api.transform.BaseUnitParser;
 import com.axelixlabs.axelix.common.api.transform.BaseUnitValueTransformer;
 import com.axelixlabs.axelix.common.api.transform.BytesMemoryBaseUnitValueTransformer;
 import com.axelixlabs.axelix.common.api.transform.KilobytesMemoryBaseUnitValueTransformer;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.ServiceMetricsGroupsAssembler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixCachesEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/AxelixCachesEndpointAutoConfiguration.java
@@ -33,6 +33,7 @@ import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
 import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheOperationsDispatcher;
 import com.axelixlabs.axelix.sbs.spring.core.cache.DefaultCacheSizeProvider;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisherAutoConfiguration;
 
 /**
  * Auto-configuration class for the caches custom actuator endpoint.

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.core.Ordered;
 
 import com.axelixlabs.axelix.sbs.spring.core.config.TransactionMonitoringConfigurationProperties;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisherAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.ProxyingDataSourceBeanPostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.TransactionMonitoringBeanPostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.TransactionMonitoringEndpoint;

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsAutoConfiguration.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.metrics;
 
 import java.util.Set;
 
@@ -32,9 +32,6 @@ import com.axelixlabs.axelix.common.api.transform.BaseUnitParser;
 import com.axelixlabs.axelix.common.api.transform.BaseUnitValueTransformer;
 import com.axelixlabs.axelix.common.api.transform.BytesMemoryBaseUnitValueTransformer;
 import com.axelixlabs.axelix.common.api.transform.KilobytesMemoryBaseUnitValueTransformer;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultServiceMetricsGroupsAssembler;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.ServiceMetricsGroupsAssembler;
 
 /**
  * Auto-configuration for the {@link AxelixMetricsEndpoint}.

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsEndpoint.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsEndpoint.java
@@ -52,7 +52,7 @@ import com.axelixlabs.axelix.common.api.transform.units.BaseUnit;
  * @author Mikhail Polivakha
  */
 @Endpoint(id = "axelix-metrics")
-public class AxelixMetricsEndpoint {
+class AxelixMetricsEndpoint {
 
     private final MetricsEndpoint delegate;
     private final MeterRegistry registry;
@@ -63,7 +63,7 @@ public class AxelixMetricsEndpoint {
     private static final Set<Statistic> ACTUAL_VALUE_STATISTICS =
             Set.of(Statistic.VALUE, Statistic.TOTAL, Statistic.COUNT);
 
-    public AxelixMetricsEndpoint(
+    AxelixMetricsEndpoint(
             MeterRegistry registry,
             BaseUnitParser baseUnitParser,
             ServiceMetricsGroupsAssembler defaultMetricsGroupsAssembler,

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsPublisherAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsPublisherAutoConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration for the {@link AxelixMetricsPublisher}.
+ *
+ * @author Sergey Cherkasov
+ */
+@AutoConfiguration(after = CompositeMeterRegistryAutoConfiguration.class)
+@ConditionalOnBean(MeterRegistry.class)
+public class AxelixMetricsPublisherAutoConfiguration {
+
+    @Bean
+    public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
+        return new DefaultAxelixMetricsPublisher(meterRegistry);
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultAxelixMetricsPublisher.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultAxelixMetricsPublisher.java
@@ -33,13 +33,13 @@ import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.Transaction
  *
  * @author Nikita Kirillov
  */
-public class DefaultAxelixMetricsPublisher implements AxelixMetricsPublisher {
+class DefaultAxelixMetricsPublisher implements AxelixMetricsPublisher {
 
     private final ConcurrentHashMap<String, Counter> cacheCounters = new ConcurrentHashMap<>();
 
     private final MeterRegistry meterRegistry;
 
-    public DefaultAxelixMetricsPublisher(MeterRegistry meterRegistry) {
+    DefaultAxelixMetricsPublisher(MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultServiceMetricsGroupsAssembler.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultServiceMetricsGroupsAssembler.java
@@ -34,13 +34,13 @@ import com.axelixlabs.axelix.common.api.metrics.MetricsGroupsFeed.MetricsGroup.M
  *
  * @author Sergey Cherkasov
  */
-public class DefaultServiceMetricsGroupsAssembler implements ServiceMetricsGroupsAssembler {
+class DefaultServiceMetricsGroupsAssembler implements ServiceMetricsGroupsAssembler {
 
     public static final String OTHER_GROUP_NAME = "Others";
 
     private final MeterRegistry registry;
 
-    public DefaultServiceMetricsGroupsAssembler(MeterRegistry registry) {
+    DefaultServiceMetricsGroupsAssembler(MeterRegistry registry) {
         this.registry = registry;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -10,7 +10,7 @@ com.axelixlabs.axelix.sbs.spring.autoconfiguration.GarbageCollectionAutoConfigur
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration
 com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointPropertiesSupportAutoConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsPublisherAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisherAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.GitInformationProviderAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.JwtAuthAutoConfiguration

--- a/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -8,7 +8,7 @@ com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixEnvironmentEndpointAuto
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.GarbageCollectionAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointPropertiesSupportAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsPublisherAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoConfiguration

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -33,7 +33,6 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoCo
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsPublisherAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointPropertiesSupportAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.GarbageCollectionAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.GitInformationProviderAutoConfiguration;
@@ -47,6 +46,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEn
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisherAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -33,7 +33,6 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoCo
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetadataEndpointConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixMetricsPublisherAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.EndpointPropertiesSupportAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.GarbageCollectionAutoConfiguration;
@@ -47,6 +46,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProvider
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
@@ -80,7 +80,7 @@ import com.axelixlabs.axelix.sbs.spring.core.env.EnvironmentService;
 import com.axelixlabs.axelix.sbs.spring.core.env.EnvironmentTestConfig;
 import com.axelixlabs.axelix.sbs.spring.core.env.PropertyNameNormalizer;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.TestAxelixMetricsPublishers;
 
 import static com.axelixlabs.axelix.sbs.spring.core.IgnoreTestContextArchitecture.POTENTIAL_CONTEXT_MUTATION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -465,7 +465,7 @@ class JwtAuthorizationFilterTest {
 
         @Bean
         public AxelixMetricsPublisher axelixMetricsPublisher() {
-            return new DefaultAxelixMetricsPublisher(new SimpleMeterRegistry());
+            return TestAxelixMetricsPublishers.create(new SimpleMeterRegistry());
         }
 
         @Bean(name = MAIN_CACHE_MANAGER)

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/AxelixCachesEndpointTest.java
@@ -54,7 +54,7 @@ import com.axelixlabs.axelix.common.api.caches.CachesFeed.CacheManagerDto;
 import com.axelixlabs.axelix.sbs.spring.core.IgnoreTestContextArchitecture;
 import com.axelixlabs.axelix.sbs.spring.core.Main;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.TestAxelixMetricsPublishers;
 import com.axelixlabs.axelix.sbs.spring.core.utils.TestRestTemplateBuilder;
 
 import static com.axelixlabs.axelix.sbs.spring.core.IgnoreTestContextArchitecture.POTENTIAL_CONTEXT_MUTATION;
@@ -537,7 +537,7 @@ class AxelixCachesEndpointTest {
 
         @Bean
         public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
-            return new DefaultAxelixMetricsPublisher(meterRegistry);
+            return TestAxelixMetricsPublishers.create(meterRegistry);
         }
 
         @Bean

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultCacheOperationsDispatcherTest.java
@@ -31,7 +31,7 @@ import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 import com.axelixlabs.axelix.common.api.caches.CachesFeed;
 import com.axelixlabs.axelix.common.api.caches.SingleCache;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.TestAxelixMetricsPublishers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -61,7 +61,7 @@ class DefaultCacheOperationsDispatcherTest {
 
     @BeforeEach
     void setUp() {
-        AxelixMetricsPublisher axelixMetricsPublisher = new DefaultAxelixMetricsPublisher(new SimpleMeterRegistry());
+        AxelixMetricsPublisher axelixMetricsPublisher = TestAxelixMetricsPublishers.create(new SimpleMeterRegistry());
         Map<String, CacheManager> managers = new HashMap<>();
 
         cacheManager1 = new DefaultEnhancedCacheManager(

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/DefaultEnhancedCacheTest.java
@@ -35,7 +35,7 @@ import org.springframework.cache.Cache;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.TestAxelixMetricsPublishers;
 
 import static com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricNames.CACHE_ENABLED;
 import static com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricNames.CACHE_REQUESTS;
@@ -70,7 +70,7 @@ class DefaultEnhancedCacheTest {
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
-        axelixMetricsPublisher = new DefaultAxelixMetricsPublisher(meterRegistry);
+        axelixMetricsPublisher = TestAxelixMetricsPublishers.create(meterRegistry);
 
         Mockito.lenient().when(delegate.getName()).thenReturn(CACHE_NAME);
         enhancedCache = new DefaultEnhancedCache(delegate, axelixMetricsPublisher);

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/cache/EnhancedCacheManagerTest.java
@@ -26,7 +26,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
 
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.TestAxelixMetricsPublishers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -46,7 +46,7 @@ class EnhancedCacheManagerTest {
     @BeforeEach
     void setUp() {
         CacheManager cacheManager = new ConcurrentMapCacheManager();
-        AxelixMetricsPublisher axelixMetricsPublisher = new DefaultAxelixMetricsPublisher(new SimpleMeterRegistry());
+        AxelixMetricsPublisher axelixMetricsPublisher = TestAxelixMetricsPublishers.create(new SimpleMeterRegistry());
         subject = new DefaultEnhancedCacheManager("testCacheManagerBeanName", cacheManager, axelixMetricsPublisher);
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricsAutoConfigurationTest.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.metrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -28,8 +28,6 @@ import com.axelixlabs.axelix.common.api.transform.BaseUnitParser;
 import com.axelixlabs.axelix.common.api.transform.BaseUnitValueTransformer;
 import com.axelixlabs.axelix.common.api.transform.BytesMemoryBaseUnitValueTransformer;
 import com.axelixlabs.axelix.common.api.transform.KilobytesMemoryBaseUnitValueTransformer;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.ServiceMetricsGroupsAssembler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/TestAxelixMetricsPublishers.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/metrics/TestAxelixMetricsPublishers.java
@@ -15,29 +15,20 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.metrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.context.annotation.Bean;
-
-import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
-
 /**
- * Auto-configuration for the {@link AxelixMetricsPublisher}.
+ * Test factory for {@link AxelixMetricsPublisher} instances.
  *
  * @author Sergey Cherkasov
  */
-@AutoConfiguration(after = CompositeMeterRegistryAutoConfiguration.class)
-@ConditionalOnBean(MeterRegistry.class)
-public class AxelixMetricsPublisherAutoConfiguration {
+public class TestAxelixMetricsPublishers {
 
-    @Bean
-    public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
+    private TestAxelixMetricsPublishers() {}
+
+    public static AxelixMetricsPublisher create(MeterRegistry meterRegistry) {
         return new DefaultAxelixMetricsPublisher(meterRegistry);
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/AbstractTransactionMonitoringSharedContextTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/AbstractTransactionMonitoringSharedContextTest.java
@@ -59,7 +59,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
-import com.axelixlabs.axelix.sbs.spring.core.metrics.DefaultAxelixMetricsPublisher;
+import com.axelixlabs.axelix.sbs.spring.core.metrics.TestAxelixMetricsPublishers;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.NPlusOneCollectionLoadListener;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.NPlusOneEntityLoadListener;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.NPlusOneIntegrator;
@@ -149,7 +149,7 @@ abstract class AbstractTransactionMonitoringSharedContextTest {
 
         @Bean
         public AxelixMetricsPublisher axelixMetricsPublisher(MeterRegistry meterRegistry) {
-            return new DefaultAxelixMetricsPublisher(meterRegistry);
+            return TestAxelixMetricsPublishers.create(meterRegistry);
         }
 
         @Bean

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/ServiceMetricsGroupsAssembler.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/ServiceMetricsGroupsAssembler.java
@@ -24,7 +24,7 @@ import com.axelixlabs.axelix.common.api.metrics.MetricsGroupsFeed;
  *
  * @author Sergey Cherkasov
  */
-public interface ServiceMetricsGroupsAssembler {
+interface ServiceMetricsGroupsAssembler {
 
     /**
      * @return assembled {@link MetricsGroupsFeed}.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved metrics-related auto-configuration and supporting components into a new shared package namespace across Spring Boot 2/3.
* **Bug Fixes**
  * Corrected metrics auto-configuration dependency ordering by updating references to the metrics publisher auto-configuration.
* **Tests**
  * Updated tests to use a shared test helper for creating the metrics publisher, keeping wiring consistent after the package move.
* **Chores**
  * Reduced visibility of internal metrics endpoint and assembler/publisher types to package-level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->