### PR TITLE
GH-1464 Rounded chart percentages on dashboard pages

### DIFF
--- a/master/front-end/src/components/Dashboard/DashboardDonutChart/DashboardLegendItem/index.tsx
+++ b/master/front-end/src/components/Dashboard/DashboardDonutChart/DashboardLegendItem/index.tsx
@@ -20,7 +20,7 @@ import styles from "./styles.module.css";
 interface IProps {
     circleColor: string;
     label: string;
-    value: string;
+    value: number;
 }
 
 export const DashboardLegendItem = ({ circleColor, label, value }: IProps) => {
@@ -33,7 +33,7 @@ export const DashboardLegendItem = ({ circleColor, label, value }: IProps) => {
                 className={styles.Circle}
             />
             <span className={styles.Label}>{label}:</span>
-            <span className={styles.Value}>{value}</span>
+            <span className={styles.Value}>{Math.round(value)}%</span>
         </div>
     );
 };

--- a/master/front-end/src/components/Dashboard/DashboardDonutChart/index.tsx
+++ b/master/front-end/src/components/Dashboard/DashboardDonutChart/index.tsx
@@ -76,7 +76,7 @@ const DEFAULT_COLORS = ["#2DD4BF", "#A78BFA", "#F59E0B", "#FB7185", "#4B9EFF"];
 export const DashboardDonutChart = ({ data, heading, rest, centre, onPieClick }: IProps) => {
     const chartData = data.map(({ categoryName, value }, index) => ({
         name: categoryName,
-        value,
+        value: value,
         fill: DEFAULT_COLORS[index % DEFAULT_COLORS.length],
     }));
 
@@ -120,7 +120,7 @@ export const DashboardDonutChart = ({ data, heading, rest, centre, onPieClick }:
 
                 <div className={styles.LegendWrapper}>
                     {chartData.map(({ name, fill, value }) => (
-                        <DashboardLegendItem key={name} circleColor={fill} label={name} value={`${value}%`} />
+                        <DashboardLegendItem key={name} circleColor={fill} label={name} value={value} />
                     ))}
                 </div>
             </div>

--- a/master/front-end/src/helpers/dashboard/dashboardOverview.ts
+++ b/master/front-end/src/helpers/dashboard/dashboardOverview.ts
@@ -30,13 +30,10 @@ export const prepareHealthStatusesChartData = (statuses: IHealthStatus["statuses
 
 export const prepareDistributionDataPerChart = (distributions: IDistribution[]): IExtendedChartData[] => {
     return distributions.map(({ softwareComponentName, versions }) => {
-        const parsedVersions = Object.entries(versions).map(
-            ([version, value]) =>
-                ({
-                    categoryName: version,
-                    value: value,
-                }) as IChartData,
-        );
+        const parsedVersions: IChartData[] = Object.entries(versions).map(([version, value]) => ({
+            categoryName: version,
+            value: value,
+        }));
 
         return {
             softwareComponentName: softwareComponentName,

--- a/master/front-end/src/pages/Dashboard/DashboardJava/DashboardProjectLeyden/index.tsx
+++ b/master/front-end/src/pages/Dashboard/DashboardJava/DashboardProjectLeyden/index.tsx
@@ -40,7 +40,7 @@ export const DashboardProjectLeyden = ({ projectLeydenData }: IProps) => {
                 subtitle: t("Dashboard.Java.leydenChartSubtitle"),
             }}
             centre={{
-                title: `${totalProjectLeydenAdoption}%`,
+                title: `${Math.round(totalProjectLeydenAdoption)}%`,
                 subtitle: t("Dashboard.Java.leydenChartCentreSubtitle"),
             }}
             rest={{


### PR DESCRIPTION
Closes GH-1464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard donut chart legends now display rounded whole-number percentages consistently.
  * Project Leyden adoption percentages in the chart center are now rounded for clearer presentation.

* **Refactor**
  * Improved chart data preparation for more consistent rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->