### PR TITLE
GH-1404 Hide `Beans` endpoint implementation classes from starter public API

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpoint.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpoint.java
@@ -31,11 +31,11 @@ import com.axelixlabs.axelix.common.api.BeansFeed;
  * @author Mikhail Polivakha
  */
 @RestControllerEndpoint(id = "axelix-beans")
-public class AxelixBeansEndpoint {
+class AxelixBeansEndpoint {
 
     private final BeansFeedBuilder beansFeedBuilder;
 
-    public AxelixBeansEndpoint(BeansFeedBuilder beansFeedBuilder) {
+    AxelixBeansEndpoint(BeansFeedBuilder beansFeedBuilder) {
         this.beansFeedBuilder = beansFeedBuilder;
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpointAutoConfiguration.java
@@ -15,24 +15,18 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.beans;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 
-import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeansFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeanMetaInfoExtractor;
-import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeansFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.beans.QualifiersPersistencePostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRefBuilder;
 
 /**
- * Auto-configuration class for the beans custom actuator endpoint.
+ * Auto-configuration class for {@link AxelixBeansEndpoint}.
  *
  * @since 07.07.2025
  * @author Nikita Kirillov
@@ -62,7 +56,7 @@ public class AxelixBeansEndpointAutoConfiguration {
     }
 
     @Bean
-    public AxelixBeansEndpoint axelixBeansEndpoint(BeansFeedBuilder cachingBeansFeedBuilder) {
+    public AxelixBeansEndpoint beansEndpointExtension(BeansFeedBuilder cachingBeansFeedBuilder) {
         return new AxelixBeansEndpoint(cachingBeansFeedBuilder);
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/BeanMetaInfoExtractor.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/BeanMetaInfoExtractor.java
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
  * @author Nikita Kirillov
  */
 @NullMarked
-public interface BeanMetaInfoExtractor {
+interface BeanMetaInfoExtractor {
 
     /**
      * Enriches bean descriptor with additional analysis information.

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeanMetaInfoExtractor.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeanMetaInfoExtractor.java
@@ -60,14 +60,14 @@ import static com.axelixlabs.axelix.common.api.BeansFeed.UnknownBean;
  * @since 04.07.2025
  */
 @NullMarked
-public class DefaultBeanMetaInfoExtractor implements BeanMetaInfoExtractor {
+class DefaultBeanMetaInfoExtractor implements BeanMetaInfoExtractor {
 
     private final DefaultQualifiersRegistry qualifiersRegistry;
     private final ConfigurableListableBeanFactory beanFactory;
     private final ConditionsReportEndpoint delegateConditions;
     private final ConditionalBeanRefBuilder conditionalBeanRefBuilder;
 
-    public DefaultBeanMetaInfoExtractor(
+    DefaultBeanMetaInfoExtractor(
             ConfigurableApplicationContext configurableApplicationContext,
             ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
         this.beanFactory = configurableApplicationContext.getBeanFactory();

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeansFeedBuilder.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeansFeedBuilder.java
@@ -43,13 +43,13 @@ import com.axelixlabs.axelix.sbs.spring.core.utils.StringUtils;
  *
  * @author Mikhail Polivakha
  */
-public class DefaultBeansFeedBuilder implements BeansFeedBuilder {
+class DefaultBeansFeedBuilder implements BeansFeedBuilder {
 
     private final BeansEndpoint delegate;
     private final BeanMetaInfoExtractor enricher;
     private final ConfigurableApplicationContext context;
 
-    public DefaultBeansFeedBuilder(BeanMetaInfoExtractor enricher, ConfigurableApplicationContext context) {
+    DefaultBeansFeedBuilder(BeanMetaInfoExtractor enricher, ConfigurableApplicationContext context) {
         // TODO: replace the actuator call with dedicated, self-written API
         this.delegate = new BeansEndpoint(context);
         this.enricher = enricher;

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/QualifiersPersistencePostProcessor.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/QualifiersPersistencePostProcessor.java
@@ -38,7 +38,7 @@ import org.springframework.core.type.MethodMetadata;
  *
  * @author Mikhail Polivakha
  */
-public class QualifiersPersistencePostProcessor implements BeanFactoryPostProcessor, Ordered {
+class QualifiersPersistencePostProcessor implements BeanFactoryPostProcessor, Ordered {
 
     @Override
     public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {

--- a/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-2-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,4 @@
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -22,7 +22,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration;
@@ -44,6 +43,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProvider
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpointAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
@@ -35,7 +35,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpEntity;
@@ -45,7 +44,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 
-import com.axelixlabs.axelix.common.api.BeansFeed;
 import com.axelixlabs.axelix.common.auth.core.AuthenticationSchemes;
 import com.axelixlabs.axelix.common.auth.core.Authority;
 import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
@@ -57,11 +55,7 @@ import com.axelixlabs.axelix.common.auth.core.User;
 import com.axelixlabs.axelix.common.auth.service.DefaultJwtEncoderService;
 import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
 import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthorizationFilterTest.JwtAuthorizationFilterTestConfiguration;
-import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeansFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeanMetaInfoExtractor;
-import com.axelixlabs.axelix.sbs.spring.core.beans.QualifiersPersistencePostProcessor;
+import com.axelixlabs.axelix.sbs.spring.core.beans.BeansTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpoint;
 import com.axelixlabs.axelix.sbs.spring.core.cache.CacheManagerBeanPostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
@@ -94,6 +88,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         })
 @Import({
     JwtAuthorizationFilterTestConfiguration.class,
+    BeansTestConfiguration.class,
     AxelixCachesEndpoint.class,
     DefaultCacheOperationsDispatcher.class,
     EnvironmentTestConfig.class,
@@ -400,28 +395,6 @@ class JwtAuthorizationFilterTest {
         @Bean
         public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
             return new DefaultConditionalBeanRefBuilder();
-        }
-
-        @Bean
-        public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
-            return new QualifiersPersistencePostProcessor();
-        }
-
-        @Bean
-        public BeanMetaInfoExtractor beanMetaInfoExtractor(
-                ConfigurableApplicationContext configurableApplicationContext,
-                ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
-            return new DefaultBeanMetaInfoExtractor(configurableApplicationContext, conditionalBeanRefBuilder);
-        }
-
-        @Bean
-        public BeansFeedBuilder noOpBeanFeedBuilder() {
-            return () -> new BeansFeed(List.of());
-        }
-
-        @Bean
-        public AxelixBeansEndpoint axelixBeansEndpoint(BeansFeedBuilder noOpBeanFeedBuilder) {
-            return new AxelixBeansEndpoint(noOpBeanFeedBuilder);
         }
 
         @Bean

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpointAutoConfigurationTest.java
@@ -15,18 +15,13 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.beans;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
-import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeansFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeansFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.beans.QualifiersPersistencePostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/BeansTestConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/BeansTestConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.beans;
+
+import java.util.List;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.common.api.BeansFeed;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
+
+/**
+ * Minimal beans-endpoint test wiring for tests outside {@code core.beans}.
+ *
+ * @author Sergey Cherkasov
+ */
+@TestConfiguration
+public class BeansTestConfiguration {
+
+    @Bean
+    public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
+        return new QualifiersPersistencePostProcessor();
+    }
+
+    @Bean
+    public BeanMetaInfoExtractor beanMetaInfoExtractor(
+            ConfigurableApplicationContext configurableApplicationContext,
+            ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
+        return new DefaultBeanMetaInfoExtractor(configurableApplicationContext, conditionalBeanRefBuilder);
+    }
+
+    @Bean
+    public BeansFeedBuilder noOpBeanFeedBuilder() {
+        return () -> new BeansFeed(List.of());
+    }
+
+    @Bean
+    public AxelixBeansEndpoint axelixBeansEndpoint(BeansFeedBuilder noOpBeanFeedBuilder) {
+        return new AxelixBeansEndpoint(noOpBeanFeedBuilder);
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpoint.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpoint.java
@@ -31,11 +31,11 @@ import com.axelixlabs.axelix.common.api.BeansFeed;
  * @author Mikhail Polivakha
  */
 @RestControllerEndpoint(id = "axelix-beans")
-public class AxelixBeansEndpoint {
+class AxelixBeansEndpoint {
 
     private final BeansFeedBuilder beansFeedBuilder;
 
-    public AxelixBeansEndpoint(BeansFeedBuilder beansFeedBuilder) {
+    AxelixBeansEndpoint(BeansFeedBuilder beansFeedBuilder) {
         this.beansFeedBuilder = beansFeedBuilder;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpointAutoConfiguration.java
@@ -15,24 +15,18 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.beans;
 
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 
-import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeansFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeanMetaInfoExtractor;
-import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeansFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.beans.QualifiersPersistencePostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
 import com.axelixlabs.axelix.sbs.spring.core.conditions.DefaultConditionalBeanRefBuilder;
 
 /**
- * Auto-configuration class for {@link AxelixBeansEndpoint}.
+ * Auto-configuration class for the beans custom actuator endpoint.
  *
  * @since 07.07.2025
  * @author Nikita Kirillov
@@ -62,7 +56,7 @@ public class AxelixBeansEndpointAutoConfiguration {
     }
 
     @Bean
-    public AxelixBeansEndpoint beansEndpointExtension(BeansFeedBuilder cachingBeansFeedBuilder) {
+    public AxelixBeansEndpoint axelixBeansEndpoint(BeansFeedBuilder cachingBeansFeedBuilder) {
         return new AxelixBeansEndpoint(cachingBeansFeedBuilder);
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/BeanMetaInfoExtractor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/BeanMetaInfoExtractor.java
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
  * @author Nikita Kirillov
  */
 @NullMarked
-public interface BeanMetaInfoExtractor {
+interface BeanMetaInfoExtractor {
 
     /**
      * Enriches bean descriptor with additional analysis information.

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeanMetaInfoExtractor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeanMetaInfoExtractor.java
@@ -60,14 +60,14 @@ import static com.axelixlabs.axelix.common.api.BeansFeed.UnknownBean;
  * @since 04.07.2025
  */
 @NullMarked
-public class DefaultBeanMetaInfoExtractor implements BeanMetaInfoExtractor {
+class DefaultBeanMetaInfoExtractor implements BeanMetaInfoExtractor {
 
     private final DefaultQualifiersRegistry qualifiersRegistry;
     private final ConfigurableListableBeanFactory beanFactory;
     private final ConditionsReportEndpoint delegateConditions;
     private final ConditionalBeanRefBuilder conditionalBeanRefBuilder;
 
-    public DefaultBeanMetaInfoExtractor(
+    DefaultBeanMetaInfoExtractor(
             ConfigurableApplicationContext configurableApplicationContext,
             ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
         this.beanFactory = configurableApplicationContext.getBeanFactory();

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeansFeedBuilder.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultBeansFeedBuilder.java
@@ -45,13 +45,13 @@ import com.axelixlabs.axelix.sbs.spring.core.utils.StringUtils;
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
  */
-public class DefaultBeansFeedBuilder implements BeansFeedBuilder {
+class DefaultBeansFeedBuilder implements BeansFeedBuilder {
 
     private final BeansEndpoint delegate;
     private final BeanMetaInfoExtractor enricher;
     private final ConfigurableApplicationContext context;
 
-    public DefaultBeansFeedBuilder(BeanMetaInfoExtractor enricher, ConfigurableApplicationContext context) {
+    DefaultBeansFeedBuilder(BeanMetaInfoExtractor enricher, ConfigurableApplicationContext context) {
         // TODO: replace the actuator call with dedicated, self-written API
         this.delegate = new BeansEndpoint(context);
         this.enricher = enricher;

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/QualifiersPersistencePostProcessor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/QualifiersPersistencePostProcessor.java
@@ -37,7 +37,7 @@ import org.springframework.core.type.MethodMetadata;
  *
  * @author Mikhail Polivakha
  */
-public class QualifiersPersistencePostProcessor implements BeanFactoryPostProcessor, Ordered {
+class QualifiersPersistencePostProcessor implements BeanFactoryPostProcessor, Ordered {
 
     @Override
     public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {

--- a/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,4 @@
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -22,7 +22,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixBeansEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixCachesEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration;
@@ -47,6 +46,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProvider
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpointAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/auth/JwtAuthorizationFilterTest.java
@@ -37,7 +37,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpEntity;
@@ -47,7 +46,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 
-import com.axelixlabs.axelix.common.api.BeansFeed;
 import com.axelixlabs.axelix.common.auth.core.AuthenticationSchemes;
 import com.axelixlabs.axelix.common.auth.core.Authority;
 import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
@@ -60,11 +58,7 @@ import com.axelixlabs.axelix.common.auth.service.DefaultJwtEncoderService;
 import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
 import com.axelixlabs.axelix.sbs.spring.core.IgnoreTestContextArchitecture;
 import com.axelixlabs.axelix.sbs.spring.core.auth.JwtAuthorizationFilterTest.JwtAuthorizationFilterTestConfiguration;
-import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeansFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeanMetaInfoExtractor;
-import com.axelixlabs.axelix.sbs.spring.core.beans.QualifiersPersistencePostProcessor;
+import com.axelixlabs.axelix.sbs.spring.core.beans.BeansTestConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.cache.AxelixCachesEndpoint;
 import com.axelixlabs.axelix.sbs.spring.core.cache.CacheManagerBeanPostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.cache.CacheSizeProvider;
@@ -102,6 +96,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         })
 @Import({
     JwtAuthorizationFilterTestConfiguration.class,
+    BeansTestConfiguration.class,
     AxelixCachesEndpoint.class,
     DefaultCacheOperationsDispatcher.class,
     EnvironmentTestConfig.class,
@@ -411,28 +406,6 @@ class JwtAuthorizationFilterTest {
         @Bean
         public ConditionalBeanRefBuilder conditionalBeanRefBuilder() {
             return new DefaultConditionalBeanRefBuilder();
-        }
-
-        @Bean
-        public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
-            return new QualifiersPersistencePostProcessor();
-        }
-
-        @Bean
-        public BeanMetaInfoExtractor beanMetaInfoExtractor(
-                ConfigurableApplicationContext configurableApplicationContext,
-                ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
-            return new DefaultBeanMetaInfoExtractor(configurableApplicationContext, conditionalBeanRefBuilder);
-        }
-
-        @Bean
-        public BeansFeedBuilder noOpBeanFeedBuilder() {
-            return () -> new BeansFeed(List.of());
-        }
-
-        @Bean
-        public AxelixBeansEndpoint axelixBeansEndpoint(BeansFeedBuilder noOpBeanFeedBuilder) {
-            return new AxelixBeansEndpoint(noOpBeanFeedBuilder);
         }
 
         @Bean

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/AxelixBeansEndpointAutoConfigurationTest.java
@@ -15,18 +15,13 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.beans;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
-import com.axelixlabs.axelix.sbs.spring.core.beans.AxelixBeansEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeanMetaInfoExtractor;
-import com.axelixlabs.axelix.sbs.spring.core.beans.BeansFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.beans.DefaultBeansFeedBuilder;
-import com.axelixlabs.axelix.sbs.spring.core.beans.QualifiersPersistencePostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/BeansTestConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/beans/BeansTestConfiguration.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.beans;
+
+import java.util.List;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+import com.axelixlabs.axelix.common.api.BeansFeed;
+import com.axelixlabs.axelix.sbs.spring.core.conditions.ConditionalBeanRefBuilder;
+
+/**
+ * Minimal beans-endpoint test wiring for tests outside {@code core.beans}.
+ *
+ * @author Sergey Cherkasov
+ */
+@TestConfiguration
+public class BeansTestConfiguration {
+
+    @Bean
+    public static QualifiersPersistencePostProcessor qualifiersPersistencePostProcessor() {
+        return new QualifiersPersistencePostProcessor();
+    }
+
+    @Bean
+    public BeanMetaInfoExtractor beanMetaInfoExtractor(
+            ConfigurableApplicationContext configurableApplicationContext,
+            ConditionalBeanRefBuilder conditionalBeanRefBuilder) {
+        return new DefaultBeanMetaInfoExtractor(configurableApplicationContext, conditionalBeanRefBuilder);
+    }
+
+    @Bean
+    public BeansFeedBuilder noOpBeanFeedBuilder() {
+        return () -> new BeansFeed(List.of());
+    }
+
+    @Bean
+    public AxelixBeansEndpoint axelixBeansEndpoint(BeansFeedBuilder noOpBeanFeedBuilder) {
+        return new AxelixBeansEndpoint(noOpBeanFeedBuilder);
+    }
+}

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/BeanMetaInfo.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/BeanMetaInfo.java
@@ -32,7 +32,7 @@ import com.axelixlabs.axelix.common.api.BeansFeed.ProxyType;
  * @author Sergey Cherkasov
  * @author Nikita Kirillov
  */
-public final class BeanMetaInfo {
+final class BeanMetaInfo {
 
     @Nullable
     private final String autoConfigurationRef;
@@ -43,7 +43,7 @@ public final class BeanMetaInfo {
     private final List<String> qualifiers;
     private final BeansFeed.BeanSource beanSource;
 
-    public BeanMetaInfo(
+    BeanMetaInfo(
             @Nullable String autoConfigurationRef,
             ProxyType proxyType,
             boolean isLazyInit,
@@ -59,27 +59,27 @@ public final class BeanMetaInfo {
     }
 
     @Nullable
-    public String getAutoConfigurationRef() {
+    String getAutoConfigurationRef() {
         return autoConfigurationRef;
     }
 
-    public ProxyType getProxyType() {
+    ProxyType getProxyType() {
         return proxyType;
     }
 
-    public boolean isLazyInit() {
+    boolean isLazyInit() {
         return isLazyInit;
     }
 
-    public boolean isPrimary() {
+    boolean isPrimary() {
         return isPrimary;
     }
 
-    public List<String> getQualifiers() {
+    List<String> getQualifiers() {
         return qualifiers;
     }
 
-    public BeansFeed.BeanSource getBeanSource() {
+    BeansFeed.BeanSource getBeanSource() {
         return beanSource;
     }
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/BeansFeedBuilder.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/BeansFeedBuilder.java
@@ -26,7 +26,7 @@ import com.axelixlabs.axelix.common.api.BeansFeed;
  *
  * @author Mikhail Polivakha
  */
-public interface BeansFeedBuilder {
+interface BeansFeedBuilder {
 
     /**
      * @return feed of beans inside the given application.

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultQualifiersRegistry.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/beans/DefaultQualifiersRegistry.java
@@ -30,9 +30,9 @@ import org.jspecify.annotations.NonNull;
  *
  * @author Mikhail Polivakha
  */
-public class DefaultQualifiersRegistry {
+class DefaultQualifiersRegistry {
 
-    public static final DefaultQualifiersRegistry INSTANCE = new DefaultQualifiersRegistry();
+    static final DefaultQualifiersRegistry INSTANCE = new DefaultQualifiersRegistry();
 
     private final ConcurrentMap<String, List<String>> cache;
 
@@ -41,11 +41,11 @@ public class DefaultQualifiersRegistry {
     }
 
     @NonNull
-    public List<String> getQualifiers(@NonNull String beanName) {
+    List<String> getQualifiers(@NonNull String beanName) {
         return Optional.ofNullable(cache.get(beanName)).orElse(new ArrayList<>());
     }
 
-    public void registerQualifiers(@NonNull String beanName, @NonNull List<String> qualifiers) {
+    void registerQualifiers(@NonNull String beanName, @NonNull List<String> qualifiers) {
         cache.compute(beanName, (s, existingQualifiers) -> {
             if (existingQualifiers == null || existingQualifiers.isEmpty()) {
                 existingQualifiers = new ArrayList<>();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Restricted internal bean-inspection and endpoint components to package-level access.
  - Reorganized bean endpoint auto-configuration while preserving automatic setup.
  - Existing bean endpoint behavior and responses remain unchanged.
  - Reduced exposure of internal bean metadata and qualifier APIs.

- **Tests**
  - Centralized shared test wiring for bean endpoint components.
  - Updated authorization and auto-configuration tests to use the shared configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->