### PR TITLE
GH-1418 Replace unreliable `author_association` check with repo-permission check in `check-linked-issues` workflow

### DIFF
--- a/.github/workflows/check_linked_issues_pull_requests.yaml
+++ b/.github/workflows/check_linked_issues_pull_requests.yaml
@@ -17,18 +17,22 @@ jobs:
   check-linked-issues:
     # External contributors can open PRs without targeting a specific issue.
     #
-    # OWNER - Author is the owner of the repository.
-    # MEMBER - Author is a member of the organization that owns the repository.
-    # COLLABORATOR - Author has been invited to collaborate on the repository.
+    # read  - Default access granted to anyone on a public repository, including external contributors.
+    # write - Granted to org members, added collaborators, and the org owner.
+    # admin - Granted to repository/organization administrators.
     #
-    # see https://docs.github.com/en/graphql/reference/issues#enums
-    if: >-
-      github.event.pull_request.author_association == 'OWNER' ||
-      github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.author_association == 'COLLABORATOR'
+    # see https://docs.github.com/en/rest/collaborators/collaborators#get-repository-permissions-for-a-user
     runs-on: ubuntu-latest
     steps:
+      - name: Check author permission
+        id: check-permission
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.event.pull_request.user.login }}
+
       - name: Check for linked issues
+        if: steps.check-permission.outputs.require-result == 'true'
         uses: nearform-actions/github-action-check-linked-issues@v1
         with:
           exclude-labels: "refactoring, dependencies, docs, security"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request validation to check repository write permissions directly.
  * Linked-issue checks now run only for contributors with the required access level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->