### PR TITLE
GH-1445 Detection of blocking `KafkaTemplate` calls inside transactions for SB-3

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.Ordered;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.web.client.RestTemplate;
 
 import com.axelixlabs.axelix.sbs.spring.core.config.TransactionMonitoringConfigurationProperties;
@@ -51,6 +52,7 @@ import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.pagination.Co
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.pagination.Log4j2InMemoryPaginationAppenderRegistrar;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.pagination.LogbackInMemoryPaginationAppenderRegistrar;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.http.ExternalCallRestTemplateCustomizer;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.kafka.KafkaTemplateMonitoringBeanPostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.DefaultTransactionStatsCollector;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionStatsCollector;
@@ -133,6 +135,17 @@ public class TransactionMonitoringAutoConfiguration {
         public ExternalCallRestTemplateCustomizer axelixRestTemplateCustomizer(
                 TransactionAccessor transactionAccessor) {
             return new ExternalCallRestTemplateCustomizer(transactionAccessor);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(KafkaTemplate.class)
+    static class KafkaMonitoringConfiguration {
+
+        @Bean
+        public KafkaTemplateMonitoringBeanPostProcessor axelixKafkaTemplateMonitoringBeanPostProcessor(
+                TransactionAccessor transactionAccessor) {
+            return new KafkaTemplateMonitoringBeanPostProcessor(transactionAccessor);
         }
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/kafka/ExternalCallKafkaSendInterceptor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/kafka/ExternalCallKafkaSendInterceptor.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence.kafka;
+
+import java.lang.reflect.Method;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+
+import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+
+/**
+ * {@link MethodInterceptor} that records every {@code send} performed by a {@link KafkaTemplate} while a
+ * transaction is open, so that the Kafka calls made inside the transaction become visible and feed its
+ * min/max/avg statistics. It measures the {@code send()} call itself — the time it blocks the transaction
+ * thread.
+ * <p>
+ * Whether the call actually belongs to a transaction is decided by the {@link TransactionAccessor}: calls
+ * made outside of any transaction are silently dropped by it.
+ *
+ * @author Sergey Cherkasov
+ */
+class ExternalCallKafkaSendInterceptor implements MethodInterceptor {
+
+    private final TransactionAccessor transactionAccessor;
+    private final KafkaTemplate<?, ?> kafkaTemplate;
+
+    ExternalCallKafkaSendInterceptor(TransactionAccessor transactionAccessor, KafkaTemplate<?, ?> kafkaTemplate) {
+        this.transactionAccessor = transactionAccessor;
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    @Override
+    @Nullable
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+        Method method = invocation.getMethod();
+
+        if (!isSendMethod(method)) {
+            return invocation.proceed();
+        }
+
+        String target = resolveTarget(method, invocation.getArguments());
+        long startNanos = System.nanoTime();
+
+        try {
+            return invocation.proceed();
+        } finally {
+            long duration = System.nanoTime() - startNanos;
+            transactionAccessor.recordExternalCall(
+                    new SimpleExternalCallRecord(TypeExternalCall.KAFKA, target, duration / 1_000_000));
+        }
+    }
+
+    // Matches only message sends. Excludes sendOffsetsToTransaction, which also starts with "send" but
+    // commits consumer offsets into a Kafka transaction rather than publishing a message (it has no topic).
+    private static boolean isSendMethod(Method method) {
+        String name = method.getName();
+        return name.equals("send") || name.equals("sendDefault");
+    }
+
+    private String resolveTarget(Method method, Object[] arguments) {
+        if (method.getName().equals("sendDefault")) {
+            return defaultTopicOrEmpty();
+        }
+
+        if (arguments.length > 0) {
+            Object first = arguments[0];
+
+            if (first instanceof String topicName) {
+                return topicName;
+            }
+            if (first instanceof ProducerRecord<?, ?> producerRecord) {
+                return producerRecord.topic();
+            }
+            if (first instanceof Message<?> message) {
+                Object topic = message.getHeaders().get(KafkaHeaders.TOPIC);
+                return topic != null ? topic.toString() : defaultTopicOrEmpty();
+            }
+        }
+
+        return "";
+    }
+
+    private String defaultTopicOrEmpty() {
+        String defaultTopic = kafkaTemplate.getDefaultTopic();
+        return defaultTopic != null ? defaultTopic : "";
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/kafka/KafkaTemplateMonitoringBeanPostProcessor.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/kafka/KafkaTemplateMonitoringBeanPostProcessor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence.kafka;
+
+import org.jspecify.annotations.NonNull;
+
+import org.springframework.aop.Advisor;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+
+/**
+ * {@link BeanPostProcessor} that wraps every {@link KafkaTemplate} bean with a proxy carrying the
+ * {@link ExternalCallKafkaSendInterceptor}, so that producer sends performed while a transaction is open are
+ * recorded as external calls.
+ *
+ * @author Sergey Cherkasov
+ */
+public class KafkaTemplateMonitoringBeanPostProcessor implements BeanPostProcessor {
+
+    private final TransactionAccessor transactionAccessor;
+
+    public KafkaTemplateMonitoringBeanPostProcessor(TransactionAccessor transactionAccessor) {
+        this.transactionAccessor = transactionAccessor;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(@NonNull Object bean, @NonNull String beanName) throws BeansException {
+        if (!(bean instanceof KafkaTemplate<?, ?> kafkaTemplate) || isAlreadyInstrumented(bean)) {
+            return bean;
+        }
+
+        ProxyFactory proxyFactory = new ProxyFactory(bean);
+        proxyFactory.setProxyTargetClass(true);
+        proxyFactory.addAdvice(new ExternalCallKafkaSendInterceptor(transactionAccessor, kafkaTemplate));
+
+        return proxyFactory.getProxy(kafkaTemplate.getClass().getClassLoader());
+    }
+
+    private static boolean isAlreadyInstrumented(Object bean) {
+        if (bean instanceof Advised advised) {
+            for (Advisor advisor : advised.getAdvisors()) {
+                if (advisor.getAdvice() instanceof ExternalCallKafkaSendInterceptor) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -28,6 +28,7 @@ import org.springframework.boot.logging.LoggingSystem;
 import org.springframework.boot.logging.log4j2.Log4J2LoggingSystem;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.web.client.RestTemplate;
 
 import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringAutoConfiguration.Log4j2InMemoryPaginationAppenderConfiguration;
@@ -35,6 +36,7 @@ import com.axelixlabs.axelix.sbs.spring.autoconfiguration.TransactionMonitoringA
 import com.axelixlabs.axelix.sbs.spring.core.persistence.ProxyingDataSourceBeanPostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.TransactionMonitoringBeanPostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.http.ExternalCallRestTemplateCustomizer;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.kafka.KafkaTemplateMonitoringBeanPostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionStatsCollector;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,6 +63,7 @@ class TransactionMonitoringAutoConfigurationTest {
             assertThat(context).hasSingleBean(TransactionMonitoringBeanPostProcessor.class);
             assertThat(context).hasSingleBean(ProxyingDataSourceBeanPostProcessor.class);
             assertThat(context).hasSingleBean(ExternalCallRestTemplateCustomizer.class);
+            assertThat(context).hasSingleBean(KafkaTemplateMonitoringBeanPostProcessor.class);
             assertThat(context).doesNotHaveBean(LogbackInMemoryPaginationAppenderConfiguration.class);
         });
     }
@@ -75,6 +78,7 @@ class TransactionMonitoringAutoConfigurationTest {
                     assertThat(context).doesNotHaveBean(TransactionMonitoringBeanPostProcessor.class);
                     assertThat(context).doesNotHaveBean(ProxyingDataSourceBeanPostProcessor.class);
                     assertThat(context).doesNotHaveBean(ExternalCallRestTemplateCustomizer.class);
+                    assertThat(context).doesNotHaveBean(KafkaTemplateMonitoringBeanPostProcessor.class);
                 });
     }
 
@@ -85,6 +89,16 @@ class TransactionMonitoringAutoConfigurationTest {
                 .run(context -> {
                     assertThat(context).hasSingleBean(TransactionMonitoringAutoConfiguration.class);
                     assertThat(context).doesNotHaveBean(ExternalCallRestTemplateCustomizer.class);
+                });
+    }
+
+    @Test
+    void shouldNotRegisterKafkaTemplateBeanPostProcessor_whenKafkaTemplateIsAbsent() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader(KafkaTemplate.class))
+                .run(context -> {
+                    assertThat(context).hasSingleBean(TransactionMonitoringAutoConfiguration.class);
+                    assertThat(context).doesNotHaveBean(KafkaTemplateMonitoringBeanPostProcessor.class);
                 });
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/kafka/ExternalCallKafkaSendInterceptorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/kafka/ExternalCallKafkaSendInterceptorTest.java
@@ -38,10 +38,12 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.TestPropertySource;
 
 import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
+import com.axelixlabs.axelix.sbs.spring.core.IgnoreTestContextArchitecture;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionExecutionProfile;
 
+import static com.axelixlabs.axelix.sbs.spring.core.IgnoreTestContextArchitecture.NO_SIBLINGS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -59,6 +61,7 @@ import static org.mockito.Mockito.when;
             "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
             "spring.kafka.template.default-topic=default-topic"
         })
+@IgnoreTestContextArchitecture(reason = NO_SIBLINGS)
 class ExternalCallKafkaSendInterceptorTest {
 
     @Autowired

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/kafka/ExternalCallKafkaSendInterceptorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/kafka/ExternalCallKafkaSendInterceptorTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence.kafka;
+
+import java.util.Map;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.KafkaOperations;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.context.TestPropertySource;
+
+import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionExecutionProfile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Integration tests for {@link ExternalCallKafkaSendInterceptor}.
+ *
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest
+@EmbeddedKafka(topics = {"orders", "events", "notifications", "counted", "ignored", "default-topic"})
+@TestPropertySource(
+        properties = {
+            "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+            "spring.kafka.template.default-topic=default-topic"
+        })
+class ExternalCallKafkaSendInterceptorTest {
+
+    @Autowired
+    private TransactionAccessor transactionAccessor;
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @AfterEach
+    void clearTransactionStack() {
+        transactionAccessor.clearAll();
+    }
+
+    @Test
+    void shouldRecordSendInsideTransaction() {
+        // given.
+        transactionAccessor.recordNewTransactionStarted();
+
+        // when.
+        kafkaTemplate.send("orders", "payload");
+
+        // then.
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+        assertThat(profile.getRecordedExternalCalls()).singleElement().satisfies(call -> {
+            assertThat(call.getType()).isEqualTo(TypeExternalCall.KAFKA);
+            assertThat(call.getTarget()).isEqualTo("orders");
+            assertThat(call.getDurationMs()).isGreaterThanOrEqualTo(0L);
+        });
+    }
+
+    @Test
+    void shouldRecordEachSend() {
+        // given.
+        transactionAccessor.recordNewTransactionStarted();
+
+        // when.
+        kafkaTemplate.send("orders", "one");
+        kafkaTemplate.send("orders", "two");
+
+        // then. Every send is tracked, not just the last one.
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+        assertThat(profile.getRecordedExternalCalls()).hasSize(2);
+    }
+
+    @Test
+    void shouldResolveTargetFromProducerRecord() {
+        // given.
+        transactionAccessor.recordNewTransactionStarted();
+
+        // when.
+        kafkaTemplate.send(new ProducerRecord<>("events", "key", "value"));
+
+        // then.
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+        assertThat(profile.getRecordedExternalCalls())
+                .singleElement()
+                .extracting(SimpleExternalCallRecord::getTarget)
+                .isEqualTo("events");
+    }
+
+    @Test
+    void shouldResolveTargetFromMessageHeader() {
+        // given.
+        transactionAccessor.recordNewTransactionStarted();
+        Message<String> message = MessageBuilder.withPayload("payload")
+                .setHeader(KafkaHeaders.TOPIC, "notifications")
+                .build();
+
+        // when.
+        kafkaTemplate.send(message);
+
+        // then.
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+        assertThat(profile.getRecordedExternalCalls())
+                .singleElement()
+                .extracting(SimpleExternalCallRecord::getTarget)
+                .isEqualTo("notifications");
+    }
+
+    @Test
+    void shouldResolveDefaultTopicForMessageWithoutTopicHeader() {
+        // given.
+        transactionAccessor.recordNewTransactionStarted();
+        Message<String> message = MessageBuilder.withPayload("payload").build();
+
+        // when.
+        kafkaTemplate.send(message);
+
+        // then.
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+        assertThat(profile.getRecordedExternalCalls())
+                .singleElement()
+                .extracting(SimpleExternalCallRecord::getTarget)
+                .isEqualTo("default-topic");
+    }
+
+    @Test
+    void shouldResolveDefaultTopicForSendDefault() {
+        // given.
+        transactionAccessor.recordNewTransactionStarted();
+
+        // when.
+        kafkaTemplate.sendDefault("payload");
+
+        // then.
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+        assertThat(profile.getRecordedExternalCalls())
+                .singleElement()
+                .extracting(SimpleExternalCallRecord::getTarget)
+                .isEqualTo("default-topic");
+    }
+
+    @Test
+    void shouldDropSendMadeOutsideTransaction() {
+        // given. A send performed while no transaction is open, then one within a transaction.
+        kafkaTemplate.send("ignored", "payload");
+        transactionAccessor.recordNewTransactionStarted();
+
+        // when.
+        kafkaTemplate.send("counted", "payload");
+
+        // then. Only the send made within the transaction is recorded.
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+        assertThat(profile.getRecordedExternalCalls())
+                .singleElement()
+                .extracting(SimpleExternalCallRecord::getTarget)
+                .isEqualTo("counted");
+    }
+
+    @Test
+    void shouldNotRecordNonSendMethods() {
+        // given.
+        transactionAccessor.recordNewTransactionStarted();
+
+        // when.
+        kafkaTemplate.flush();
+
+        // then.
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+        assertThat(profile.getRecordedExternalCalls()).isEmpty();
+    }
+
+    @Test
+    void shouldNotRecordSendOffsetsToTransaction() throws Throwable {
+        // given. sendOffsetsToTransaction also starts with "send" but is not a message send.
+        ExternalCallKafkaSendInterceptor subject =
+                new ExternalCallKafkaSendInterceptor(transactionAccessor, kafkaTemplate);
+        MethodInvocation invocation = mock(MethodInvocation.class);
+        when(invocation.getMethod())
+                .thenReturn(KafkaOperations.class.getMethod(
+                        "sendOffsetsToTransaction", Map.class, ConsumerGroupMetadata.class));
+        transactionAccessor.recordNewTransactionStarted();
+
+        // when.
+        subject.invoke(invocation);
+
+        // then. The call is passed through without being recorded.
+        verify(invocation).proceed();
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+        assertThat(profile.getRecordedExternalCalls()).isEmpty();
+    }
+
+    @TestConfiguration
+    static class KafkaMonitoringTestConfiguration {
+
+        @Bean
+        public TransactionAccessor transactionAccessor() {
+            return new TransactionAccessor();
+        }
+
+        @Bean
+        public KafkaTemplateMonitoringBeanPostProcessor kafkaTemplateMonitoringBeanPostProcessor(
+                TransactionAccessor transactionAccessor) {
+            return new KafkaTemplateMonitoringBeanPostProcessor(transactionAccessor);
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/kafka/KafkaTemplateMonitoringBeanPostProcessorTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/kafka/KafkaTemplateMonitoringBeanPostProcessorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence.kafka;
+
+import java.util.Arrays;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link KafkaTemplateMonitoringBeanPostProcessor}.
+ *
+ * @author Sergey Cherkasov
+ */
+class KafkaTemplateMonitoringBeanPostProcessorTest {
+
+    private final KafkaTemplateMonitoringBeanPostProcessor subject =
+            new KafkaTemplateMonitoringBeanPostProcessor(new TransactionAccessor());
+
+    @Test
+    void shouldInstrumentKafkaTemplate() {
+        // given.
+        KafkaTemplate<String, String> kafkaTemplate = newKafkaTemplate();
+
+        // when.
+        Object result = subject.postProcessAfterInitialization(kafkaTemplate, "kafkaTemplate");
+
+        // then.
+        assertThat(AopUtils.isAopProxy(result)).isTrue();
+        assertThat(result).isInstanceOf(KafkaTemplate.class);
+        assertThat(((Advised) result).getAdvisors())
+                .anyMatch(advisor -> advisor.getAdvice() instanceof ExternalCallKafkaSendInterceptor);
+    }
+
+    @Test
+    void shouldNotInstrumentTheSameKafkaTemplateTwice() {
+        // given.
+        KafkaTemplate<String, String> kafkaTemplate = newKafkaTemplate();
+        Object instrumented = subject.postProcessAfterInitialization(kafkaTemplate, "kafkaTemplate");
+
+        // when.
+        Object result = subject.postProcessAfterInitialization(instrumented, "kafkaTemplate");
+
+        // then. A second proxy would make every send be recorded twice.
+        assertThat(result).isSameAs(instrumented);
+        long interceptorCount = Arrays.stream(((Advised) result).getAdvisors())
+                .filter(advisor -> advisor.getAdvice() instanceof ExternalCallKafkaSendInterceptor)
+                .count();
+        assertThat(interceptorCount).isEqualTo(1);
+    }
+
+    private static KafkaTemplate<String, String> newKafkaTemplate() {
+        ProducerFactory<String, String> producerFactory =
+                () -> new MockProducer<>(true, new StringSerializer(), new StringSerializer());
+        return new KafkaTemplate<>(producerFactory);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kafka-based monitoring for message `send` operations, including topic/target resolution and send duration tracking.
  * Kafka templates are now automatically instrumented when Kafka is available.
* **Bug Fixes**
  * Monitoring is skipped when no transaction is active and for non-send operations.
  * Prevents duplicate instrumentation; unsupported topic info results in an empty target, and `sendOffsetsToTransaction` is passed through without recording.
* **Tests**
  * Expanded Kafka monitoring, auto-configuration conditional registration, and AOP proxy/idempotency coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->