### PR TITLE
GH-1452 Detection of blocking `FeignClient` calls inside transactions for SB-3

### DIFF
--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfiguration.java
@@ -22,6 +22,7 @@ import java.util.List;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.servlet.DispatcherType;
 
+import feign.Feign;
 import org.hibernate.jpa.boot.spi.IntegratorProvider;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -33,6 +34,7 @@ import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomi
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
@@ -54,6 +56,7 @@ import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.NPlusOneInteg
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.pagination.ConditionalOnLoggingSystem;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.pagination.Log4j2InMemoryPaginationAppenderRegistrar;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.hibernate.pagination.LogbackInMemoryPaginationAppenderRegistrar;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.http.ExternalCallFeignCapability;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.http.ExternalCallRestTemplateCustomizer;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.DefaultTransactionStatsCollector;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
@@ -150,6 +153,16 @@ public class TransactionMonitoringAutoConfiguration {
         public ExternalCallRestTemplateCustomizer axelixRestTemplateCustomizer(
                 TransactionAccessor transactionAccessor) {
             return new ExternalCallRestTemplateCustomizer(transactionAccessor);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass({Feign.class, FeignClient.class})
+    static class FeignMonitoringConfiguration {
+
+        @Bean
+        public ExternalCallFeignCapability axelixFeignCapability(TransactionAccessor transactionAccessor) {
+            return new ExternalCallFeignCapability(transactionAccessor);
         }
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallFeignCapability.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallFeignCapability.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence.http;
+
+import feign.Capability;
+import feign.Client;
+
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+
+/**
+ * {@link Capability} that decorates the {@link Client} of every Feign client with the
+ * {@link ExternalCallFeignClient}, so that the calls performed while a transaction is open are recorded as
+ * external calls.
+ *
+ * @author Sergey Cherkasov
+ */
+public class ExternalCallFeignCapability implements Capability {
+
+    private final TransactionAccessor transactionAccessor;
+
+    public ExternalCallFeignCapability(TransactionAccessor transactionAccessor) {
+        this.transactionAccessor = transactionAccessor;
+    }
+
+    @Override
+    public Client enrich(Client client) {
+        return client instanceof ExternalCallFeignClient
+                ? client
+                : new ExternalCallFeignClient(client, transactionAccessor);
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallFeignClient.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallFeignClient.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence.http;
+
+import java.io.IOException;
+import java.net.URI;
+
+import feign.Client;
+import feign.Request;
+import feign.Request.Options;
+import feign.Response;
+
+import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.SimpleExternalCallRecord;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+
+/**
+ * {@link Client} that records every call performed by a Feign client while a transaction is open, so that
+ * the blocking calls holding the transaction become visible. Every such call is recorded as a
+ * {@link TypeExternalCall#HTTP_CLIENT} one, just like a {@code RestTemplate} call is.
+ *
+ * @author Sergey Cherkasov
+ */
+class ExternalCallFeignClient implements Client {
+
+    private final Client delegate;
+    private final TransactionAccessor transactionAccessor;
+
+    ExternalCallFeignClient(Client delegate, TransactionAccessor transactionAccessor) {
+        this.delegate = delegate;
+        this.transactionAccessor = transactionAccessor;
+    }
+
+    @Override
+    public Response execute(Request request, Options options) throws IOException {
+        long startNanos = System.nanoTime();
+
+        try {
+            return delegate.execute(request, options);
+        } finally {
+            long duration = System.nanoTime() - startNanos;
+            try {
+                transactionAccessor.recordExternalCall(new SimpleExternalCallRecord(
+                        TypeExternalCall.HTTP_CLIENT, resolveTarget(request), duration / 1_000_000));
+            } catch (RuntimeException ignored) {
+                // Instrumentation must never replace the Feign result: swallow any recording failure.
+            }
+        }
+    }
+
+    private static String resolveTarget(Request request) {
+        String method = request.httpMethod().name();
+
+        try {
+            URI uri = URI.create(request.url());
+            String host = uri.getHost();
+            String path = uri.getPath() == null ? "" : uri.getPath();
+
+            if (host != null) {
+                return method + " " + host + path;
+            }
+            return path.isEmpty() ? method : method + " " + path;
+        } catch (IllegalArgumentException e) {
+            return method;
+        }
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/TransactionMonitoringAutoConfigurationTest.java
@@ -19,6 +19,7 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
 import jakarta.persistence.EntityManagerFactory;
 
+import feign.Feign;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -36,6 +37,7 @@ import com.axelixlabs.axelix.sbs.spring.core.master.insights.JpaEntitiesProfileP
 import com.axelixlabs.axelix.sbs.spring.core.persistence.ProxyingDataSourceBeanPostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.TransactionMonitoringBeanPostProcessor;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.entities.DefaultJpaEntitiesProfileProvider;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.http.ExternalCallFeignCapability;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.http.ExternalCallRestTemplateCustomizer;
 import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionStatsCollector;
 
@@ -63,6 +65,7 @@ class TransactionMonitoringAutoConfigurationTest {
             assertThat(context).hasSingleBean(TransactionMonitoringBeanPostProcessor.class);
             assertThat(context).hasSingleBean(ProxyingDataSourceBeanPostProcessor.class);
             assertThat(context).hasSingleBean(ExternalCallRestTemplateCustomizer.class);
+            assertThat(context).hasSingleBean(ExternalCallFeignCapability.class);
             assertThat(context).doesNotHaveBean(LogbackInMemoryPaginationAppenderConfiguration.class);
         });
     }
@@ -77,6 +80,7 @@ class TransactionMonitoringAutoConfigurationTest {
                     assertThat(context).doesNotHaveBean(TransactionMonitoringBeanPostProcessor.class);
                     assertThat(context).doesNotHaveBean(ProxyingDataSourceBeanPostProcessor.class);
                     assertThat(context).doesNotHaveBean(ExternalCallRestTemplateCustomizer.class);
+                    assertThat(context).doesNotHaveBean(ExternalCallFeignCapability.class);
                 });
     }
 
@@ -104,6 +108,14 @@ class TransactionMonitoringAutoConfigurationTest {
     @Test
     void shouldNotRegisterJpaEntitiesProfileProvider_whenEntityManagerFactoryIsMissing() {
         contextRunner.run(context -> assertThat(context).doesNotHaveBean(JpaEntitiesProfileProvider.class));
+    }
+
+    @Test
+    void shouldNotRegisterFeignCapability_whenFeignIsAbsent() {
+        contextRunner.withClassLoader(new FilteredClassLoader(Feign.class)).run(context -> {
+            assertThat(context).hasSingleBean(TransactionMonitoringAutoConfiguration.class);
+            assertThat(context).doesNotHaveBean(ExternalCallFeignCapability.class);
+        });
     }
 
     @Test // GH-1254

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallFeignCapabilityTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallFeignCapabilityTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence.http;
+
+import feign.Client;
+import org.junit.jupiter.api.Test;
+
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ExternalCallFeignCapability}.
+ *
+ * @author Sergey Cherkasov
+ */
+class ExternalCallFeignCapabilityTest {
+
+    private final ExternalCallFeignCapability subject = new ExternalCallFeignCapability(new TransactionAccessor());
+
+    @Test
+    void shouldInstrumentTheClient() {
+        // given.
+        Client client = new Client.Default(null, null);
+
+        // when.
+        Client result = subject.enrich(client);
+
+        // then.
+        assertThat(result).isInstanceOf(ExternalCallFeignClient.class);
+    }
+
+    @Test
+    void shouldNotInstrumentTheSameClientTwice() {
+        // given.
+        Client instrumented = subject.enrich(new Client.Default(null, null));
+
+        // when.
+        Client result = subject.enrich(instrumented);
+
+        // then. A second decoration would make every call be recorded twice.
+        assertThat(result).isSameAs(instrumented);
+    }
+}

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallFeignClientTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/persistence/http/ExternalCallFeignClientTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.sbs.spring.core.persistence.http;
+
+import java.io.IOException;
+import java.util.Map;
+
+import feign.Client;
+import feign.Request;
+import feign.Request.HttpMethod;
+import feign.Request.Options;
+import feign.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import com.axelixlabs.axelix.common.domain.insights.TypeExternalCall;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionAccessor;
+import com.axelixlabs.axelix.sbs.spring.core.persistence.transaction.TransactionExecutionProfile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link ExternalCallFeignClient}.
+ *
+ * @author Sergey Cherkasov
+ */
+class ExternalCallFeignClientTest {
+
+    private final TransactionAccessor transactionAccessor = new TransactionAccessor();
+
+    @AfterEach
+    void tearDown() {
+        // The accessor keeps its state in a static ThreadLocal, so reset it to keep tests isolated.
+        transactionAccessor.clearAll();
+    }
+
+    @Test
+    void shouldRecordTheCallIntoTheActiveTransaction() throws IOException {
+        // given.
+        ExternalCallFeignClient subject = new ExternalCallFeignClient(okDelegate(), transactionAccessor);
+        transactionAccessor.recordNewTransactionStarted();
+
+        // when.
+        subject.execute(request("http://payments/charge?id=1"), new Options());
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+
+        // then. The host of a Feign url is the name of the called service, so it is a part of the target.
+        assertThat(profile.getRecordedExternalCalls()).singleElement().satisfies(recorded -> {
+            assertThat(recorded.getType()).isEqualTo(TypeExternalCall.HTTP_CLIENT);
+            assertThat(recorded.getTarget()).isEqualTo("GET payments/charge");
+            assertThat(recorded.getDurationMs()).isNotNegative();
+        });
+    }
+
+    @Test
+    void shouldSanitizeTheTargetStrippingCredentialsQueryAndFragment() throws IOException {
+        // given.
+        ExternalCallFeignClient subject = new ExternalCallFeignClient(okDelegate(), transactionAccessor);
+        transactionAccessor.recordNewTransactionStarted();
+
+        // when.
+        subject.execute(request("http://user:pass@payments/charge?id=1#frag"), new Options());
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+
+        // then. Credentials, query and fragment must never leak into the recorded target.
+        assertThat(profile.getRecordedExternalCalls())
+                .singleElement()
+                .satisfies(recorded -> assertThat(recorded.getTarget()).isEqualTo("GET payments/charge"));
+    }
+
+    @Test
+    void shouldRecordOnlyThePathForARelativeUrl() throws IOException {
+        // given. A relative url has no host, so the fallback must still not persist the raw url with its query.
+        ExternalCallFeignClient subject = new ExternalCallFeignClient(okDelegate(), transactionAccessor);
+        transactionAccessor.recordNewTransactionStarted();
+
+        // when.
+        subject.execute(request("/charge?id=1"), new Options());
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+
+        // then.
+        assertThat(profile.getRecordedExternalCalls())
+                .singleElement()
+                .satisfies(recorded -> assertThat(recorded.getTarget()).isEqualTo("GET /charge"));
+    }
+
+    @Test
+    void shouldReturnTheResponseProducedByTheDelegate() throws IOException {
+        // given.
+        Response expectedResponse = response(request("http://payments/charge"));
+        ExternalCallFeignClient subject =
+                new ExternalCallFeignClient((request, options) -> expectedResponse, transactionAccessor);
+        transactionAccessor.recordNewTransactionStarted();
+
+        // when.
+        Response actualResponse = subject.execute(request("http://payments/charge"), new Options());
+
+        // then. The client is transparent: it hands back exactly what the delegate produced.
+        assertThat(actualResponse).isSameAs(expectedResponse);
+    }
+
+    @Test
+    void shouldStillRecordTheCallWhenTheDelegateFails() {
+        // given. A blocking call that fails still held the transaction open, so it must be recorded.
+        Client failing = (request, options) -> {
+            throw new IOException("connection reset");
+        };
+        ExternalCallFeignClient subject = new ExternalCallFeignClient(failing, transactionAccessor);
+        transactionAccessor.recordNewTransactionStarted();
+
+        // when.
+        assertThatThrownBy(() -> subject.execute(request("http://payments/charge"), new Options()))
+                .isInstanceOf(IOException.class)
+                .hasMessage("connection reset");
+
+        // then.
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+        assertThat(profile.getRecordedExternalCalls())
+                .singleElement()
+                .satisfies(recorded -> assertThat(recorded.getTarget()).isEqualTo("GET payments/charge"));
+    }
+
+    @Test
+    void shouldRecordNothingWhenThereIsNoActiveTransaction() throws IOException {
+        // given. No transaction was started, so the call blocks nothing.
+        ExternalCallFeignClient subject = new ExternalCallFeignClient(okDelegate(), transactionAccessor);
+
+        // when.
+        subject.execute(request("http://payments/charge"), new Options());
+        transactionAccessor.recordNewTransactionStarted();
+        TransactionExecutionProfile profile = transactionAccessor.recordTransactionCompletion();
+
+        // then.
+        assertThat(profile.getRecordedExternalCalls()).isEmpty();
+    }
+
+    private static Client okDelegate() {
+        return (request, options) -> response(request);
+    }
+
+    private static Request request(String url) {
+        return Request.create(HttpMethod.GET, url, Map.of(), null, null, null);
+    }
+
+    private static Response response(Request request) {
+        return Response.builder().status(200).request(request).build();
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transaction monitoring for external calls made through Feign clients.
  * Feign requests are now captured with HTTP method, destination/target, and call duration when a transaction is active.
  * Monitoring is auto-enabled when Feign is available and is not applied when Feign is absent.

* **Bug Fixes**
  * Failed Feign calls are still recorded for monitoring, without impacting call behavior.

* **Tests**
  * Expanded coverage to verify Feign capability/client behavior, idempotent instrumentation, and correct target/duration recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->