### PR TITLE
GH-1406 Hide `Feign` endpoint implementation classes from starter public API

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/integrations/feign/AxelixFeignEndpoint.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/integrations/feign/AxelixFeignEndpoint.java
@@ -30,11 +30,11 @@ import com.axelixlabs.axelix.common.api.integration.FeignIntegration;
  * @author Sergey Cherkasov
  */
 @Endpoint(id = "axelix-feign")
-public class AxelixFeignEndpoint {
+class AxelixFeignEndpoint {
 
     private final FeignClientIntegrationDiscoverer discoverer;
 
-    public AxelixFeignEndpoint(FeignClientIntegrationDiscoverer discoverer) {
+    AxelixFeignEndpoint(FeignClientIntegrationDiscoverer discoverer) {
         this.discoverer = discoverer;
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/integrations/feign/AxelixFeignEndpointAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/integrations/feign/AxelixFeignEndpointAutoConfiguration.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.integrations.feign;
 
 import feign.Feign;
 
@@ -29,10 +29,6 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.cloud.openfeign.FeignClientFactoryBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-
-import com.axelixlabs.axelix.sbs.spring.core.integrations.feign.AxelixFeignEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.integrations.feign.FeignClientIntegrationDiscoverer;
-import com.axelixlabs.axelix.sbs.spring.core.integrations.feign.NoOpDiscoveryClient;
 
 /**
  * Auto-configuration for discovering HTTP integrations based on Spring Cloud OpenFeign.

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/integrations/feign/FeignClientIntegrationDiscoverer.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/integrations/feign/FeignClientIntegrationDiscoverer.java
@@ -36,7 +36,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.axelixlabs.axelix.common.api.integration.FeignIntegration;
 import com.axelixlabs.axelix.common.domain.http.HttpVersion;
-import com.axelixlabs.axelix.sbs.spring.core.integrations.IntegrationComponentDiscoverer;
 
 /**
  * Discovers HTTP service integrations based on {@link FeignClient} annotations
@@ -49,7 +48,7 @@ import com.axelixlabs.axelix.sbs.spring.core.integrations.IntegrationComponentDi
  * @author Sergey Cherkasov
  * @author Mikhail Polivakha
  */
-public class FeignClientIntegrationDiscoverer implements IntegrationComponentDiscoverer<FeignIntegration> {
+class FeignClientIntegrationDiscoverer {
 
     private static final String UNKNOWN = "UNKNOWN";
 
@@ -57,12 +56,12 @@ public class FeignClientIntegrationDiscoverer implements IntegrationComponentDis
 
     private final DiscoveryClient discoveryClient;
 
-    public FeignClientIntegrationDiscoverer(ApplicationContext context, DiscoveryClient discoveryClient) {
+    FeignClientIntegrationDiscoverer(ApplicationContext context, DiscoveryClient discoveryClient) {
         this.context = context;
         this.discoveryClient = discoveryClient;
     }
 
-    public Set<FeignIntegration> discoverIntegrations() {
+    Set<FeignIntegration> discoverIntegrations() {
         return Arrays.stream(context.getBeanNamesForAnnotation(FeignClient.class))
                 .map(this::extractFeignClientClass)
                 .filter(Objects::nonNull)

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/integrations/feign/NoOpDiscoveryClient.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/integrations/feign/NoOpDiscoveryClient.java
@@ -28,7 +28,7 @@ import org.springframework.cloud.client.discovery.DiscoveryClient;
  *
  * @author Sergey Cherkasov
  */
-public final class NoOpDiscoveryClient implements DiscoveryClient {
+final class NoOpDiscoveryClient implements DiscoveryClient {
 
     @Override
     public String description() {

--- a/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sbs/axelix-spring-boot-3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -19,7 +19,7 @@ com.axelixlabs.axelix.sbs.spring.autoconfiguration.ScheduledTaskManagementAutoCo
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.SelfRegistrationAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProviderAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration
-com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixFeignEndpointAutoConfiguration
+com.axelixlabs.axelix.sbs.spring.core.integrations.feign.AxelixFeignEndpointAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.SecurityContextExecutorAutoConfiguration
 com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/Main.java
@@ -28,7 +28,6 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConditionsEndpoi
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixConfigurationsPropertiesEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixDetailsEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixEnvironmentEndpointAutoConfiguration;
-import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixFeignEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixGcEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixHeapDumpEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.AxelixLoggersEndpointAutoConfiguration;
@@ -47,6 +46,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ShortBuildInfoProvider
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ThreadDumpManagementEndpointAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.ValidationListenerAutoConfiguration;
+import com.axelixlabs.axelix.sbs.spring.core.integrations.feign.AxelixFeignEndpointAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/integrations/feign/AxelixFeignEndpointAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/integrations/feign/AxelixFeignEndpointAutoConfigurationTest.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
+package com.axelixlabs.axelix.sbs.spring.core.integrations.feign;
 
 import feign.Feign;
 import org.junit.jupiter.api.Test;
@@ -26,10 +26,6 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.openfeign.FeignClientFactoryBean;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import com.axelixlabs.axelix.sbs.spring.core.integrations.feign.AxelixFeignEndpoint;
-import com.axelixlabs.axelix.sbs.spring.core.integrations.feign.FeignClientIntegrationDiscoverer;
-import com.axelixlabs.axelix.sbs.spring.core.integrations.feign.NoOpDiscoveryClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/integrations/IntegrationComponentDiscoverer.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/integrations/IntegrationComponentDiscoverer.java
@@ -26,7 +26,7 @@ import java.util.Set;
  * @author Mikhail Polivakha
  */
 @Deprecated // I am not sure we need this abstraction
-public interface IntegrationComponentDiscoverer<T> {
+interface IntegrationComponentDiscoverer<T> {
 
     Set<T> discoverIntegrations();
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Relocated Feign endpoint auto-configuration components and updated the Spring Boot auto-configuration import registry to load the new location.
  * Restricted Feign discovery and endpoint-related classes/contracts to package-level visibility.
  * Preserved existing Feign integration discovery and endpoint behavior.
* **Tests**
  * Updated the Feign endpoint auto-configuration test package/imports to align with the new component location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->