### PR TITLE
GH-1437 Detection of blocking `RestTemplate` calls inside transactions for SB-3

### DIFF
--- a/common/api/src/main/java/com/axelixlabs/axelix/common/api/registration/insights/persistence/ExecutionStats.java
+++ b/common/api/src/main/java/com/axelixlabs/axelix/common/api/registration/insights/persistence/ExecutionStats.java
@@ -20,14 +20,14 @@ package com.axelixlabs.axelix.common.api.registration.insights.persistence;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class TransactionOverallStats {
+public class ExecutionStats {
 
     private final long minMs;
     private final long maxMs;
     private final long averageMs;
 
     @JsonCreator
-    public TransactionOverallStats(
+    public ExecutionStats(
             @JsonProperty("minMs") long minMs,
             @JsonProperty("maxMs") long max,
             @JsonProperty("averageMs") long averageMs) {

--- a/common/api/src/main/java/com/axelixlabs/axelix/common/api/registration/insights/persistence/ExternalCallInsight.java
+++ b/common/api/src/main/java/com/axelixlabs/axelix/common/api/registration/insights/persistence/ExternalCallInsight.java
@@ -15,34 +15,45 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.core.persistence;
+package com.axelixlabs.axelix.common.api.registration.insights.persistence;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
 
 /**
- * Record of a single blocking call to an external system made while a transaction was open.
+ * Aggregated timing of the blocking calls made to a single external endpoint from within a transactional
+ * method, folded across every invocation of that method.
  *
  * @author Sergey Cherkasov
  */
-public class SimpleExternalCallRecord {
+public class ExternalCallInsight {
+
     private final TypeExternalCall type;
     private final String target;
-    private final long durationMs;
+    private final TransactionOverallStats stats;
 
     /**
-     * Create a new SimpleExternalCallRecord.
+     * Create a new ExternalCallInsight.
      *
      * @param type       the client that performed the call, e.g. {@link TypeExternalCall#REST_TEMPLATE} or
      *                   {@link TypeExternalCall#REST_CLIENT} for an HTTP call, {@link TypeExternalCall#KAFKA} for a
      *                   messaging one.
      * @param target     where the call went: the request method and url for an HTTP call, e.g.
      *                   {@code "GET https://payments/charge"}. The topic / queue / exchange for a messaging call.
-     * @param durationMs the call duration in milliseconds.
+     * @param stats      the min/max/avg call duration aggregated across every invocation of the transactional method.
      */
-    public SimpleExternalCallRecord(TypeExternalCall type, String target, long durationMs) {
+    @JsonCreator
+    public ExternalCallInsight(
+            @JsonProperty("type") TypeExternalCall type,
+            @JsonProperty("target") String target,
+            @JsonProperty("stats") TransactionOverallStats stats) {
         this.type = type;
         this.target = target;
-        this.durationMs = durationMs;
+        this.stats = stats;
     }
 
     public TypeExternalCall getType() {
@@ -53,7 +64,31 @@ public class SimpleExternalCallRecord {
         return target;
     }
 
-    public long getDurationMs() {
-        return durationMs;
+    public TransactionOverallStats getStats() {
+        return stats;
+    }
+
+    @Override
+    public String toString() {
+        return "ExternalCallInsight{" + "type='"
+                + type + '\'' + ", target='"
+                + target + '\'' + ", stats="
+                + stats + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ExternalCallInsight that = (ExternalCallInsight) o;
+        return Objects.equals(type, that.type)
+                && Objects.equals(target, that.target)
+                && Objects.equals(stats, that.stats);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, target, stats);
     }
 }

--- a/common/api/src/main/java/com/axelixlabs/axelix/common/api/registration/insights/persistence/ExternalCallInsight.java
+++ b/common/api/src/main/java/com/axelixlabs/axelix/common/api/registration/insights/persistence/ExternalCallInsight.java
@@ -17,8 +17,6 @@
  */
 package com.axelixlabs.axelix.common.api.registration.insights.persistence;
 
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -34,14 +32,13 @@ public class ExternalCallInsight {
 
     private final TypeExternalCall type;
     private final String target;
-    private final TransactionOverallStats stats;
+    private final ExecutionStats stats;
 
     /**
      * Create a new ExternalCallInsight.
      *
-     * @param type       the client that performed the call, e.g. {@link TypeExternalCall#REST_TEMPLATE} or
-     *                   {@link TypeExternalCall#REST_CLIENT} for an HTTP call, {@link TypeExternalCall#KAFKA} for a
-     *                   messaging one.
+     * @param type       the client that performed the call, e.g. {@link TypeExternalCall#HTTP_CLIENT} for an HTTP
+     *                   call, {@link TypeExternalCall#KAFKA} for a messaging one.
      * @param target     where the call went: the request method and url for an HTTP call, e.g.
      *                   {@code "GET https://payments/charge"}. The topic / queue / exchange for a messaging call.
      * @param stats      the min/max/avg call duration aggregated across every invocation of the transactional method.
@@ -50,7 +47,7 @@ public class ExternalCallInsight {
     public ExternalCallInsight(
             @JsonProperty("type") TypeExternalCall type,
             @JsonProperty("target") String target,
-            @JsonProperty("stats") TransactionOverallStats stats) {
+            @JsonProperty("stats") ExecutionStats stats) {
         this.type = type;
         this.target = target;
         this.stats = stats;
@@ -64,7 +61,7 @@ public class ExternalCallInsight {
         return target;
     }
 
-    public TransactionOverallStats getStats() {
+    public ExecutionStats getStats() {
         return stats;
     }
 
@@ -74,21 +71,5 @@ public class ExternalCallInsight {
                 + type + '\'' + ", target='"
                 + target + '\'' + ", stats="
                 + stats + '}';
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ExternalCallInsight that = (ExternalCallInsight) o;
-        return Objects.equals(type, that.type)
-                && Objects.equals(target, that.target)
-                && Objects.equals(stats, that.stats);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, target, stats);
     }
 }

--- a/common/api/src/main/java/com/axelixlabs/axelix/common/api/registration/insights/persistence/TransactionAggregatedProfile.java
+++ b/common/api/src/main/java/com/axelixlabs/axelix/common/api/registration/insights/persistence/TransactionAggregatedProfile.java
@@ -32,7 +32,7 @@ public class TransactionAggregatedProfile {
 
     private final TransactionOrigin transactionOrigin;
     private final TransactionalKey transactionalKey;
-    private final TransactionOverallStats transactionOverallStats;
+    private final ExecutionStats transactionOverallStats;
     private final List<CountedLazyLoadingTarget> lazyLoadingTargets;
     private final Map<String, Integer> inMemoryPagination;
     private final List<ExternalCallInsight> externalCalls;
@@ -41,7 +41,7 @@ public class TransactionAggregatedProfile {
     public TransactionAggregatedProfile(
             @JsonProperty("transactionOrigin") TransactionOrigin transactionOrigin,
             @JsonProperty("transactionalKey") TransactionalKey transactionalKey,
-            @JsonProperty("transactionOverallStats") TransactionOverallStats transactionOverallStats,
+            @JsonProperty("transactionOverallStats") ExecutionStats transactionOverallStats,
             @JsonProperty("lazyLoadingTargets") List<CountedLazyLoadingTarget> lazyLoadingTargets,
             @JsonProperty("inMemoryPagination") Map<String, Integer> inMemoryPagination,
             @JsonProperty("externalCalls") List<ExternalCallInsight> externalCalls) {
@@ -61,7 +61,7 @@ public class TransactionAggregatedProfile {
         return transactionalKey;
     }
 
-    public TransactionOverallStats getTransactionOverallStats() {
+    public ExecutionStats getTransactionOverallStats() {
         return transactionOverallStats;
     }
 

--- a/common/api/src/main/java/com/axelixlabs/axelix/common/api/registration/insights/persistence/TransactionAggregatedProfile.java
+++ b/common/api/src/main/java/com/axelixlabs/axelix/common/api/registration/insights/persistence/TransactionAggregatedProfile.java
@@ -35,6 +35,7 @@ public class TransactionAggregatedProfile {
     private final TransactionOverallStats transactionOverallStats;
     private final List<CountedLazyLoadingTarget> lazyLoadingTargets;
     private final Map<String, Integer> inMemoryPagination;
+    private final List<ExternalCallInsight> externalCalls;
 
     @JsonCreator
     public TransactionAggregatedProfile(
@@ -42,12 +43,14 @@ public class TransactionAggregatedProfile {
             @JsonProperty("transactionalKey") TransactionalKey transactionalKey,
             @JsonProperty("transactionOverallStats") TransactionOverallStats transactionOverallStats,
             @JsonProperty("lazyLoadingTargets") List<CountedLazyLoadingTarget> lazyLoadingTargets,
-            @JsonProperty("inMemoryPagination") Map<String, Integer> inMemoryPagination) {
+            @JsonProperty("inMemoryPagination") Map<String, Integer> inMemoryPagination,
+            @JsonProperty("externalCalls") List<ExternalCallInsight> externalCalls) {
         this.transactionOrigin = transactionOrigin;
         this.transactionalKey = transactionalKey;
         this.transactionOverallStats = transactionOverallStats;
         this.lazyLoadingTargets = lazyLoadingTargets;
         this.inMemoryPagination = inMemoryPagination;
+        this.externalCalls = externalCalls;
     }
 
     public TransactionOrigin getTransactionOrigin() {
@@ -68,5 +71,9 @@ public class TransactionAggregatedProfile {
 
     public Map<String, Integer> getInMemoryPagination() {
         return inMemoryPagination;
+    }
+
+    public List<ExternalCallInsight> getExternalCalls() {
+        return externalCalls;
     }
 }

--- a/common/domain/src/main/java/com/axelixlabs/axelix/common/domain/insights/TypeExternalCall.java
+++ b/common/domain/src/main/java/com/axelixlabs/axelix/common/domain/insights/TypeExternalCall.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.common.domain.insights;
+
+/**
+ * The client that performed a blocking call to an external system: an HTTP client, or a messaging client.
+ *
+ * @author Sergey Cherkasov
+ */
+public enum TypeExternalCall {
+    REST_TEMPLATE,
+    REST_CLIENT,
+    WEB_CLIENT,
+    KAFKA,
+    RABBIT
+}

--- a/common/domain/src/main/java/com/axelixlabs/axelix/common/domain/insights/TypeExternalCall.java
+++ b/common/domain/src/main/java/com/axelixlabs/axelix/common/domain/insights/TypeExternalCall.java
@@ -23,9 +23,7 @@ package com.axelixlabs.axelix.common.domain.insights;
  * @author Sergey Cherkasov
  */
 public enum TypeExternalCall {
-    REST_TEMPLATE,
-    REST_CLIENT,
-    WEB_CLIENT,
+    HTTP_CLIENT,
     KAFKA,
     RABBIT
 }

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/DashboardApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/DashboardApiTest.java
@@ -36,10 +36,10 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import com.axelixlabs.axelix.common.api.LazyLoadingTarget;
 import com.axelixlabs.axelix.common.api.registration.BasicRegistrationMetadata;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.CountedLazyLoadingTarget;
+import com.axelixlabs.axelix.common.api.registration.insights.persistence.ExecutionStats;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.PersistenceInsights;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionAggregatedProfile;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionOrigin;
-import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionOverallStats;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionalKey;
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
 import com.axelixlabs.axelix.common.domain.insights.GarbageCollector;
@@ -331,7 +331,7 @@ public class DashboardApiTest {
         TransactionAggregatedProfile profile = new TransactionAggregatedProfile(
                 TransactionOrigin.APPLICATION_DECLARATIVE,
                 new TransactionalKey("com.example.OwnerService", "loadOwners"),
-                new TransactionOverallStats(1, 10, 5),
+                new ExecutionStats(1, 10, 5),
                 lazyLoadingTargets,
                 inMemoryPagination,
                 List.of());

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/DashboardApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/DashboardApiTest.java
@@ -333,7 +333,8 @@ public class DashboardApiTest {
                 new TransactionalKey("com.example.OwnerService", "loadOwners"),
                 new TransactionOverallStats(1, 10, 5),
                 lazyLoadingTargets,
-                inMemoryPagination);
+                inMemoryPagination,
+                List.of());
         return TestMetadataFactory.withPersistenceInsights(
                 groupId, artifactId, new PersistenceInsights(List.of(profile)));
     }

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/TransactionMonitoringApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/TransactionMonitoringApiTest.java
@@ -81,7 +81,8 @@ class TransactionMonitoringApiTest {
                   "lazyLoadingTargets": [],
                   "inMemoryPagination": {
                     "com.example.Pet": 2
-                  }
+                  },
+                  "externalCalls": []
                 }
               ]
             }
@@ -128,7 +129,8 @@ class TransactionMonitoringApiTest {
                 new TransactionalKey("com.example.OwnerService", "saveOwner"),
                 new TransactionOverallStats(1, 10, 5),
                 List.of(),
-                Map.of("com.example.Pet", 2));
+                Map.of("com.example.Pet", 2),
+                List.of());
         BasicRegistrationMetadata metadata = TestMetadataFactory.withPersistenceInsights(
                 groupId, artifactId, new PersistenceInsights(List.of(profile)));
         registry.reload(TestInstanceFactory.create(activeInstanceId, groupId, artifactId));

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/TransactionMonitoringApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/TransactionMonitoringApiTest.java
@@ -33,10 +33,10 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import com.axelixlabs.axelix.common.api.registration.BasicRegistrationMetadata;
+import com.axelixlabs.axelix.common.api.registration.insights.persistence.ExecutionStats;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.PersistenceInsights;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionAggregatedProfile;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionOrigin;
-import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionOverallStats;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionalKey;
 import com.axelixlabs.axelix.common.domain.http.HttpMethod;
 import com.axelixlabs.axelix.master.domain.HistoricalApplicationSnapshot;
@@ -127,7 +127,7 @@ class TransactionMonitoringApiTest {
         TransactionAggregatedProfile profile = new TransactionAggregatedProfile(
                 TransactionOrigin.APPLICATION_DECLARATIVE,
                 new TransactionalKey("com.example.OwnerService", "saveOwner"),
-                new TransactionOverallStats(1, 10, 5),
+                new ExecutionStats(1, 10, 5),
                 List.of(),
                 Map.of("com.example.Pet", 2),
                 List.of());

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/convert/HistoricalApplicationSnapshotConverterTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/convert/HistoricalApplicationSnapshotConverterTest.java
@@ -78,7 +78,8 @@ class HistoricalApplicationSnapshotConverterTest {
                 new TransactionalKey("com.example.OwnerService", "saveOwner"),
                 new TransactionOverallStats(1, 10, 5),
                 List.of(),
-                Map.of("com.example.Pet", 2));
+                Map.of("com.example.Pet", 2),
+                List.of());
         BasicRegistrationMetadata metadata = TestMetadataFactory.withPersistenceInsights(
                 "org.springframework.samples", "petclinic", new PersistenceInsights(List.of(profile)));
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/convert/HistoricalApplicationSnapshotConverterTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/convert/HistoricalApplicationSnapshotConverterTest.java
@@ -25,10 +25,10 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import com.axelixlabs.axelix.common.api.registration.BasicRegistrationMetadata;
+import com.axelixlabs.axelix.common.api.registration.insights.persistence.ExecutionStats;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.PersistenceInsights;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionAggregatedProfile;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionOrigin;
-import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionOverallStats;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionalKey;
 import com.axelixlabs.axelix.common.domain.insights.GarbageCollector;
 import com.axelixlabs.axelix.master.domain.HistoricalApplicationSnapshot;
@@ -76,7 +76,7 @@ class HistoricalApplicationSnapshotConverterTest {
         TransactionAggregatedProfile profile = new TransactionAggregatedProfile(
                 TransactionOrigin.APPLICATION_DECLARATIVE,
                 new TransactionalKey("com.example.OwnerService", "saveOwner"),
-                new TransactionOverallStats(1, 10, 5),
+                new ExecutionStats(1, 10, 5),
                 List.of(),
                 Map.of("com.example.Pet", 2),
                 List.of());

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseHistoricalApplicationSnapshotServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseHistoricalApplicationSnapshotServiceTest.java
@@ -118,7 +118,8 @@ class DatabaseHistoricalApplicationSnapshotServiceTest {
                     new TransactionalKey("com.example.OwnerService", "saveOwner"),
                     new TransactionOverallStats(1, 10, 5),
                     List.of(),
-                    Map.of("com.example.Pet", 2));
+                    Map.of("com.example.Pet", 2),
+                    List.of());
             BasicRegistrationMetadata metadata = TestMetadataFactory.withPersistenceInsights(
                     "org.springframework.samples", "petclinic", new PersistenceInsights(List.of(profile)));
 
@@ -327,7 +328,8 @@ class DatabaseHistoricalApplicationSnapshotServiceTest {
                     new TransactionalKey("com.example.OwnerService", "saveOwner"),
                     new TransactionOverallStats(1, 10, 5),
                     List.of(),
-                    Map.of("com.example.Pet", 2));
+                    Map.of("com.example.Pet", 2),
+                    List.of());
             BasicRegistrationMetadata metadata = TestMetadataFactory.withPersistenceInsights(
                     groupId, artifactId, new PersistenceInsights(List.of(profile)));
             jdbcAggregateTemplate.insert(TestInstanceFactory.create(instanceId, groupId, artifactId));
@@ -519,7 +521,8 @@ class DatabaseHistoricalApplicationSnapshotServiceTest {
                 new TransactionalKey("com.example.OwnerService", "loadOwners"),
                 new TransactionOverallStats(1, 10, 5),
                 lazyLoadingTargets,
-                inMemoryPagination);
+                inMemoryPagination,
+                List.of());
         return new PersistenceInsights(List.of(profile));
     }
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseHistoricalApplicationSnapshotServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseHistoricalApplicationSnapshotServiceTest.java
@@ -33,10 +33,10 @@ import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
 import com.axelixlabs.axelix.common.api.LazyLoadingTarget;
 import com.axelixlabs.axelix.common.api.registration.BasicRegistrationMetadata;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.CountedLazyLoadingTarget;
+import com.axelixlabs.axelix.common.api.registration.insights.persistence.ExecutionStats;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.PersistenceInsights;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionAggregatedProfile;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionOrigin;
-import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionOverallStats;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionalKey;
 import com.axelixlabs.axelix.common.domain.insights.FeatureId;
 import com.axelixlabs.axelix.common.domain.insights.GarbageCollector;
@@ -116,7 +116,7 @@ class DatabaseHistoricalApplicationSnapshotServiceTest {
             TransactionAggregatedProfile profile = new TransactionAggregatedProfile(
                     TransactionOrigin.APPLICATION_DECLARATIVE,
                     new TransactionalKey("com.example.OwnerService", "saveOwner"),
-                    new TransactionOverallStats(1, 10, 5),
+                    new ExecutionStats(1, 10, 5),
                     List.of(),
                     Map.of("com.example.Pet", 2),
                     List.of());
@@ -326,7 +326,7 @@ class DatabaseHistoricalApplicationSnapshotServiceTest {
             TransactionAggregatedProfile profile = new TransactionAggregatedProfile(
                     TransactionOrigin.APPLICATION_DECLARATIVE,
                     new TransactionalKey("com.example.OwnerService", "saveOwner"),
-                    new TransactionOverallStats(1, 10, 5),
+                    new ExecutionStats(1, 10, 5),
                     List.of(),
                     Map.of("com.example.Pet", 2),
                     List.of());
@@ -519,7 +519,7 @@ class DatabaseHistoricalApplicationSnapshotServiceTest {
         TransactionAggregatedProfile profile = new TransactionAggregatedProfile(
                 TransactionOrigin.APPLICATION_DECLARATIVE,
                 new TransactionalKey("com.example.OwnerService", "loadOwners"),
-                new TransactionOverallStats(1, 10, 5),
+                new ExecutionStats(1, 10, 5),
                 lazyLoadingTargets,
                 inMemoryPagination,
                 List.of());

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -120,10 +120,15 @@ public class TransactionMonitoringAutoConfiguration {
         return registrationBean;
     }
 
-    @Bean
+    @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(RestTemplate.class)
-    public ExternalCallRestTemplateCustomizer axelixRestTemplateCustomizer(TransactionAccessor transactionAccessor) {
-        return new ExternalCallRestTemplateCustomizer(transactionAccessor);
+    static class RestTemplateMonitoringConfiguration {
+
+        @Bean
+        public ExternalCallRestTemplateCustomizer axelixRestTemplateCustomizer(
+                TransactionAccessor transactionAccessor) {
+            return new ExternalCallRestTemplateCustomizer(transactionAccessor);
+        }
     }
 
     @Configuration

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.hibernate.jpa.boot.spi.IntegratorProvider;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
@@ -35,6 +36,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.Ordered;
+import org.springframework.web.client.RestTemplate;
 
 import com.axelixlabs.axelix.sbs.spring.core.config.TransactionMonitoringConfigurationProperties;
 import com.axelixlabs.axelix.sbs.spring.core.metrics.AxelixMetricsPublisher;
@@ -48,6 +50,7 @@ import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.NPlusOneInteg
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.pagination.ConditionalOnLoggingSystem;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.pagination.Log4j2InMemoryPaginationAppenderRegistrar;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.pagination.LogbackInMemoryPaginationAppenderRegistrar;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.http.ExternalCallRestTemplateCustomizer;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.DefaultTransactionStatsCollector;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionStatsCollector;
@@ -115,6 +118,12 @@ public class TransactionMonitoringAutoConfiguration {
         registrationBean.setDispatcherTypes(DispatcherType.REQUEST, DispatcherType.ASYNC, DispatcherType.ERROR);
 
         return registrationBean;
+    }
+
+    @Bean
+    @ConditionalOnClass(RestTemplate.class)
+    public ExternalCallRestTemplateCustomizer axelixRestTemplateCustomizer(TransactionAccessor transactionAccessor) {
+        return new ExternalCallRestTemplateCustomizer(transactionAccessor);
     }
 
     @Configuration

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultAxelixMetricsPublisher.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/DefaultAxelixMetricsPublisher.java
@@ -60,6 +60,13 @@ public class DefaultAxelixMetricsPublisher implements AxelixMetricsPublisher {
                 .tag("method", methodName)
                 .register(meterRegistry)
                 .increment(transaction.getQueriesCount());
+
+        Counter.builder(AxelixMetricNames.TRANSACTION_EXTERNAL_CALLS)
+                .description("Total number of external calls made inside transactions")
+                .tag("class", className)
+                .tag("method", methodName)
+                .register(meterRegistry)
+                .increment(transaction.getExternalCallCount());
     }
 
     @Override

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallHttpRequestInterceptor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallHttpRequestInterceptor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence.http;
+
+import java.io.IOException;
+
+import org.jspecify.annotations.NonNull;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord.TypeExternal;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+
+/**
+ * {@link ClientHttpRequestInterceptor} that records every synchronous HTTP call performed while a transaction
+ * is open, so that the blocking calls holding the transaction become visible. It serves any client built on
+ * {@link ClientHttpRequestInterceptor} — both {@code RestTemplate} and {@code RestClient} — the concrete client
+ * is supplied via {@code type}.
+ * <p>
+ * Whether the call actually belongs to a transaction is decided by the {@link TransactionAccessor}: calls
+ * made outside of any transaction are silently dropped by it.
+ *
+ * @author Sergey Cherkasov
+ */
+class ExternalCallHttpRequestInterceptor implements ClientHttpRequestInterceptor {
+
+    private final TransactionAccessor transactionAccessor;
+    private final TypeExternal type;
+
+    ExternalCallHttpRequestInterceptor(TransactionAccessor transactionAccessor, TypeExternal type) {
+        this.transactionAccessor = transactionAccessor;
+        this.type = type;
+    }
+
+    @Override
+    public @NonNull ClientHttpResponse intercept(
+            @NonNull HttpRequest request, byte @NonNull [] body, @NonNull ClientHttpRequestExecution execution)
+            throws IOException {
+
+        long startNanos = System.nanoTime();
+
+        try {
+            return execution.execute(request, body);
+        } finally {
+            long duration = System.nanoTime() - startNanos;
+            String target = request.getMethod().name() + " " + request.getURI();
+            transactionAccessor.recordExternalCall(new SimpleExternalCallRecord(type, target, duration / 1_000_000));
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallHttpRequestInterceptor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallHttpRequestInterceptor.java
@@ -33,8 +33,8 @@ import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.Transaction
 /**
  * {@link ClientHttpRequestInterceptor} that records every synchronous HTTP call performed while a transaction
  * is open, so that the blocking calls holding the transaction become visible. It serves any client built on
- * {@link ClientHttpRequestInterceptor} — both {@code RestTemplate} and {@code RestClient} — the concrete client
- * is supplied via {@code type}.
+ * {@link ClientHttpRequestInterceptor} — both {@code RestTemplate} and {@code RestClient} — recording every such
+ * call as a {@link TypeExternalCall#HTTP_CLIENT} one.
  * <p>
  * Whether the call actually belongs to a transaction is decided by the {@link TransactionAccessor}: calls
  * made outside of any transaction are silently dropped by it.
@@ -44,11 +44,9 @@ import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.Transaction
 class ExternalCallHttpRequestInterceptor implements ClientHttpRequestInterceptor {
 
     private final TransactionAccessor transactionAccessor;
-    private final TypeExternalCall type;
 
-    ExternalCallHttpRequestInterceptor(TransactionAccessor transactionAccessor, TypeExternalCall type) {
+    ExternalCallHttpRequestInterceptor(TransactionAccessor transactionAccessor) {
         this.transactionAccessor = transactionAccessor;
-        this.type = type;
     }
 
     @Override
@@ -62,8 +60,9 @@ class ExternalCallHttpRequestInterceptor implements ClientHttpRequestInterceptor
             return execution.execute(request, body);
         } finally {
             long duration = System.nanoTime() - startNanos;
-            String target = request.getMethod().name() + " " + request.getURI();
-            transactionAccessor.recordExternalCall(new SimpleExternalCallRecord(type, target, duration / 1_000_000));
+            String target = request.getMethod().name() + " " + request.getURI().getPath();
+            transactionAccessor.recordExternalCall(
+                    new SimpleExternalCallRecord(TypeExternalCall.HTTP_CLIENT, target, duration / 1_000_000));
         }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallHttpRequestInterceptor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallHttpRequestInterceptor.java
@@ -26,8 +26,8 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 
+import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
-import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord.TypeExternal;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
 
 /**
@@ -44,9 +44,9 @@ import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.Transaction
 class ExternalCallHttpRequestInterceptor implements ClientHttpRequestInterceptor {
 
     private final TransactionAccessor transactionAccessor;
-    private final TypeExternal type;
+    private final TypeExternalCall type;
 
-    ExternalCallHttpRequestInterceptor(TransactionAccessor transactionAccessor, TypeExternal type) {
+    ExternalCallHttpRequestInterceptor(TransactionAccessor transactionAccessor, TypeExternalCall type) {
         this.transactionAccessor = transactionAccessor;
         this.type = type;
     }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallRestTemplateCustomizer.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallRestTemplateCustomizer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence.http;
+
+import org.jspecify.annotations.NonNull;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.web.client.RestTemplateCustomizer;
+import org.springframework.web.client.RestTemplate;
+
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+
+/**
+ * {@link RestTemplateCustomizer} that registers the {@link ExternalCallHttpRequestInterceptor} on every
+ * {@link RestTemplate} assembled by the auto-configured {@link RestTemplateBuilder}.
+ * <p>
+ * This mirrors how Spring Boot instruments a {@link RestTemplate} itself — both its metrics and its observation
+ * support attach through a {@link RestTemplateCustomizer} and nothing else. A {@link RestTemplate} that never goes
+ * through the auto-configured {@link RestTemplateBuilder}, such as a plain {@code new RestTemplate()} bean, is
+ * therefore deliberately not instrumented, exactly as it would carry no Spring Boot metrics.
+ *
+ * @author Sergey Cherkasov
+ */
+public class ExternalCallRestTemplateCustomizer implements RestTemplateCustomizer {
+
+    private final TransactionAccessor transactionAccessor;
+
+    public ExternalCallRestTemplateCustomizer(TransactionAccessor transactionAccessor) {
+        this.transactionAccessor = transactionAccessor;
+    }
+
+    @Override
+    public void customize(@NonNull RestTemplate restTemplate) {
+        boolean alreadyInstrumented =
+                restTemplate.getInterceptors().stream().anyMatch(ExternalCallHttpRequestInterceptor.class::isInstance);
+
+        if (!alreadyInstrumented) {
+            restTemplate
+                    .getInterceptors()
+                    .add(new ExternalCallHttpRequestInterceptor(
+                            transactionAccessor, SimpleExternalCallRecord.TypeExternal.REST_TEMPLATE));
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallRestTemplateCustomizer.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallRestTemplateCustomizer.java
@@ -23,8 +23,9 @@ import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.boot.web.client.RestTemplateCustomizer;
 import org.springframework.web.client.RestTemplate;
 
-import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+
+import static com.axelixlabs.axelix.common.domain.insights.TypeExternalCall.REST_TEMPLATE;
 
 /**
  * {@link RestTemplateCustomizer} that registers the {@link ExternalCallHttpRequestInterceptor} on every
@@ -53,8 +54,7 @@ public class ExternalCallRestTemplateCustomizer implements RestTemplateCustomize
         if (!alreadyInstrumented) {
             restTemplate
                     .getInterceptors()
-                    .add(new ExternalCallHttpRequestInterceptor(
-                            transactionAccessor, SimpleExternalCallRecord.TypeExternal.REST_TEMPLATE));
+                    .add(new ExternalCallHttpRequestInterceptor(transactionAccessor, REST_TEMPLATE));
         }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallRestTemplateCustomizer.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallRestTemplateCustomizer.java
@@ -25,8 +25,6 @@ import org.springframework.web.client.RestTemplate;
 
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
 
-import static com.axelixlabs.axelix.common.domain.insights.TypeExternalCall.REST_TEMPLATE;
-
 /**
  * {@link RestTemplateCustomizer} that registers the {@link ExternalCallHttpRequestInterceptor} on every
  * {@link RestTemplate} assembled by the auto-configured {@link RestTemplateBuilder}.
@@ -52,9 +50,7 @@ public class ExternalCallRestTemplateCustomizer implements RestTemplateCustomize
                 restTemplate.getInterceptors().stream().anyMatch(ExternalCallHttpRequestInterceptor.class::isInstance);
 
         if (!alreadyInstrumented) {
-            restTemplate
-                    .getInterceptors()
-                    .add(new ExternalCallHttpRequestInterceptor(transactionAccessor, REST_TEMPLATE));
+            restTemplate.getInterceptors().add(new ExternalCallHttpRequestInterceptor(transactionAccessor));
         }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -26,7 +26,9 @@ import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.logging.LoggingSystem;
 import org.springframework.boot.logging.log4j2.Log4J2LoggingSystem;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.web.client.RestTemplate;
 
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration.Log4j2InMemoryPaginationAppenderConfiguration;
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration;
@@ -61,6 +63,16 @@ class TransactionMonitoringAutoConfigurationTest {
             assertThat(context).hasSingleBean(ExternalCallRestTemplateCustomizer.class);
             assertThat(context).doesNotHaveBean(LogbackInMemoryPaginationAppenderConfiguration.class);
         });
+    }
+
+    @Test
+    void shouldNotRegisterRestTemplateCustomizer_whenRestTemplateIsAbsent() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader(RestTemplate.class))
+                .run(context -> {
+                    assertThat(context).hasSingleBean(TransactionMonitoringAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(ExternalCallRestTemplateCustomizer.class);
+                });
     }
 
     @Test // GH-1254

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -32,6 +32,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringA
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration.LogbackInMemoryPaginationAppenderConfiguration;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.ProxyingDataSourceBeanPostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.TransactionMonitoringBeanPostProcessor;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.http.ExternalCallRestTemplateCustomizer;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionStatsCollector;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,6 +58,7 @@ class TransactionMonitoringAutoConfigurationTest {
             assertThat(context).hasSingleBean(TransactionStatsCollector.class);
             assertThat(context).hasSingleBean(TransactionMonitoringBeanPostProcessor.class);
             assertThat(context).hasSingleBean(ProxyingDataSourceBeanPostProcessor.class);
+            assertThat(context).hasSingleBean(ExternalCallRestTemplateCustomizer.class);
             assertThat(context).doesNotHaveBean(LogbackInMemoryPaginationAppenderConfiguration.class);
         });
     }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallHttpRequestInterceptorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallHttpRequestInterceptorTest.java
@@ -58,8 +58,7 @@ class ExternalCallHttpRequestInterceptorTest {
     @Test
     void shouldRecordTheCallIntoTheActiveTransaction() throws IOException {
         // given.
-        ExternalCallHttpRequestInterceptor subject =
-                new ExternalCallHttpRequestInterceptor(transactionAccessor, TypeExternalCall.REST_TEMPLATE);
+        ExternalCallHttpRequestInterceptor subject = new ExternalCallHttpRequestInterceptor(transactionAccessor);
         transactionAccessor.recordNewTransactionStarted();
         MockClientHttpRequest request =
                 new MockClientHttpRequest(HttpMethod.GET, URI.create("https://payments/charge"));
@@ -70,37 +69,16 @@ class ExternalCallHttpRequestInterceptorTest {
 
         // then.
         assertThat(profile.getRecordedExternalCalls()).singleElement().satisfies(recorded -> {
-            assertThat(recorded.getType()).isEqualTo(TypeExternalCall.REST_TEMPLATE);
-            assertThat(recorded.getTarget()).isEqualTo("GET https://payments/charge");
+            assertThat(recorded.getType()).isEqualTo(TypeExternalCall.HTTP_CLIENT);
+            assertThat(recorded.getTarget()).isEqualTo("GET /charge");
             assertThat(recorded.getDurationMs()).isNotNegative();
         });
     }
 
     @Test
-    void shouldRecordTheConfiguredClientType() throws IOException {
-        // given. The same interceptor serves any ClientHttpRequestInterceptor-based client; the client is the 'type'.
-        ExternalCallHttpRequestInterceptor subject =
-                new ExternalCallHttpRequestInterceptor(transactionAccessor, TypeExternalCall.REST_CLIENT);
-        transactionAccessor.recordNewTransactionStarted();
-        MockClientHttpRequest request =
-                new MockClientHttpRequest(HttpMethod.POST, URI.create("https://payments/charge"));
-
-        // when.
-        subject.intercept(request, NO_BODY, okExecution());
-        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
-
-        // then.
-        assertThat(profile.getRecordedExternalCalls())
-                .singleElement()
-                .extracting(SimpleExternalCallRecord::getType)
-                .isEqualTo(TypeExternalCall.REST_CLIENT);
-    }
-
-    @Test
     void shouldReturnTheResponseProducedByTheExecution() throws IOException {
         // given.
-        ExternalCallHttpRequestInterceptor subject =
-                new ExternalCallHttpRequestInterceptor(transactionAccessor, TypeExternalCall.REST_TEMPLATE);
+        ExternalCallHttpRequestInterceptor subject = new ExternalCallHttpRequestInterceptor(transactionAccessor);
         transactionAccessor.recordNewTransactionStarted();
         MockClientHttpRequest request =
                 new MockClientHttpRequest(HttpMethod.GET, URI.create("https://payments/charge"));
@@ -116,8 +94,7 @@ class ExternalCallHttpRequestInterceptorTest {
     @Test
     void shouldStillRecordTheCallWhenTheExecutionFails() {
         // given. A blocking call that fails still held the transaction open, so it must be recorded.
-        ExternalCallHttpRequestInterceptor subject =
-                new ExternalCallHttpRequestInterceptor(transactionAccessor, TypeExternalCall.REST_TEMPLATE);
+        ExternalCallHttpRequestInterceptor subject = new ExternalCallHttpRequestInterceptor(transactionAccessor);
         transactionAccessor.recordNewTransactionStarted();
         MockClientHttpRequest request =
                 new MockClientHttpRequest(HttpMethod.GET, URI.create("https://payments/charge"));
@@ -135,7 +112,7 @@ class ExternalCallHttpRequestInterceptorTest {
         assertThat(profile.getRecordedExternalCalls())
                 .singleElement()
                 .extracting(SimpleExternalCallRecord::getTarget)
-                .isEqualTo("GET https://payments/charge");
+                .isEqualTo("GET /charge");
     }
 
     private static ClientHttpRequestExecution okExecution() {

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallHttpRequestInterceptorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallHttpRequestInterceptorTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence.http;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpRequest;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+
+import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionExecutionProfile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link ExternalCallHttpRequestInterceptor}.
+ *
+ * @author Sergey Cherkasov
+ */
+class ExternalCallHttpRequestInterceptorTest {
+
+    private static final byte[] NO_BODY = new byte[0];
+
+    private final TransactionAccessor transactionAccessor = new TransactionAccessor();
+
+    @AfterEach
+    void tearDown() {
+        // The accessor keeps its state in a static ThreadLocal, so reset it to keep tests isolated.
+        transactionAccessor.clearAll();
+    }
+
+    @Test
+    void shouldRecordTheCallIntoTheActiveTransaction() throws IOException {
+        // given.
+        ExternalCallHttpRequestInterceptor subject =
+                new ExternalCallHttpRequestInterceptor(transactionAccessor, TypeExternalCall.REST_TEMPLATE);
+        transactionAccessor.recordNewTransactionStarted();
+        MockClientHttpRequest request =
+                new MockClientHttpRequest(HttpMethod.GET, URI.create("https://payments/charge"));
+
+        // when.
+        subject.intercept(request, NO_BODY, okExecution());
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+
+        // then.
+        assertThat(profile.getRecordedExternalCalls()).singleElement().satisfies(recorded -> {
+            assertThat(recorded.getType()).isEqualTo(TypeExternalCall.REST_TEMPLATE);
+            assertThat(recorded.getTarget()).isEqualTo("GET https://payments/charge");
+            assertThat(recorded.getDurationMs()).isNotNegative();
+        });
+    }
+
+    @Test
+    void shouldRecordTheConfiguredClientType() throws IOException {
+        // given. The same interceptor serves any ClientHttpRequestInterceptor-based client; the client is the 'type'.
+        ExternalCallHttpRequestInterceptor subject =
+                new ExternalCallHttpRequestInterceptor(transactionAccessor, TypeExternalCall.REST_CLIENT);
+        transactionAccessor.recordNewTransactionStarted();
+        MockClientHttpRequest request =
+                new MockClientHttpRequest(HttpMethod.POST, URI.create("https://payments/charge"));
+
+        // when.
+        subject.intercept(request, NO_BODY, okExecution());
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+
+        // then.
+        assertThat(profile.getRecordedExternalCalls())
+                .singleElement()
+                .extracting(SimpleExternalCallRecord::getType)
+                .isEqualTo(TypeExternalCall.REST_CLIENT);
+    }
+
+    @Test
+    void shouldReturnTheResponseProducedByTheExecution() throws IOException {
+        // given.
+        ExternalCallHttpRequestInterceptor subject =
+                new ExternalCallHttpRequestInterceptor(transactionAccessor, TypeExternalCall.REST_TEMPLATE);
+        transactionAccessor.recordNewTransactionStarted();
+        MockClientHttpRequest request =
+                new MockClientHttpRequest(HttpMethod.GET, URI.create("https://payments/charge"));
+        ClientHttpResponse expectedResponse = new MockClientHttpResponse(NO_BODY, HttpStatus.OK);
+
+        // when.
+        ClientHttpResponse actualResponse = subject.intercept(request, NO_BODY, (req, body) -> expectedResponse);
+
+        // then. The interceptor is transparent: it hands back exactly what the execution produced.
+        assertThat(actualResponse).isSameAs(expectedResponse);
+    }
+
+    @Test
+    void shouldStillRecordTheCallWhenTheExecutionFails() {
+        // given. A blocking call that fails still held the transaction open, so it must be recorded.
+        ExternalCallHttpRequestInterceptor subject =
+                new ExternalCallHttpRequestInterceptor(transactionAccessor, TypeExternalCall.REST_TEMPLATE);
+        transactionAccessor.recordNewTransactionStarted();
+        MockClientHttpRequest request =
+                new MockClientHttpRequest(HttpMethod.GET, URI.create("https://payments/charge"));
+        ClientHttpRequestExecution failing = (req, body) -> {
+            throw new IOException("connection reset");
+        };
+
+        // when.
+        assertThatThrownBy(() -> subject.intercept(request, NO_BODY, failing))
+                .isInstanceOf(IOException.class)
+                .hasMessage("connection reset");
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+
+        // then.
+        assertThat(profile.getRecordedExternalCalls())
+                .singleElement()
+                .extracting(SimpleExternalCallRecord::getTarget)
+                .isEqualTo("GET https://payments/charge");
+    }
+
+    private static ClientHttpRequestExecution okExecution() {
+        return (request, body) -> new MockClientHttpResponse(NO_BODY, HttpStatus.OK);
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallRestTemplateCustomizerTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallRestTemplateCustomizerTest.java
@@ -17,18 +17,12 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.persistence.http;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpRequest;
-import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
-import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.RestTemplate;
 
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
@@ -90,46 +84,5 @@ class ExternalCallRestTemplateCustomizerTest {
         assertThat(restTemplate.getInterceptors())
                 .hasSize(1)
                 .hasOnlyElementsOfType(ExternalCallHttpRequestInterceptor.class);
-    }
-
-    @Test
-    void shouldNotReorderTheInterceptorsTheApplicationRegistered() {
-        // given. RestTemplateBuilder keeps the order the application registered them in. The @Order(1) is what
-        // makes this test able to fail at all: AnnotationAwareOrderComparator scores an interceptor without any
-        // order metadata as Ordered.LOWEST_PRECEDENCE and the sort is stable, so two unordered interceptors
-        // would come out of a sort untouched and the bug would slip through.
-        UnorderedInterceptor unordered = new UnorderedInterceptor();
-        OrderedInterceptor ordered = new OrderedInterceptor();
-
-        RestTemplate restTemplate = new RestTemplateBuilder()
-                .additionalInterceptors(unordered, ordered)
-                .build();
-
-        // when.
-        subject.customize(restTemplate);
-
-        // then. The application's own order must survive, with ours appended last.
-        List<ClientHttpRequestInterceptor> interceptors = restTemplate.getInterceptors();
-
-        assertThat(interceptors).hasSize(3);
-        assertThat(interceptors.subList(0, 2)).containsExactly(unordered, ordered);
-        assertThat(interceptors.get(2)).isInstanceOf(ExternalCallHttpRequestInterceptor.class);
-    }
-
-    @Order(1)
-    private static class OrderedInterceptor implements ClientHttpRequestInterceptor {
-        @Override
-        public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
-                throws IOException {
-            return execution.execute(request, body);
-        }
-    }
-
-    private static class UnorderedInterceptor implements ClientHttpRequestInterceptor {
-        @Override
-        public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
-                throws IOException {
-            return execution.execute(request, body);
-        }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallRestTemplateCustomizerTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallRestTemplateCustomizerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence.http;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.RestTemplate;
+
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ExternalCallRestTemplateCustomizer}.
+ *
+ * @author Sergey Cherkasov
+ */
+class ExternalCallRestTemplateCustomizerTest {
+
+    private final ExternalCallRestTemplateCustomizer subject =
+            new ExternalCallRestTemplateCustomizer(new TransactionAccessor());
+
+    @Test
+    void shouldInstrumentRestTemplate() {
+        // given.
+        RestTemplate restTemplate = new RestTemplate();
+
+        // when.
+        subject.customize(restTemplate);
+
+        // then.
+        assertThat(restTemplate.getInterceptors())
+                .hasSize(1)
+                .hasOnlyElementsOfType(ExternalCallHttpRequestInterceptor.class);
+    }
+
+    @Test
+    void shouldKeepInterceptorsTheRestTemplateAlreadyCarried() {
+        // given.
+        ClientHttpRequestInterceptor existing = (request, body, execution) -> execution.execute(request, body);
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setInterceptors(new ArrayList<>(List.of(existing)));
+
+        // when.
+        subject.customize(restTemplate);
+
+        // then.
+        assertThat(restTemplate.getInterceptors())
+                .hasSize(2)
+                .contains(existing)
+                .hasAtLeastOneElementOfType(ExternalCallHttpRequestInterceptor.class);
+    }
+
+    @Test
+    void shouldNotInstrumentTheSameRestTemplateTwice() {
+        // given. A RestTemplateBuilder is reusable, so nothing stops an application from having us customize the
+        // same template twice.
+        RestTemplate restTemplate = new RestTemplate();
+        subject.customize(restTemplate);
+
+        // when.
+        subject.customize(restTemplate);
+
+        // then. A second interceptor would make every outgoing call be recorded twice.
+        assertThat(restTemplate.getInterceptors())
+                .hasSize(1)
+                .hasOnlyElementsOfType(ExternalCallHttpRequestInterceptor.class);
+    }
+
+    @Test
+    void shouldNotReorderTheInterceptorsTheApplicationRegistered() {
+        // given. RestTemplateBuilder keeps the order the application registered them in. The @Order(1) is what
+        // makes this test able to fail at all: AnnotationAwareOrderComparator scores an interceptor without any
+        // order metadata as Ordered.LOWEST_PRECEDENCE and the sort is stable, so two unordered interceptors
+        // would come out of a sort untouched and the bug would slip through.
+        UnorderedInterceptor unordered = new UnorderedInterceptor();
+        OrderedInterceptor ordered = new OrderedInterceptor();
+
+        RestTemplate restTemplate = new RestTemplateBuilder()
+                .additionalInterceptors(unordered, ordered)
+                .build();
+
+        // when.
+        subject.customize(restTemplate);
+
+        // then. The application's own order must survive, with ours appended last.
+        List<ClientHttpRequestInterceptor> interceptors = restTemplate.getInterceptors();
+
+        assertThat(interceptors).hasSize(3);
+        assertThat(interceptors.subList(0, 2)).containsExactly(unordered, ordered);
+        assertThat(interceptors.get(2)).isInstanceOf(ExternalCallHttpRequestInterceptor.class);
+    }
+
+    @Order(1)
+    private static class OrderedInterceptor implements ClientHttpRequestInterceptor {
+        @Override
+        public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+                throws IOException {
+            return execution.execute(request, body);
+        }
+    }
+
+    private static class UnorderedInterceptor implements ClientHttpRequestInterceptor {
+        @Override
+        public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+                throws IOException {
+            return execution.execute(request, body);
+        }
+    }
+}

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/master/insights/DefaultInsightsInfoProvider.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/master/insights/DefaultInsightsInfoProvider.java
@@ -28,6 +28,7 @@ import com.axelixlabs.axelix.common.api.registration.insights.HotSpotInsights;
 import com.axelixlabs.axelix.common.api.registration.insights.InsightFeature;
 import com.axelixlabs.axelix.common.api.registration.insights.Insights;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.CountedLazyLoadingTarget;
+import com.axelixlabs.axelix.common.api.registration.insights.persistence.ExternalCallInsight;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.PersistenceInsights;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionAggregatedProfile;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionOrigin;
@@ -37,6 +38,7 @@ import com.axelixlabs.axelix.common.domain.insights.FeatureId;
 import com.axelixlabs.axelix.sbs.spring.core.gclog.GcLogService;
 import com.axelixlabs.axelix.sbs.spring.core.master.OpenSessionInViewStateProvider;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.MethodClassKey;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.AggregatedExternalCall;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.PerformanceStats;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionStats;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionStatsCollector;
@@ -108,7 +110,8 @@ public class DefaultInsightsInfoProvider implements InsightsInfoProvider {
                                     performanceStats.getMaxMs(),
                                     performanceStats.getAvgMs()),
                             convertLazyLoadingTargets(transactionStats.getNPlusOneOccasions()),
-                            new HashMap<>(transactionStats.getInMemoryPaginatedEntities()));
+                            new HashMap<>(transactionStats.getInMemoryPaginatedEntities()),
+                            convertExternalCalls(transactionStats.getExternalCalls()));
                 })
                 .collect(Collectors.toList());
 
@@ -124,6 +127,18 @@ public class DefaultInsightsInfoProvider implements InsightsInfoProvider {
                                 entry.getKey().ownerEntityClass().getName(),
                                 entry.getKey().associationPropertyName()),
                         entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    private static List<ExternalCallInsight> convertExternalCalls(List<AggregatedExternalCall> externalCalls) {
+        return externalCalls.stream()
+                .map(aggregatedCall -> {
+                    PerformanceStats stats = aggregatedCall.getStats();
+                    return new ExternalCallInsight(
+                            aggregatedCall.getType(),
+                            aggregatedCall.getTarget(),
+                            new TransactionOverallStats(stats.getMinMs(), stats.getMaxMs(), stats.getAvgMs()));
+                })
                 .collect(Collectors.toList());
     }
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/master/insights/DefaultInsightsInfoProvider.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/master/insights/DefaultInsightsInfoProvider.java
@@ -28,11 +28,11 @@ import com.axelixlabs.axelix.common.api.registration.insights.HotSpotInsights;
 import com.axelixlabs.axelix.common.api.registration.insights.InsightFeature;
 import com.axelixlabs.axelix.common.api.registration.insights.Insights;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.CountedLazyLoadingTarget;
+import com.axelixlabs.axelix.common.api.registration.insights.persistence.ExecutionStats;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.ExternalCallInsight;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.PersistenceInsights;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionAggregatedProfile;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionOrigin;
-import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionOverallStats;
 import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionalKey;
 import com.axelixlabs.axelix.common.domain.insights.FeatureId;
 import com.axelixlabs.axelix.sbs.spring.core.gclog.GcLogService;
@@ -105,7 +105,7 @@ public class DefaultInsightsInfoProvider implements InsightsInfoProvider {
                             new TransactionalKey(
                                     key.getTargetClass().getName(),
                                     key.getMethod().getName()),
-                            new TransactionOverallStats(
+                            new ExecutionStats(
                                     performanceStats.getMinMs(),
                                     performanceStats.getMaxMs(),
                                     performanceStats.getAvgMs()),
@@ -137,7 +137,7 @@ public class DefaultInsightsInfoProvider implements InsightsInfoProvider {
                     return new ExternalCallInsight(
                             aggregatedCall.getType(),
                             aggregatedCall.getTarget(),
-                            new TransactionOverallStats(stats.getMinMs(), stats.getMaxMs(), stats.getAvgMs()));
+                            new ExecutionStats(stats.getMinMs(), stats.getMaxMs(), stats.getAvgMs()));
                 })
                 .collect(Collectors.toList());
     }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricNames.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/metrics/AxelixMetricNames.java
@@ -26,6 +26,7 @@ public final class AxelixMetricNames {
 
     public static final String TRANSACTION_DURATION = "axelix_transaction_duration";
     public static final String TRANSACTION_QUERIES = "axelix_transaction_queries";
+    public static final String TRANSACTION_EXTERNAL_CALLS = "axelix_transaction_external_calls";
     public static final String CACHE_REQUESTS = "axelix_cache_requests";
     public static final String CACHE_ENABLED = "axelix_cache_enabled";
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/SimpleExternalCallRecord.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/SimpleExternalCallRecord.java
@@ -32,9 +32,8 @@ public class SimpleExternalCallRecord {
     /**
      * Create a new SimpleExternalCallRecord.
      *
-     * @param type       the client that performed the call, e.g. {@link TypeExternalCall#REST_TEMPLATE} or
-     *                   {@link TypeExternalCall#REST_CLIENT} for an HTTP call, {@link TypeExternalCall#KAFKA} for a
-     *                   messaging one.
+     * @param type       the client that performed the call, e.g. {@link TypeExternalCall#HTTP_CLIENT} for an HTTP
+     *                   call, {@link TypeExternalCall#KAFKA} for a messaging one.
      * @param target     where the call went: the request method and url for an HTTP call, e.g.
      *                   {@code "GET https://payments/charge"}. The topic / queue / exchange for a messaging call.
      * @param durationMs the call duration in milliseconds.

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/SimpleExternalCallRecord.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/SimpleExternalCallRecord.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence;
+
+/**
+ * Record of a single blocking call to an external system made while a transaction was open.
+ *
+ * @author Sergey Cherkasov
+ */
+public class SimpleExternalCallRecord {
+    private final TypeExternal type;
+    private final String target;
+    private final long durationMs;
+
+    /**
+     * Create a new SimpleExternalCallRecord.
+     *
+     * @param type       the client that performed the call, e.g. {@link TypeExternal#REST_TEMPLATE} or
+     *                   {@link TypeExternal#REST_CLIENT} for an HTTP call, {@link TypeExternal#KAFKA} for a
+     *                   messaging one.
+     * @param target     where the call went: the request method and url for an HTTP call, e.g.
+     *                   {@code "GET https://payments/charge"}. The topic / queue / exchange for a messaging call.
+     * @param durationMs the call duration in milliseconds.
+     */
+    public SimpleExternalCallRecord(TypeExternal type, String target, long durationMs) {
+        this.type = type;
+        this.target = target;
+        this.durationMs = durationMs;
+    }
+
+    public TypeExternal getType() {
+        return type;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public long getDurationMs() {
+        return durationMs;
+    }
+
+    /**
+     * The client that performed a {@link SimpleExternalCallRecord}: an HTTP client, or a messaging client.
+     */
+    public enum TypeExternal {
+        REST_TEMPLATE,
+        REST_CLIENT,
+        WEB_CLIENT,
+        KAFKA,
+        RABBIT
+    }
+}

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/AggregatedExternalCall.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/AggregatedExternalCall.java
@@ -40,9 +40,8 @@ public class AggregatedExternalCall {
     /**
      * Create a new ggregatedExternalCall.
      *
-     * @param type       the client that performed the call, e.g. {@link TypeExternalCall#REST_TEMPLATE} or
-     *                   {@link TypeExternalCall#REST_CLIENT} for an HTTP call, {@link TypeExternalCall#KAFKA} for a
-     *                   messaging one.
+     * @param type       the client that performed the call, e.g. {@link TypeExternalCall#HTTP_CLIENT} for an HTTP
+     *                   call, {@link TypeExternalCall#KAFKA} for a messaging one.
      * @param target     where the call went: the request method and url for an HTTP call, e.g.
      *                   {@code "GET https://payments/charge"}. The topic / queue / exchange for a messaging call.
      */

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/AggregatedExternalCall.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/AggregatedExternalCall.java
@@ -15,34 +15,45 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.sbs.spring.core.persistence;
+package com.axelixlabs.axelix.sbs.spring.core.persistence.transaction;
+
+import java.util.Objects;
 
 import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
 
 /**
- * Record of a single blocking call to an external system made while a transaction was open.
+ * Aggregate of all the blocking calls made to a single {@code (type, target)} external endpoint, carrying the
+ * running min/max/avg duration across them.
  *
  * @author Sergey Cherkasov
  */
-public class SimpleExternalCallRecord {
+public class AggregatedExternalCall {
+
     private final TypeExternalCall type;
     private final String target;
-    private final long durationMs;
 
     /**
-     * Create a new SimpleExternalCallRecord.
+     * The min/max/avg call duration aggregated across every invocation of the transactional method.
+     */
+    private final PerformanceStats stats;
+
+    /**
+     * Create a new ggregatedExternalCall.
      *
      * @param type       the client that performed the call, e.g. {@link TypeExternalCall#REST_TEMPLATE} or
      *                   {@link TypeExternalCall#REST_CLIENT} for an HTTP call, {@link TypeExternalCall#KAFKA} for a
      *                   messaging one.
      * @param target     where the call went: the request method and url for an HTTP call, e.g.
      *                   {@code "GET https://payments/charge"}. The topic / queue / exchange for a messaging call.
-     * @param durationMs the call duration in milliseconds.
      */
-    public SimpleExternalCallRecord(TypeExternalCall type, String target, long durationMs) {
+    public AggregatedExternalCall(TypeExternalCall type, String target) {
         this.type = type;
         this.target = target;
-        this.durationMs = durationMs;
+        this.stats = new PerformanceStats();
+    }
+
+    void record(long durationMs) {
+        stats.record(durationMs);
     }
 
     public TypeExternalCall getType() {
@@ -53,7 +64,26 @@ public class SimpleExternalCallRecord {
         return target;
     }
 
-    public long getDurationMs() {
-        return durationMs;
+    public PerformanceStats getStats() {
+        return stats;
+    }
+
+    @Override
+    public String toString() {
+        return "AggregatedExternalCall{" + "type=" + type + ", target='" + target + '\'' + ", stats=" + stats + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AggregatedExternalCall that = (AggregatedExternalCall) o;
+        return type == that.type && Objects.equals(target, that.target) && Objects.equals(stats, that.stats);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, target, stats);
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/PerformanceStats.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/PerformanceStats.java
@@ -18,7 +18,7 @@
 package com.axelixlabs.axelix.sbs.spring.core.persistence.transaction;
 
 /**
- * Running min/max/avg call duration across every call aggregated into the owning record.
+ * Aggregated performance stats.
  *
  * @author Mikhail Polivakha
  */

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/PerformanceStats.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/PerformanceStats.java
@@ -17,26 +17,30 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.persistence.transaction;
 
+/**
+ * Running min/max/avg call duration across every call aggregated into the owning record.
+ *
+ * @author Mikhail Polivakha
+ * @author Sergey Cherkasov
+ */
 public class PerformanceStats {
 
     private long minMs;
     private long maxMs;
     private long avgMs;
-    private long transactionsRecorded;
+    private long recorded;
 
-    public void recordTransaction(TransactionExecutionProfile transaction) {
-        long transactionDurationMs = transaction.getTransactionDuration().toMillis();
-
-        if (transactionsRecorded == 0) {
-            this.minMs = transactionDurationMs;
-            this.maxMs = transactionDurationMs;
-            this.avgMs = transactionDurationMs;
+    public void record(long durationMs) {
+        if (durationMs == 0) {
+            this.minMs = durationMs;
+            this.maxMs = durationMs;
+            this.avgMs = durationMs;
         } else {
-            this.minMs = Math.min(transactionDurationMs, minMs);
-            this.maxMs = Math.max(transactionDurationMs, maxMs);
-            this.avgMs = (avgMs * transactionsRecorded + transactionDurationMs) / (transactionsRecorded + 1);
+            this.minMs = Math.min(durationMs, minMs);
+            this.maxMs = Math.max(durationMs, maxMs);
+            this.avgMs = (avgMs * durationMs + durationMs) / (durationMs + 1);
         }
-        this.transactionsRecorded++;
+        this.recorded++;
     }
 
     public long getMinMs() {
@@ -49,5 +53,9 @@ public class PerformanceStats {
 
     public long getAvgMs() {
         return avgMs;
+    }
+
+    public long getRecorded() {
+        return recorded;
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/PerformanceStats.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/PerformanceStats.java
@@ -21,7 +21,6 @@ package com.axelixlabs.axelix.sbs.spring.core.persistence.transaction;
  * Running min/max/avg call duration across every call aggregated into the owning record.
  *
  * @author Mikhail Polivakha
- * @author Sergey Cherkasov
  */
 public class PerformanceStats {
 
@@ -31,14 +30,14 @@ public class PerformanceStats {
     private long recorded;
 
     public void record(long durationMs) {
-        if (durationMs == 0) {
+        if (recorded == 0) {
             this.minMs = durationMs;
             this.maxMs = durationMs;
             this.avgMs = durationMs;
         } else {
             this.minMs = Math.min(durationMs, minMs);
             this.maxMs = Math.max(durationMs, maxMs);
-            this.avgMs = (avgMs * durationMs + durationMs) / (durationMs + 1);
+            this.avgMs = (avgMs * recorded + durationMs) / (recorded + 1);
         }
         this.recorded++;
     }
@@ -53,9 +52,5 @@ public class PerformanceStats {
 
     public long getAvgMs() {
         return avgMs;
-    }
-
-    public long getRecorded() {
-        return recorded;
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionAccessor.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionAccessor.java
@@ -24,6 +24,7 @@ import java.util.Deque;
 import org.jspecify.annotations.Nullable;
 
 import com.axelixlabs.axelix.common.utils.Assert;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleSqlQueryRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.LazyLoadingTarget;
 
@@ -60,6 +61,20 @@ public class TransactionAccessor {
 
         if (currentTransactionProfile != null) {
             currentTransactionProfile.recordQuery(sqlQueryRecord);
+        }
+    }
+
+    /**
+     * Record the given blocking call to an external system to the current transaction.
+     * <p>
+     * Just like with the sql queries, if there is no active transaction for the current {@link Thread},
+     * the call is just ignored, as it does not block any transaction.
+     */
+    public void recordExternalCall(SimpleExternalCallRecord externalCall) {
+        TransactionExecutionProfile currentTransactionProfile = getCurrentTransactionProfile();
+
+        if (currentTransactionProfile != null) {
+            currentTransactionProfile.recordExternalCall(externalCall);
         }
     }
 

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionExecutionProfile.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionExecutionProfile.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.jspecify.annotations.Nullable;
 
 import com.axelixlabs.axelix.common.utils.Assert;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleSqlQueryRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.LazyLoadingTarget;
 
@@ -34,19 +35,24 @@ import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.LazyLoadingTa
  * @author Mikhail Polivakha
  */
 public class TransactionExecutionProfile {
-
     private final List<AnalyzedSqlQueryRecord> recordedQueries;
+    private final List<SimpleExternalCallRecord> recordedExternalCalls;
     private final Instant startedAt;
     private @Nullable Instant finishedAt;
 
     public TransactionExecutionProfile(Instant startedAt) {
         this.recordedQueries = new ArrayList<>(4);
+        this.recordedExternalCalls = new ArrayList<>(4);
         this.startedAt = startedAt;
         this.finishedAt = null;
     }
 
     public void recordQuery(SimpleSqlQueryRecord sqlQueryRecord) {
         recordedQueries.add(new AnalyzedSqlQueryRecord(sqlQueryRecord));
+    }
+
+    public void recordExternalCall(SimpleExternalCallRecord externalCall) {
+        recordedExternalCalls.add(externalCall);
     }
 
     public void recordLazyLoading(LazyLoadingTarget lazyLoadingTarget) {
@@ -101,6 +107,33 @@ public class TransactionExecutionProfile {
         return recordedQueries.size();
     }
 
+    public int getExternalCallCount() {
+        return recordedExternalCalls.size();
+    }
+
+    /**
+     * Fold the raw recorded external calls into one {@link AggregatedExternalCall}
+     * per {@code (type, target)} endpoint, carrying the running min/max/avg duration across the calls to it.
+     */
+    public List<AggregatedExternalCall> getAggregatedExternalCalls() {
+        List<AggregatedExternalCall> aggregated = new ArrayList<>();
+
+        for (SimpleExternalCallRecord call : recordedExternalCalls) {
+            AggregatedExternalCall endpoint = aggregated.stream()
+                    .filter(a -> a.getExternalCall().getType() == call.getType()
+                            && a.getExternalCall().getTarget().equals(call.getTarget()))
+                    .findFirst()
+                    .orElseGet(() -> {
+                        AggregatedExternalCall created = new AggregatedExternalCall(call);
+                        aggregated.add(created);
+                        return created;
+                    });
+            endpoint.record(call.getDurationMs());
+        }
+
+        return aggregated;
+    }
+
     public static class AnalyzedSqlQueryRecord {
 
         private final SimpleSqlQueryRecord queryRecord;
@@ -142,6 +175,33 @@ public class TransactionExecutionProfile {
 
         public @Nullable LazyLoadingTarget getLazyLoadingTarget() {
             return lazyLoadingTarget;
+        }
+    }
+
+    /**
+     * Aggregate of all the calls to a single {@code (type, target)} external endpoint within the transaction,
+     * carrying the running min/max/avg duration across them.
+     */
+    public static class AggregatedExternalCall {
+
+        private final SimpleExternalCallRecord externalCall;
+        private final PerformanceStats stats;
+
+        AggregatedExternalCall(SimpleExternalCallRecord externalCall) {
+            this.externalCall = externalCall;
+            this.stats = new PerformanceStats();
+        }
+
+        void record(long durationMs) {
+            stats.record(durationMs);
+        }
+
+        public SimpleExternalCallRecord getExternalCall() {
+            return externalCall;
+        }
+
+        public PerformanceStats getStats() {
+            return stats;
         }
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionExecutionProfile.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionExecutionProfile.java
@@ -20,9 +20,7 @@ package com.axelixlabs.axelix.sbs.spring.core.persistence.transaction;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
 
@@ -76,6 +74,10 @@ public class TransactionExecutionProfile {
         return recordedQueries;
     }
 
+    public List<SimpleExternalCallRecord> getRecordedExternalCalls() {
+        return recordedExternalCalls;
+    }
+
     public long getStartedAtMillisFromEpoch() {
         return startedAt.toEpochMilli();
     }
@@ -111,24 +113,6 @@ public class TransactionExecutionProfile {
 
     public int getExternalCallCount() {
         return recordedExternalCalls.size();
-    }
-
-    /**
-     * Fold the raw recorded external calls into one {@link AggregatedExternalCall}
-     * per {@code (type, target)} endpoint, carrying the running min/max/avg duration across the calls to it.
-     */
-    public List<AggregatedExternalCall> getAggregatedExternalCalls() {
-        Map<Map.Entry<SimpleExternalCallRecord.TypeExternal, String>, AggregatedExternalCall> aggregated =
-                new LinkedHashMap<>();
-
-        for (SimpleExternalCallRecord call : recordedExternalCalls) {
-            aggregated
-                    .computeIfAbsent(
-                            Map.entry(call.getType(), call.getTarget()), key -> new AggregatedExternalCall(call))
-                    .record(call.getDurationMs());
-        }
-
-        return new ArrayList<>(aggregated.values());
     }
 
     public static class AnalyzedSqlQueryRecord {
@@ -172,33 +156,6 @@ public class TransactionExecutionProfile {
 
         public @Nullable LazyLoadingTarget getLazyLoadingTarget() {
             return lazyLoadingTarget;
-        }
-    }
-
-    /**
-     * Aggregate of all the calls to a single {@code (type, target)} external endpoint within the transaction,
-     * carrying the running min/max/avg duration across them.
-     */
-    public static class AggregatedExternalCall {
-
-        private final SimpleExternalCallRecord externalCall;
-        private final PerformanceStats stats;
-
-        AggregatedExternalCall(SimpleExternalCallRecord externalCall) {
-            this.externalCall = externalCall;
-            this.stats = new PerformanceStats();
-        }
-
-        void record(long durationMs) {
-            stats.record(durationMs);
-        }
-
-        public SimpleExternalCallRecord getExternalCall() {
-            return externalCall;
-        }
-
-        public PerformanceStats getStats() {
-            return stats;
         }
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionExecutionProfile.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionExecutionProfile.java
@@ -20,7 +20,9 @@ package com.axelixlabs.axelix.sbs.spring.core.persistence.transaction;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
 
@@ -116,22 +118,17 @@ public class TransactionExecutionProfile {
      * per {@code (type, target)} endpoint, carrying the running min/max/avg duration across the calls to it.
      */
     public List<AggregatedExternalCall> getAggregatedExternalCalls() {
-        List<AggregatedExternalCall> aggregated = new ArrayList<>();
+        Map<Map.Entry<SimpleExternalCallRecord.TypeExternal, String>, AggregatedExternalCall> aggregated =
+                new LinkedHashMap<>();
 
         for (SimpleExternalCallRecord call : recordedExternalCalls) {
-            AggregatedExternalCall endpoint = aggregated.stream()
-                    .filter(a -> a.getExternalCall().getType() == call.getType()
-                            && a.getExternalCall().getTarget().equals(call.getTarget()))
-                    .findFirst()
-                    .orElseGet(() -> {
-                        AggregatedExternalCall created = new AggregatedExternalCall(call);
-                        aggregated.add(created);
-                        return created;
-                    });
-            endpoint.record(call.getDurationMs());
+            aggregated
+                    .computeIfAbsent(
+                            Map.entry(call.getType(), call.getTarget()), key -> new AggregatedExternalCall(call))
+                    .record(call.getDurationMs());
         }
 
-        return aggregated;
+        return new ArrayList<>(aggregated.values());
     }
 
     public static class AnalyzedSqlQueryRecord {

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionStats.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionStats.java
@@ -17,12 +17,16 @@
  */
 package com.axelixlabs.axelix.sbs.spring.core.persistence.transaction;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
+import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.LazyLoadingTarget;
 
 /**
@@ -40,17 +44,35 @@ public class TransactionStats {
 
     private final Map<LazyLoadingTarget, Integer> lazyLoadingOccasions;
     private final Map<String, Integer> inMemoryPaginatedEntities;
+    private final List<AggregatedExternalCall> externalCalls;
     private final PerformanceStats performanceStats;
 
     public TransactionStats() {
         this.lazyLoadingOccasions = new HashMap<>(1);
         this.inMemoryPaginatedEntities = new HashMap<>(1);
+        this.externalCalls = new ArrayList<>(1);
         this.performanceStats = new PerformanceStats();
     }
 
     public void put(TransactionExecutionProfile transaction) {
         updateProblemsProfilers(transaction);
         performanceStats.record(transaction.getTransactionDuration().toMillis());
+
+        for (SimpleExternalCallRecord call : transaction.getRecordedExternalCalls()) {
+            getOrCreateAggregate(call.getType(), call.getTarget()).record(call.getDurationMs());
+        }
+    }
+
+    private AggregatedExternalCall getOrCreateAggregate(TypeExternalCall type, String target) {
+        for (AggregatedExternalCall aggregatedCall : externalCalls) {
+            if (aggregatedCall.getType() == type && aggregatedCall.getTarget().equals(target)) {
+                return aggregatedCall;
+            }
+        }
+
+        AggregatedExternalCall created = new AggregatedExternalCall(type, target);
+        externalCalls.add(created);
+        return created;
     }
 
     private void updateProblemsProfilers(TransactionExecutionProfile transaction) {
@@ -134,5 +156,9 @@ public class TransactionStats {
 
     public Map<String, Integer> getInMemoryPaginatedEntities() {
         return inMemoryPaginatedEntities;
+    }
+
+    public List<AggregatedExternalCall> getExternalCalls() {
+        return externalCalls;
     }
 }

--- a/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionStats.java
+++ b/sbs/starter-domain/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionStats.java
@@ -50,7 +50,7 @@ public class TransactionStats {
 
     public void put(TransactionExecutionProfile transaction) {
         updateProblemsProfilers(transaction);
-        performanceStats.recordTransaction(transaction);
+        performanceStats.record(transaction.getTransactionDuration().toMillis());
     }
 
     private void updateProblemsProfilers(TransactionExecutionProfile transaction) {

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultInsightsInfoProviderTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultInsightsInfoProviderTest.java
@@ -18,6 +18,7 @@
 package com.axelixlabs.axelix.sbs.spring.core.master;
 
 import java.io.File;
+import java.time.Instant;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -25,11 +26,16 @@ import org.junit.jupiter.api.Test;
 import com.axelixlabs.axelix.common.api.gclog.GcLogStatus;
 import com.axelixlabs.axelix.common.api.registration.insights.InsightFeature;
 import com.axelixlabs.axelix.common.api.registration.insights.Insights;
+import com.axelixlabs.axelix.common.api.registration.insights.persistence.TransactionAggregatedProfile;
 import com.axelixlabs.axelix.common.domain.insights.FeatureId;
+import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
 import com.axelixlabs.axelix.sbs.spring.core.gclog.GcLogService;
 import com.axelixlabs.axelix.sbs.spring.core.master.insights.DefaultInsightsInfoProvider;
 import com.axelixlabs.axelix.sbs.spring.core.master.insights.VmOptionsAccessor;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.MethodClassKey;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.DefaultTransactionStatsCollector;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionExecutionProfile;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionStatsCollector;
 
 import static com.axelixlabs.axelix.common.domain.insights.FeatureId.AOT_CACHE;
@@ -156,6 +162,35 @@ class DefaultInsightsInfoProviderTest {
         assertFeatureEnabled(insights.getSpringFramework(), OSIV, true);
     }
 
+    @Test
+    void surfacesExternalCallsInPersistenceInsights() throws Exception {
+        // given.
+        DefaultTransactionStatsCollector collector = new DefaultTransactionStatsCollector();
+        MethodClassKey key = new MethodClassKey(SampleService.class.getMethod("charge"), SampleService.class);
+        TransactionExecutionProfile profile = new TransactionExecutionProfile(Instant.now());
+        profile.recordExternalCall(
+                new SimpleExternalCallRecord(TypeExternalCall.REST_TEMPLATE, "GET https://payments/charge", 15L));
+        profile.complete();
+        collector.recordTransaction(key, profile);
+
+        var subject = new DefaultInsightsInfoProvider(osivDisabled(), gcLogDisabled(), emptyVmOptions(), collector);
+
+        // when.
+        Insights insights = subject.getInsight();
+
+        // then.
+        List<TransactionAggregatedProfile> transactions =
+                insights.getPersistenceInsights().getTransactions();
+        assertThat(transactions).hasSize(1);
+        assertThat(transactions.get(0).getExternalCalls()).singleElement().satisfies(call -> {
+            assertThat(call.getType()).isEqualTo(TypeExternalCall.REST_TEMPLATE);
+            assertThat(call.getTarget()).isEqualTo("GET https://payments/charge");
+            assertThat(call.getStats().getMinMs()).isEqualTo(15L);
+            assertThat(call.getStats().getMaxMs()).isEqualTo(15L);
+            assertThat(call.getStats().getAverageMs()).isEqualTo(15L);
+        });
+    }
+
     private static void assertFeatureEnabled(List<InsightFeature> features, FeatureId featureId, boolean enabled) {
         InsightFeature feature = findByFeatureId(features, featureId);
 
@@ -196,6 +231,10 @@ class DefaultInsightsInfoProviderTest {
 
     private static OpenSessionInViewStateProvider osivEnabled() {
         return () -> true;
+    }
+
+    private static final class SampleService {
+        public void charge() {}
     }
 
     private static final class TestGcLogService implements GcLogService {

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultInsightsInfoProviderTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/master/DefaultInsightsInfoProviderTest.java
@@ -169,7 +169,7 @@ class DefaultInsightsInfoProviderTest {
         MethodClassKey key = new MethodClassKey(SampleService.class.getMethod("charge"), SampleService.class);
         TransactionExecutionProfile profile = new TransactionExecutionProfile(Instant.now());
         profile.recordExternalCall(
-                new SimpleExternalCallRecord(TypeExternalCall.REST_TEMPLATE, "GET https://payments/charge", 15L));
+                new SimpleExternalCallRecord(TypeExternalCall.HTTP_CLIENT, "GET https://payments/charge", 15L));
         profile.complete();
         collector.recordTransaction(key, profile);
 
@@ -183,7 +183,7 @@ class DefaultInsightsInfoProviderTest {
                 insights.getPersistenceInsights().getTransactions();
         assertThat(transactions).hasSize(1);
         assertThat(transactions.get(0).getExternalCalls()).singleElement().satisfies(call -> {
-            assertThat(call.getType()).isEqualTo(TypeExternalCall.REST_TEMPLATE);
+            assertThat(call.getType()).isEqualTo(TypeExternalCall.HTTP_CLIENT);
             assertThat(call.getTarget()).isEqualTo("GET https://payments/charge");
             assertThat(call.getStats().getMinMs()).isEqualTo(15L);
             assertThat(call.getStats().getMaxMs()).isEqualTo(15L);

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionAccessorTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionAccessorTest.java
@@ -52,7 +52,7 @@ class TransactionAccessorTest {
     }
 
     private static SimpleExternalCallRecord externalCall(String target, long durationMs) {
-        return new SimpleExternalCallRecord(TypeExternalCall.REST_TEMPLATE, target, durationMs);
+        return new SimpleExternalCallRecord(TypeExternalCall.HTTP_CLIENT, target, durationMs);
     }
 
     @Nested

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionAccessorTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionAccessorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleSqlQueryRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.LazyLoadingTarget;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionExecutionProfile.AnalyzedSqlQueryRecord;
@@ -47,6 +48,10 @@ class TransactionAccessorTest {
 
     private static SimpleSqlQueryRecord query(String sql) {
         return new SimpleSqlQueryRecord(sql, 5L, 1_000L, false);
+    }
+
+    private static SimpleExternalCallRecord externalCall(String target, long durationMs) {
+        return new SimpleExternalCallRecord(SimpleExternalCallRecord.TypeExternal.REST_TEMPLATE, target, durationMs);
     }
 
     @Nested
@@ -110,6 +115,88 @@ class TransactionAccessorTest {
                     .hasSize(1)
                     .extracting(AnalyzedSqlQueryRecord::getSql)
                     .containsExactly("select 1");
+        }
+    }
+
+    @Nested
+    class RecordExternalCall {
+
+        @Test
+        void shouldRecordExternalCallIntoActiveTransaction() {
+            // given.
+            subject.recordNewTransactionStarted();
+
+            // when.
+            subject.recordExternalCall(externalCall("GET https://payments/charge", 15L));
+            TransactionExecutionProfile profile = subject.recordTransactionCompletion();
+
+            // then.
+            assertThat(profile.getAggregatedExternalCalls())
+                    .hasSize(1)
+                    .extracting(agg -> agg.getExternalCall().getTarget())
+                    .containsExactly("GET https://payments/charge");
+        }
+
+        @Test
+        void shouldRecordExternalCallsAlongsideSqlQueries() {
+            // given.
+            subject.recordNewTransactionStarted();
+
+            // when.
+            subject.recordSqlQuery(query("select 1"));
+            subject.recordExternalCall(externalCall("GET https://payments/charge", 15L));
+            TransactionExecutionProfile profile = subject.recordTransactionCompletion();
+
+            // then.
+            assertThat(profile.getRecordedQueries()).hasSize(1);
+            assertThat(profile.getAggregatedExternalCalls()).hasSize(1);
+        }
+
+        @Test
+        void shouldSilentlyIgnoreExternalCallWhenNoTransactionIsActive() {
+            // given.
+            // no transaction has been started
+
+            // when then.
+            assertThatCode(() -> subject.recordExternalCall(externalCall("GET https://payments/charge", 15L)))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        void shouldNotLeakExternalCallRecordedOutsideTransactionIntoTheNextTransaction() {
+            // given.
+            subject.recordExternalCall(externalCall("GET https://orphan", 15L));
+
+            // when.
+            subject.recordNewTransactionStarted();
+            subject.recordExternalCall(externalCall("GET https://payments/charge", 15L));
+            TransactionExecutionProfile profile = subject.recordTransactionCompletion();
+
+            // then.
+            assertThat(profile.getAggregatedExternalCalls())
+                    .hasSize(1)
+                    .extracting(agg -> agg.getExternalCall().getTarget())
+                    .containsExactly("GET https://payments/charge");
+        }
+
+        @Test
+        void shouldAggregateRepeatedCallsToTheSameTarget() {
+            // given.
+            subject.recordNewTransactionStarted();
+
+            // when.
+            subject.recordExternalCall(externalCall("GET https://payments/charge", 10L));
+            subject.recordExternalCall(externalCall("GET https://payments/charge", 30L));
+            TransactionExecutionProfile profile = subject.recordTransactionCompletion();
+
+            // then. The two calls fold into one aggregated endpoint.
+            assertThat(profile.getAggregatedExternalCalls()).hasSize(1);
+
+            PerformanceStats stats = profile.getAggregatedExternalCalls().get(0).getStats();
+            assertThat(stats.getMinMs()).isEqualTo(10L);
+            assertThat(stats.getMaxMs()).isEqualTo(30L);
+            assertThat(stats.getAvgMs()).isEqualTo(20L);
+            assertThat(stats.getRecorded()).isEqualTo(2L);
         }
     }
 

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionAccessorTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionAccessorTest.java
@@ -196,7 +196,6 @@ class TransactionAccessorTest {
             assertThat(stats.getMinMs()).isEqualTo(10L);
             assertThat(stats.getMaxMs()).isEqualTo(30L);
             assertThat(stats.getAvgMs()).isEqualTo(20L);
-            assertThat(stats.getRecorded()).isEqualTo(2L);
         }
     }
 

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionAccessorTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionAccessorTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleSqlQueryRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.LazyLoadingTarget;
@@ -51,7 +52,7 @@ class TransactionAccessorTest {
     }
 
     private static SimpleExternalCallRecord externalCall(String target, long durationMs) {
-        return new SimpleExternalCallRecord(SimpleExternalCallRecord.TypeExternal.REST_TEMPLATE, target, durationMs);
+        return new SimpleExternalCallRecord(TypeExternalCall.REST_TEMPLATE, target, durationMs);
     }
 
     @Nested
@@ -131,9 +132,9 @@ class TransactionAccessorTest {
             TransactionExecutionProfile profile = subject.recordTransactionCompletion();
 
             // then.
-            assertThat(profile.getAggregatedExternalCalls())
+            assertThat(profile.getRecordedExternalCalls())
                     .hasSize(1)
-                    .extracting(agg -> agg.getExternalCall().getTarget())
+                    .extracting(SimpleExternalCallRecord::getTarget)
                     .containsExactly("GET https://payments/charge");
         }
 
@@ -149,7 +150,7 @@ class TransactionAccessorTest {
 
             // then.
             assertThat(profile.getRecordedQueries()).hasSize(1);
-            assertThat(profile.getAggregatedExternalCalls()).hasSize(1);
+            assertThat(profile.getRecordedExternalCalls()).hasSize(1);
         }
 
         @Test
@@ -173,14 +174,14 @@ class TransactionAccessorTest {
             TransactionExecutionProfile profile = subject.recordTransactionCompletion();
 
             // then.
-            assertThat(profile.getAggregatedExternalCalls())
+            assertThat(profile.getRecordedExternalCalls())
                     .hasSize(1)
-                    .extracting(agg -> agg.getExternalCall().getTarget())
+                    .extracting(SimpleExternalCallRecord::getTarget)
                     .containsExactly("GET https://payments/charge");
         }
 
         @Test
-        void shouldAggregateRepeatedCallsToTheSameTarget() {
+        void shouldRecordRepeatedCallsToTheSameTargetAsSeparateRecords() {
             // given.
             subject.recordNewTransactionStarted();
 
@@ -189,13 +190,11 @@ class TransactionAccessorTest {
             subject.recordExternalCall(externalCall("GET https://payments/charge", 30L));
             TransactionExecutionProfile profile = subject.recordTransactionCompletion();
 
-            // then. The two calls fold into one aggregated endpoint.
-            assertThat(profile.getAggregatedExternalCalls()).hasSize(1);
-
-            PerformanceStats stats = profile.getAggregatedExternalCalls().get(0).getStats();
-            assertThat(stats.getMinMs()).isEqualTo(10L);
-            assertThat(stats.getMaxMs()).isEqualTo(30L);
-            assertThat(stats.getAvgMs()).isEqualTo(20L);
+            // then. The profile keeps every raw call; aggregation happens later in TransactionStats.
+            assertThat(profile.getRecordedExternalCalls())
+                    .hasSize(2)
+                    .extracting(SimpleExternalCallRecord::getDurationMs)
+                    .containsExactly(10L, 30L);
         }
     }
 

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionStatsTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionStatsTest.java
@@ -135,7 +135,7 @@ class TransactionStatsTest {
 
             // then.
             assertThat(subject.getExternalCalls()).singleElement().satisfies(aggregatedCall -> {
-                assertThat(aggregatedCall.getType()).isEqualTo(TypeExternalCall.REST_TEMPLATE);
+                assertThat(aggregatedCall.getType()).isEqualTo(TypeExternalCall.HTTP_CLIENT);
                 assertThat(aggregatedCall.getTarget()).isEqualTo("GET https://payments/charge");
                 assertThat(aggregatedCall.getStats().getMinMs()).isEqualTo(10L);
                 assertThat(aggregatedCall.getStats().getMaxMs()).isEqualTo(30L);
@@ -170,7 +170,7 @@ class TransactionStatsTest {
     }
 
     private static SimpleExternalCallRecord externalCall(long durationMs) {
-        return new SimpleExternalCallRecord(TypeExternalCall.REST_TEMPLATE, "GET https://payments/charge", durationMs);
+        return new SimpleExternalCallRecord(TypeExternalCall.HTTP_CLIENT, "GET https://payments/charge", durationMs);
     }
 
     private static TransactionExecutionProfile profileWith(SimpleSqlQueryRecord... queries) {

--- a/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionStatsTest.java
+++ b/sbs/starter-domain/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/transaction/TransactionStatsTest.java
@@ -22,6 +22,8 @@ import java.time.Instant;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleSqlQueryRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.LazyLoadingTarget;
 
@@ -117,6 +119,58 @@ class TransactionStatsTest {
             assertThat(subject.getNPlusOneOccasions()).containsEntry(pets, 2);
             assertThat(subject.getInMemoryPaginatedEntities()).isEmpty();
         }
+    }
+
+    @Nested
+    class ExternalCallAggregation {
+
+        @Test
+        void shouldAggregateCallsToTheSameEndpointWithinATransaction() {
+            // given.
+            TransactionStats subject = new TransactionStats();
+            TransactionExecutionProfile profile = profileWithExternalCalls(externalCall(10L), externalCall(30L));
+
+            // when.
+            subject.put(profile);
+
+            // then.
+            assertThat(subject.getExternalCalls()).singleElement().satisfies(aggregatedCall -> {
+                assertThat(aggregatedCall.getType()).isEqualTo(TypeExternalCall.REST_TEMPLATE);
+                assertThat(aggregatedCall.getTarget()).isEqualTo("GET https://payments/charge");
+                assertThat(aggregatedCall.getStats().getMinMs()).isEqualTo(10L);
+                assertThat(aggregatedCall.getStats().getMaxMs()).isEqualTo(30L);
+                assertThat(aggregatedCall.getStats().getAvgMs()).isEqualTo(20L);
+            });
+        }
+
+        @Test
+        void shouldAggregateTheSameEndpointAcrossTransactions() {
+            // given.
+            TransactionStats subject = new TransactionStats();
+
+            // when.
+            subject.put(profileWithExternalCalls(externalCall(10L), externalCall(30L)));
+            subject.put(profileWithExternalCalls(externalCall(50L)));
+
+            // then. Recording every raw call across both invocations: min/max span both, avg is the running mean.
+            assertThat(subject.getExternalCalls()).singleElement().satisfies(aggregatedCall -> {
+                assertThat(aggregatedCall.getStats().getMinMs()).isEqualTo(10L);
+                assertThat(aggregatedCall.getStats().getMaxMs()).isEqualTo(50L);
+                assertThat(aggregatedCall.getStats().getAvgMs()).isEqualTo(30L);
+            });
+        }
+    }
+
+    private static TransactionExecutionProfile profileWithExternalCalls(SimpleExternalCallRecord... calls) {
+        TransactionExecutionProfile profile = new TransactionExecutionProfile(Instant.now());
+        for (SimpleExternalCallRecord call : calls) {
+            profile.recordExternalCall(call);
+        }
+        return profile.complete();
+    }
+
+    private static SimpleExternalCallRecord externalCall(long durationMs) {
+        return new SimpleExternalCallRecord(TypeExternalCall.REST_TEMPLATE, "GET https://payments/charge", durationMs);
     }
 
     private static TransactionExecutionProfile profileWith(SimpleSqlQueryRecord... queries) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transaction-aware instrumentation to capture and time synchronous `RestTemplate` external calls.
  * Automatically registers a single external-call `RestTemplate` interceptor (without duplicating existing interceptors) and preserves interceptor ordering.
  * Transaction reporting and Micrometer metrics now include external-call counts aggregated by call type and target.
* **Tests**
  * Updated/added unit tests to verify auto-configuration wiring, external-call recording, idempotent interceptor behavior, and correct interceptor ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->