### PR TITLE
Exclude unreachable OIDC option from /settings instead of failing (#1…

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/SettingsApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/SettingsApi.java
@@ -51,6 +51,8 @@ public class SettingsApi {
 
     @GetMapping(path = ApiPaths.SettingsApi.SETTINGS)
     public AxelixSettings getAxelixSettings() {
-        return new AxelixSettings(authSettings, isMcpServerEnabled);
+        List<AuthenticationOption> availableOptions =
+                authSettings.stream().filter(AuthenticationOption::isAvailable).toList();
+        return new AxelixSettings(availableOptions, isMcpServerEnabled);
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/response/settings/AuthenticationOption.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/response/settings/AuthenticationOption.java
@@ -17,6 +17,8 @@
  */
 package com.axelixlabs.axelix.master.api.external.response.settings;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * Interface that represent a specific authentication option.
  *
@@ -33,4 +35,18 @@ public sealed interface AuthenticationOption
      * @return the type identifier, e.g. {@code "oidc"} or {@code login-password}
      */
     String type();
+
+    /**
+     * Whether this authentication option can currently be offered to the user.
+     * <p>
+     * Options that depend on an external system (e.g. an OIDC provider) may become temporarily
+     * unavailable. Such options are excluded from the settings response so that the UI still loads
+     * and the remaining options stay usable, instead of failing the whole response.
+     *
+     * @return {@code true} if the option should be exposed, {@code false} to omit it
+     */
+    @JsonIgnore
+    default boolean isAvailable() {
+        return true;
+    }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/response/settings/OidcAuthenticationOption.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/response/settings/OidcAuthenticationOption.java
@@ -17,9 +17,11 @@
  */
 package com.axelixlabs.axelix.master.api.external.response.settings;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.axelixlabs.axelix.common.utils.Lazy;
+import com.axelixlabs.axelix.master.exception.auth.OidcMetadataUnavailableException;
 
 /**
  * Authentication settings for OAuth2/OIDC userOrigin.
@@ -51,6 +53,22 @@ public final class OidcAuthenticationOption implements AuthenticationOption {
 
     public String getAuthorizationEndpoint() {
         return authorizationEndpointResolver.require();
+    }
+
+    /**
+     * The OIDC option is only available when the provider's metadata (and thus the authorization
+     * endpoint) can be resolved. When the provider is unreachable we omit this option rather than
+     * failing the whole settings response during serialization.
+     */
+    @Override
+    @JsonIgnore
+    public boolean isAvailable() {
+        try {
+            authorizationEndpointResolver.require();
+            return true;
+        } catch (OidcMetadataUnavailableException e) {
+            return false;
+        }
     }
 
     public String getClientId() {

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/SettingsApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/SettingsApiTest.java
@@ -37,6 +37,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import com.axelixlabs.axelix.master.exception.auth.OidcMetadataUnavailableException;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcMetadataProvider;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
@@ -218,6 +219,62 @@ class SettingsApiTest {
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThatJson(response.getBody()).isEqualTo(EXPECTED_JSON);
+        }
+    }
+
+    @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+    @AutoConfigureTestRestTemplate
+    @TestPropertySource(
+            properties = {
+                "axelix.master.auth.options.local.enabled=true",
+                "axelix.master.auth.options.super-admin.credentials.password=admin",
+                "axelix.master.auth.options.super-admin.credentials.username=admin",
+                "axelix.master.auth.options.oauth2.enabled=true",
+                // Distinct issuer keeps this test in its own Spring context (and thus a freshly-resolved
+                // OIDC metadata Lazy), so the mock throwing is not masked by a cached, already-resolved value.
+                "axelix.master.auth.options.oauth2.issuer-uri=http://unreachable.provider.test",
+                "axelix.master.auth.options.oauth2.client-id=test-client",
+                "axelix.master.auth.options.oauth2.client-secret=test-secret",
+                "axelix.master.auth.options.oauth2.base-url=http://localhost:3000"
+            })
+    @Nested
+    class WhenOAuth2ProviderUnreachable {
+
+        // The OIDC option is dropped so that the UI still loads and local/super-admin login remain usable.
+        private static final String EXPECTED_JSON =
+                // language=json
+                """
+                {
+                  "authenticationOptions": [
+                    {
+                      "type": "super-admin"
+                    },
+                    {
+                      "type": "local"
+                    }
+                  ],
+                  "isMcpServerEnabled" : false
+                }
+                """;
+
+        @Autowired
+        private TestRestTemplate restTemplate;
+
+        @MockitoBean
+        private OidcMetadataProvider oidcMetadataProvider;
+
+        @BeforeEach
+        void prepare() {
+            Mockito.when(oidcMetadataProvider.getAuthorizationEndpoint())
+                    .thenThrow(new OidcMetadataUnavailableException("http://unreachable.provider.test"));
+        }
+
+        @Test
+        void shouldOmitOidcAndReturnOtherProviders() {
+            ResponseEntity<String> response = restTemplate.getForEntity("/api/external/settings", String.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThatJson(response.getBody()).when(Option.IGNORING_ARRAY_ORDER).isEqualTo(EXPECTED_JSON);
         }
     }
 }


### PR DESCRIPTION
…413)

When the OIDC provider was unreachable, the authorization endpoint was fetched lazily during Jackson serialization of GET /settings. The thrown OidcMetadataUnavailableException was wrapped mid-serialization and mapped to a 500, failing the entire settings response and blocking UI init, including local/super-admin login.

Now an OIDC option whose metadata cannot currently be resolved is omitted from the response via AuthenticationOption#isAvailable, so /settings still returns 200 with the remaining options and the UI loads. The metadata Lazy does not cache failures, so the option reappears once the provider is back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings now omit unavailable authentication options.
  * The settings endpoint remains available when an OAuth2/OIDC provider cannot be reached.
  * Other authentication options continue to be displayed normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->