### PR TITLE
GH-1485 Fixes Conflict with spring-boot-starter-websocket.

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -24,11 +24,10 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskHolder;
 
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
@@ -53,6 +52,9 @@ import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskReschedul
 @ConditionalOnAvailableEndpoint(endpoint = AxelixScheduledTasksEndpoint.class)
 public class ScheduledTaskManagementAutoConfiguration {
 
+    public static final String THREAD_POOL_TASK_EXECUTOR_QUALIFIER = "schedulingThreadPoolTaskExecutor";
+    public static final String TASK_SCHEDULER_QUALIFIER = "schedulingTaskScheduler";
+
     @Bean
     public ScheduledTasksRegistry scheduledTasksRegistry(ObjectProvider<ScheduledTaskHolder> taskHolders) {
         return new ScheduledTasksRegistry(taskHolders.orderedStream().collect(Collectors.toList()));
@@ -62,19 +64,17 @@ public class ScheduledTaskManagementAutoConfiguration {
     public ScheduledTaskService scheduledTaskService(
             ScheduledTasksRegistry scheduledTasksRegistry,
             List<TaskRescheduler> taskReschedulers,
-            @Qualifier("axelixThreadPoolTaskExecutor") ThreadPoolTaskExecutor threadPoolTaskExecutor) {
+            @Qualifier(THREAD_POOL_TASK_EXECUTOR_QUALIFIER) ThreadPoolTaskExecutor threadPoolTaskExecutor) {
         return new ScheduledTaskService(scheduledTasksRegistry, taskReschedulers, threadPoolTaskExecutor);
     }
 
     @Bean
-    @ConditionalOnBean(TaskScheduler.class)
-    public TaskRescheduler intervalBasedTaskRescheduler(TaskScheduler scheduler) {
+    public TaskRescheduler intervalBasedTaskRescheduler(@Qualifier(TASK_SCHEDULER_QUALIFIER) TaskScheduler scheduler) {
         return new IntervalBasedTaskRescheduler(scheduler);
     }
 
     @Bean
-    @ConditionalOnBean(TaskScheduler.class)
-    public TaskRescheduler triggerBasedTaskRescheduler(TaskScheduler scheduler) {
+    public TaskRescheduler triggerBasedTaskRescheduler(@Qualifier(TASK_SCHEDULER_QUALIFIER) TaskScheduler scheduler) {
         return new TriggerBasedTaskRescheduler(scheduler);
     }
 
@@ -90,8 +90,16 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean(name = "axelixThreadPoolTaskExecutor")
-    public ThreadPoolTaskExecutor axelixThreadPoolTaskExecutor() {
+    @Qualifier(TASK_SCHEDULER_QUALIFIER)
+    public ThreadPoolTaskScheduler schedulingTaskScheduler() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(1);
+        return taskScheduler;
+    }
+
+    @Bean
+    @Qualifier(THREAD_POOL_TASK_EXECUTOR_QUALIFIER)
+    public ThreadPoolTaskExecutor schedulingThreadPoolTaskExecutor() {
         ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
         threadPoolTaskExecutor.setCorePoolSize(1);
         threadPoolTaskExecutor.setMaxPoolSize(3);

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -58,8 +59,10 @@ public class ScheduledTaskManagementAutoConfiguration {
 
     @Bean
     public ScheduledTaskService scheduledTaskService(
-            ScheduledTasksRegistry scheduledTasksRegistry, List<TaskRescheduler> taskReschedulers) {
-        return new ScheduledTaskService(scheduledTasksRegistry, taskReschedulers, createThreadPoolExecutor());
+            ScheduledTasksRegistry scheduledTasksRegistry,
+            List<TaskRescheduler> taskReschedulers,
+            @Qualifier("axelixThreadPoolTaskExecutor") ThreadPoolTaskExecutor threadPoolTaskExecutor) {
+        return new ScheduledTaskService(scheduledTasksRegistry, taskReschedulers, threadPoolTaskExecutor);
     }
 
     @Bean
@@ -85,13 +88,15 @@ public class ScheduledTaskManagementAutoConfiguration {
         return new DefaultScheduledTasksAssembler(scheduledTasksRegistry);
     }
 
-    private static ThreadPoolTaskExecutor createThreadPoolExecutor() {
+    @Bean
+    public ThreadPoolTaskExecutor axelixThreadPoolTaskExecutor() {
         ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
         threadPoolTaskExecutor.setCorePoolSize(1);
         threadPoolTaskExecutor.setMaxPoolSize(3);
         threadPoolTaskExecutor.setAllowCoreThreadTimeOut(false);
         threadPoolTaskExecutor.setPrestartAllCoreThreads(true);
-        threadPoolTaskExecutor.initialize();
+        threadPoolTaskExecutor.setAwaitTerminationSeconds(30);
+        threadPoolTaskExecutor.setWaitForTasksToCompleteOnShutdown(true);
         return threadPoolTaskExecutor;
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -89,6 +90,7 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(name = "axelixThreadPoolTaskExecutor")
     public ThreadPoolTaskExecutor axelixThreadPoolTaskExecutor() {
         ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
         threadPoolTaskExecutor.setCorePoolSize(1);

--- a/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-2-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -44,6 +44,7 @@ import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskReschedul
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
+ * @author Dmitry Kiselev
  * @since 14.10.2025
  */
 @AutoConfiguration
@@ -57,13 +58,8 @@ public class ScheduledTaskManagementAutoConfiguration {
 
     @Bean
     public ScheduledTaskService scheduledTaskService(
-            ScheduledTasksRegistry scheduledTasksRegistry,
-            List<TaskRescheduler> taskReschedulers,
-            ObjectProvider<ThreadPoolTaskExecutor> taskExecutor) {
-        return new ScheduledTaskService(
-                scheduledTasksRegistry,
-                taskReschedulers,
-                taskExecutor.getIfAvailable() != null ? taskExecutor.getIfAvailable() : createThreadPoolExecutor());
+            ScheduledTasksRegistry scheduledTasksRegistry, List<TaskRescheduler> taskReschedulers) {
+        return new ScheduledTaskService(scheduledTasksRegistry, taskReschedulers, createThreadPoolExecutor());
     }
 
     @Bean

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -88,7 +88,7 @@ class ScheduledTaskManagementAutoConfigurationTest {
     }
 
     @Test
-    void shouldActivateWithoutReschedulers_whenSchedulingNotEnabled() {
+    void shouldActivateReschedulers_backedByLocalScheduler_whenSchedulingNotEnabled() {
         // given
         new ApplicationContextRunner()
                 .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
@@ -103,8 +103,11 @@ class ScheduledTaskManagementAutoConfigurationTest {
                     assertThat(context).hasSingleBean(AxelixScheduledTasksEndpoint.class);
                     assertThat(context).hasSingleBean(ThreadPoolTaskExecutor.class);
 
-                    // no scheduling -> reschedulers are not created
-                    assertThat(context).getBeans(TaskRescheduler.class).isEmpty();
+                    // reschedulers are backed by the locally-declared TaskScheduler, so they are
+                    // created even without @EnableScheduling
+                    assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
+                    assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
+                    assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
                 });
     }
 
@@ -128,7 +131,10 @@ class ScheduledTaskManagementAutoConfigurationTest {
                     assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
                     assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
                     assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
-                    assertThat(context).hasBean("axelixThreadPoolTaskExecutor");
+
+                    // our executor is registered alongside the user-declared ones, and the
+                    // ScheduledTaskService is wired via @Qualifier despite the ambiguity
+                    assertThat(context).getBeans(ThreadPoolTaskExecutor.class).hasSize(3);
                 });
     }
 

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -54,7 +54,11 @@ class ScheduledTaskManagementAutoConfigurationTest {
 
     @Test
     void shouldCreateAllBeansInDefaultScenario() {
+        // given: ApplicationContextRunner configured with required properties and scheduling enabled
+
+        // when
         contextRunner.run(context -> {
+            // then
             assertThat(context).hasSingleBean(ScheduledTasksRegistry.class);
             assertThat(context).hasSingleBean(ScheduledTaskService.class);
             assertThat(context).hasSingleBean(ScheduledTasksAssembler.class);
@@ -63,15 +67,19 @@ class ScheduledTaskManagementAutoConfigurationTest {
             assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
             assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
             assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
+            assertThat(context).hasSingleBean(ThreadPoolTaskExecutor.class);
         });
     }
 
     @Test
     void shouldNotActivateAutoConfiguration_withoutRequiredProperty() {
+        // given
         new ApplicationContextRunner()
                 .withUserConfiguration(EnableSchedulingConfig.class)
                 .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                // when
                 .run(context -> {
+                    // then
                     assertThat(context).doesNotHaveBean(ScheduledTaskManagementAutoConfiguration.class);
                     assertThat(context).doesNotHaveBean(ScheduledTasksRegistry.class);
                     assertThat(context).doesNotHaveBean(ScheduledTaskService.class);
@@ -81,32 +89,22 @@ class ScheduledTaskManagementAutoConfigurationTest {
 
     @Test
     void shouldActivateWithoutReschedulers_whenSchedulingNotEnabled() {
+        // given
         new ApplicationContextRunner()
                 .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
                 .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                // when
                 .run(context -> {
+                    // then
                     // read path is available even without @EnableScheduling
                     assertThat(context).hasSingleBean(ScheduledTasksRegistry.class);
                     assertThat(context).hasSingleBean(ScheduledTaskService.class);
                     assertThat(context).hasSingleBean(ScheduledTasksAssembler.class);
                     assertThat(context).hasSingleBean(AxelixScheduledTasksEndpoint.class);
+                    assertThat(context).hasSingleBean(ThreadPoolTaskExecutor.class);
 
                     // no scheduling -> reschedulers are not created
                     assertThat(context).getBeans(TaskRescheduler.class).isEmpty();
-                });
-    }
-
-    @Test // GH-1485
-    void shouldCreateThreadPoolTaskExecutorAndNotUseAnyFromContext() {
-        new ApplicationContextRunner()
-                .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
-                .withUserConfiguration(ThreadPoolTaskExecutorsConfig.class)
-                .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
-                .run(context -> {
-                    assertThat(context)
-                            .getBean(ScheduledTaskService.class)
-                            .extracting("taskExecutor")
-                            .isNotIn(context.getBeansOfType(ThreadPoolTaskExecutor.class));
                 });
     }
 
@@ -117,21 +115,6 @@ class ScheduledTaskManagementAutoConfigurationTest {
         @Bean
         public TaskScheduler taskScheduler() {
             return new ThreadPoolTaskScheduler();
-        }
-    }
-
-    @TestConfiguration
-    @EnableScheduling
-    static class ThreadPoolTaskExecutorsConfig {
-
-        @Bean
-        public ThreadPoolTaskExecutor threadPoolTaskExecutor1() {
-            return new ThreadPoolTaskExecutor();
-        }
-
-        @Bean
-        public ThreadPoolTaskExecutor threadPoolTaskExecutor2() {
-            return new ThreadPoolTaskExecutor();
         }
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -108,6 +108,30 @@ class ScheduledTaskManagementAutoConfigurationTest {
                 });
     }
 
+    @Test // GH-1485
+    void shouldCreateAllBeans_whenThereAreOtherThreadPoolTaskExecutorsInContext() {
+        // given: there are other ThreadPoolTaskExecutors in context
+
+        new ApplicationContextRunner()
+                .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
+                .withUserConfiguration(EnableSchedulingConfig.class)
+                .withUserConfiguration(ThreadPoolTaskExecutorsConfig.class)
+                .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                // when
+                .run(context -> {
+                    // then
+                    assertThat(context).hasSingleBean(ScheduledTasksRegistry.class);
+                    assertThat(context).hasSingleBean(ScheduledTaskService.class);
+                    assertThat(context).hasSingleBean(ScheduledTasksAssembler.class);
+                    assertThat(context).hasSingleBean(AxelixScheduledTasksEndpoint.class);
+
+                    assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
+                    assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
+                    assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
+                    assertThat(context).hasBean("axelixThreadPoolTaskExecutor");
+                });
+    }
+
     @TestConfiguration
     @EnableScheduling
     static class EnableSchedulingConfig {
@@ -115,6 +139,21 @@ class ScheduledTaskManagementAutoConfigurationTest {
         @Bean
         public TaskScheduler taskScheduler() {
             return new ThreadPoolTaskScheduler();
+        }
+    }
+
+    @TestConfiguration
+    @EnableScheduling
+    static class ThreadPoolTaskExecutorsConfig {
+
+        @Bean
+        public ThreadPoolTaskExecutor threadPoolTaskExecutor1() {
+            return new ThreadPoolTaskExecutor();
+        }
+
+        @Bean
+        public ThreadPoolTaskExecutor threadPoolTaskExecutor2() {
+            return new ThreadPoolTaskExecutor();
         }
     }
 }

--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @since 10.02.2026
  * @author Nikita Kirillov
+ * @author Dmitry Kiselev
  */
 class ScheduledTaskManagementAutoConfigurationTest {
 
@@ -94,6 +96,20 @@ class ScheduledTaskManagementAutoConfigurationTest {
                 });
     }
 
+    @Test // GH-1485
+    void shouldCreateThreadPoolTaskExecutorAndNotUseAnyFromContext() {
+        new ApplicationContextRunner()
+                .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
+                .withUserConfiguration(ThreadPoolTaskExecutorsConfig.class)
+                .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context)
+                            .getBean(ScheduledTaskService.class)
+                            .extracting("taskExecutor")
+                            .isNotIn(context.getBeansOfType(ThreadPoolTaskExecutor.class));
+                });
+    }
+
     @TestConfiguration
     @EnableScheduling
     static class EnableSchedulingConfig {
@@ -101,6 +117,21 @@ class ScheduledTaskManagementAutoConfigurationTest {
         @Bean
         public TaskScheduler taskScheduler() {
             return new ThreadPoolTaskScheduler();
+        }
+    }
+
+    @TestConfiguration
+    @EnableScheduling
+    static class ThreadPoolTaskExecutorsConfig {
+
+        @Bean
+        public ThreadPoolTaskExecutor threadPoolTaskExecutor1() {
+            return new ThreadPoolTaskExecutor();
+        }
+
+        @Bean
+        public ThreadPoolTaskExecutor threadPoolTaskExecutor2() {
+            return new ThreadPoolTaskExecutor();
         }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -20,6 +20,7 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 import java.util.List;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -57,8 +58,10 @@ public class ScheduledTaskManagementAutoConfiguration {
 
     @Bean
     public ScheduledTaskService scheduledTaskService(
-            ScheduledTasksRegistry scheduledTasksRegistry, List<TaskRescheduler> taskReschedulers) {
-        return new ScheduledTaskService(scheduledTasksRegistry, taskReschedulers, createThreadPoolExecutor());
+            ScheduledTasksRegistry scheduledTasksRegistry,
+            List<TaskRescheduler> taskReschedulers,
+            @Qualifier("axelixThreadPoolTaskExecutor") ThreadPoolTaskExecutor threadPoolTaskExecutor) {
+        return new ScheduledTaskService(scheduledTasksRegistry, taskReschedulers, threadPoolTaskExecutor);
     }
 
     @Bean
@@ -84,12 +87,15 @@ public class ScheduledTaskManagementAutoConfiguration {
         return new DefaultScheduledTasksAssembler(scheduledTasksRegistry);
     }
 
-    private static ThreadPoolTaskExecutor createThreadPoolExecutor() {
+    @Bean
+    public ThreadPoolTaskExecutor axelixThreadPoolTaskExecutor() {
         ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
         threadPoolTaskExecutor.setCorePoolSize(1);
         threadPoolTaskExecutor.setMaxPoolSize(3);
         threadPoolTaskExecutor.setAllowCoreThreadTimeOut(false);
         threadPoolTaskExecutor.setPrestartAllCoreThreads(true);
+        threadPoolTaskExecutor.setAwaitTerminationSeconds(30);
+        threadPoolTaskExecutor.setWaitForTasksToCompleteOnShutdown(true);
         return threadPoolTaskExecutor;
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -23,11 +23,10 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskHolder;
 
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
@@ -52,6 +51,9 @@ import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskReschedul
 @ConditionalOnAvailableEndpoint(endpoint = AxelixScheduledTasksEndpoint.class)
 public class ScheduledTaskManagementAutoConfiguration {
 
+    public static final String THREAD_POOL_TASK_EXECUTOR_QUALIFIER = "schedulingThreadPoolTaskExecutor";
+    public static final String TASK_SCHEDULER_QUALIFIER = "schedulingTaskScheduler";
+
     @Bean
     public ScheduledTasksRegistry scheduledTasksRegistry(ObjectProvider<ScheduledTaskHolder> taskHolders) {
         return new ScheduledTasksRegistry(taskHolders.orderedStream().toList());
@@ -61,19 +63,17 @@ public class ScheduledTaskManagementAutoConfiguration {
     public ScheduledTaskService scheduledTaskService(
             ScheduledTasksRegistry scheduledTasksRegistry,
             List<TaskRescheduler> taskReschedulers,
-            @Qualifier("axelixThreadPoolTaskExecutor") ThreadPoolTaskExecutor threadPoolTaskExecutor) {
+            @Qualifier(THREAD_POOL_TASK_EXECUTOR_QUALIFIER) ThreadPoolTaskExecutor threadPoolTaskExecutor) {
         return new ScheduledTaskService(scheduledTasksRegistry, taskReschedulers, threadPoolTaskExecutor);
     }
 
     @Bean
-    @ConditionalOnBean(TaskScheduler.class)
-    public TaskRescheduler intervalBasedTaskRescheduler(TaskScheduler scheduler) {
+    public TaskRescheduler intervalBasedTaskRescheduler(@Qualifier(TASK_SCHEDULER_QUALIFIER) TaskScheduler scheduler) {
         return new IntervalBasedTaskRescheduler(scheduler);
     }
 
     @Bean
-    @ConditionalOnBean(TaskScheduler.class)
-    public TaskRescheduler triggerBasedTaskRescheduler(TaskScheduler scheduler) {
+    public TaskRescheduler triggerBasedTaskRescheduler(@Qualifier(TASK_SCHEDULER_QUALIFIER) TaskScheduler scheduler) {
         return new TriggerBasedTaskRescheduler(scheduler);
     }
 
@@ -89,8 +89,16 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean(name = "axelixThreadPoolTaskExecutor")
-    public ThreadPoolTaskExecutor axelixThreadPoolTaskExecutor() {
+    @Qualifier(TASK_SCHEDULER_QUALIFIER)
+    public ThreadPoolTaskScheduler schedulingTaskScheduler() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(1);
+        return taskScheduler;
+    }
+
+    @Bean
+    @Qualifier(THREAD_POOL_TASK_EXECUTOR_QUALIFIER)
+    public ThreadPoolTaskExecutor schedulingThreadPoolTaskExecutor() {
         ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
         threadPoolTaskExecutor.setCorePoolSize(1);
         threadPoolTaskExecutor.setMaxPoolSize(3);

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -43,6 +43,7 @@ import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskReschedul
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
+ * @author Dmitry Kiselev
  * @since 14.10.2025
  */
 @AutoConfiguration
@@ -56,13 +57,8 @@ public class ScheduledTaskManagementAutoConfiguration {
 
     @Bean
     public ScheduledTaskService scheduledTaskService(
-            ScheduledTasksRegistry scheduledTasksRegistry,
-            List<TaskRescheduler> taskReschedulers,
-            ObjectProvider<ThreadPoolTaskExecutor> taskExecutor) {
-        return new ScheduledTaskService(
-                scheduledTasksRegistry,
-                taskReschedulers,
-                taskExecutor.getIfAvailable() != null ? taskExecutor.getIfAvailable() : createThreadPoolExecutor());
+            ScheduledTasksRegistry scheduledTasksRegistry, List<TaskRescheduler> taskReschedulers) {
+        return new ScheduledTaskService(scheduledTasksRegistry, taskReschedulers, createThreadPoolExecutor());
     }
 
     @Bean

--- a/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-3-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -88,6 +89,7 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(name = "axelixThreadPoolTaskExecutor")
     public ThreadPoolTaskExecutor axelixThreadPoolTaskExecutor() {
         ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
         threadPoolTaskExecutor.setCorePoolSize(1);

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -109,6 +109,30 @@ class ScheduledTaskManagementAutoConfigurationTest {
                 });
     }
 
+    @Test // GH-1485
+    void shouldCreateAllBeans_whenThereAreOtherThreadPoolTaskExecutorsInContext() {
+        // given: there are other ThreadPoolTaskExecutors in context
+
+        new ApplicationContextRunner()
+                .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
+                .withUserConfiguration(EnableSchedulingConfig.class)
+                .withUserConfiguration(ThreadPoolTaskExecutorsConfig.class)
+                .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                // when
+                .run(context -> {
+                    // then
+                    assertThat(context).hasSingleBean(ScheduledTasksRegistry.class);
+                    assertThat(context).hasSingleBean(ScheduledTaskService.class);
+                    assertThat(context).hasSingleBean(ScheduledTasksAssembler.class);
+                    assertThat(context).hasSingleBean(AxelixScheduledTasksEndpoint.class);
+
+                    assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
+                    assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
+                    assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
+                    assertThat(context).hasBean("axelixThreadPoolTaskExecutor");
+                });
+    }
+
     @TestConfiguration
     @EnableScheduling
     static class EnableSchedulingConfig {
@@ -116,6 +140,21 @@ class ScheduledTaskManagementAutoConfigurationTest {
         @Bean
         public TaskScheduler taskScheduler() {
             return new ThreadPoolTaskScheduler();
+        }
+    }
+
+    @TestConfiguration
+    @EnableScheduling
+    static class ThreadPoolTaskExecutorsConfig {
+
+        @Bean
+        public ThreadPoolTaskExecutor threadPoolTaskExecutor1() {
+            return new ThreadPoolTaskExecutor();
+        }
+
+        @Bean
+        public ThreadPoolTaskExecutor threadPoolTaskExecutor2() {
+            return new ThreadPoolTaskExecutor();
         }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -89,7 +89,7 @@ class ScheduledTaskManagementAutoConfigurationTest {
     }
 
     @Test
-    void shouldActivateWithoutReschedulers_whenSchedulingNotEnabled() {
+    void shouldActivateReschedulers_backedByLocalScheduler_whenSchedulingNotEnabled() {
         // given
         new ApplicationContextRunner()
                 .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
@@ -104,8 +104,11 @@ class ScheduledTaskManagementAutoConfigurationTest {
                     assertThat(context).hasSingleBean(AxelixScheduledTasksEndpoint.class);
                     assertThat(context).hasSingleBean(ThreadPoolTaskExecutor.class);
 
-                    // no scheduling -> reschedulers are not created
-                    assertThat(context).getBeans(TaskRescheduler.class).isEmpty();
+                    // reschedulers are backed by the locally-declared TaskScheduler, so they are
+                    // created even without @EnableScheduling
+                    assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
+                    assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
+                    assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
                 });
     }
 
@@ -129,7 +132,10 @@ class ScheduledTaskManagementAutoConfigurationTest {
                     assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
                     assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
                     assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
-                    assertThat(context).hasBean("axelixThreadPoolTaskExecutor");
+
+                    // our executor is registered alongside the user-declared ones, and the
+                    // ScheduledTaskService is wired via @Qualifier despite the ambiguity
+                    assertThat(context).getBeans(ThreadPoolTaskExecutor.class).hasSize(3);
                 });
     }
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -54,7 +54,11 @@ class ScheduledTaskManagementAutoConfigurationTest {
 
     @Test
     void shouldCreateAllBeansInDefaultScenario() {
+        // given: ApplicationContextRunner configured with required properties and scheduling enabled
+
+        // when
         contextRunner.run(context -> {
+            // then
             assertThat(context).hasSingleBean(ScheduledTasksRegistry.class);
             assertThat(context).hasSingleBean(ScheduledTaskService.class);
             assertThat(context).hasSingleBean(ScheduledTasksAssembler.class);
@@ -63,50 +67,45 @@ class ScheduledTaskManagementAutoConfigurationTest {
             assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
             assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
             assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
+            assertThat(context).hasSingleBean(ThreadPoolTaskExecutor.class);
         });
     }
 
     @Test
     void shouldNotActivateAutoConfiguration_withoutRequiredProperty() {
+        // given
         new ApplicationContextRunner()
                 .withUserConfiguration(EnableSchedulingConfig.class)
                 .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                // when
                 .run(context -> {
+                    // then
                     assertThat(context).doesNotHaveBean(ScheduledTaskManagementAutoConfiguration.class);
                     assertThat(context).doesNotHaveBean(ScheduledTasksRegistry.class);
                     assertThat(context).doesNotHaveBean(ScheduledTaskService.class);
                     assertThat(context).doesNotHaveBean(AxelixScheduledTasksEndpoint.class);
+                    assertThat(context).doesNotHaveBean(ThreadPoolTaskExecutor.class);
                 });
     }
 
     @Test
     void shouldActivateWithoutReschedulers_whenSchedulingNotEnabled() {
+        // given
         new ApplicationContextRunner()
                 .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
                 .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                // when
                 .run(context -> {
+                    // then
                     // read path is available even without @EnableScheduling
                     assertThat(context).hasSingleBean(ScheduledTasksRegistry.class);
                     assertThat(context).hasSingleBean(ScheduledTaskService.class);
                     assertThat(context).hasSingleBean(ScheduledTasksAssembler.class);
                     assertThat(context).hasSingleBean(AxelixScheduledTasksEndpoint.class);
+                    assertThat(context).hasSingleBean(ThreadPoolTaskExecutor.class);
 
                     // no scheduling -> reschedulers are not created
                     assertThat(context).getBeans(TaskRescheduler.class).isEmpty();
-                });
-    }
-
-    @Test // GH-1485
-    void shouldCreateThreadPoolTaskExecutorAndNotUseAnyFromContext() {
-        new ApplicationContextRunner()
-                .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
-                .withUserConfiguration(ThreadPoolTaskExecutorsConfig.class)
-                .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
-                .run(context -> {
-                    assertThat(context)
-                            .getBean(ScheduledTaskService.class)
-                            .extracting("taskExecutor")
-                            .isNotIn(context.getBeansOfType(ThreadPoolTaskExecutor.class));
                 });
     }
 
@@ -117,21 +116,6 @@ class ScheduledTaskManagementAutoConfigurationTest {
         @Bean
         public TaskScheduler taskScheduler() {
             return new ThreadPoolTaskScheduler();
-        }
-    }
-
-    @TestConfiguration
-    @EnableScheduling
-    static class ThreadPoolTaskExecutorsConfig {
-
-        @Bean
-        public ThreadPoolTaskExecutor threadPoolTaskExecutor1() {
-            return new ThreadPoolTaskExecutor();
-        }
-
-        @Bean
-        public ThreadPoolTaskExecutor threadPoolTaskExecutor2() {
-            return new ThreadPoolTaskExecutor();
         }
     }
 }

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @since 10.02.2026
  * @author Nikita Kirillov
+ * @author Dmitry Kiselev
  */
 class ScheduledTaskManagementAutoConfigurationTest {
 
@@ -94,6 +96,20 @@ class ScheduledTaskManagementAutoConfigurationTest {
                 });
     }
 
+    @Test // GH-1485
+    void shouldCreateThreadPoolTaskExecutorAndNotUseAnyFromContext() {
+        new ApplicationContextRunner()
+                .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
+                .withUserConfiguration(ThreadPoolTaskExecutorsConfig.class)
+                .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context)
+                            .getBean(ScheduledTaskService.class)
+                            .extracting("taskExecutor")
+                            .isNotIn(context.getBeansOfType(ThreadPoolTaskExecutor.class));
+                });
+    }
+
     @TestConfiguration
     @EnableScheduling
     static class EnableSchedulingConfig {
@@ -101,6 +117,21 @@ class ScheduledTaskManagementAutoConfigurationTest {
         @Bean
         public TaskScheduler taskScheduler() {
             return new ThreadPoolTaskScheduler();
+        }
+    }
+
+    @TestConfiguration
+    @EnableScheduling
+    static class ThreadPoolTaskExecutorsConfig {
+
+        @Bean
+        public ThreadPoolTaskExecutor threadPoolTaskExecutor1() {
+            return new ThreadPoolTaskExecutor();
+        }
+
+        @Bean
+        public ThreadPoolTaskExecutor threadPoolTaskExecutor2() {
+            return new ThreadPoolTaskExecutor();
         }
     }
 }

--- a/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -20,6 +20,7 @@ package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 import java.util.List;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -57,8 +58,10 @@ public class ScheduledTaskManagementAutoConfiguration {
 
     @Bean
     public ScheduledTaskService scheduledTaskService(
-            ScheduledTasksRegistry scheduledTasksRegistry, List<TaskRescheduler> taskReschedulers) {
-        return new ScheduledTaskService(scheduledTasksRegistry, taskReschedulers, createThreadPoolExecutor());
+            ScheduledTasksRegistry scheduledTasksRegistry,
+            List<TaskRescheduler> taskReschedulers,
+            @Qualifier("axelixThreadPoolTaskExecutor") ThreadPoolTaskExecutor threadPoolTaskExecutor) {
+        return new ScheduledTaskService(scheduledTasksRegistry, taskReschedulers, threadPoolTaskExecutor);
     }
 
     @Bean
@@ -84,12 +87,15 @@ public class ScheduledTaskManagementAutoConfiguration {
         return new DefaultScheduledTasksAssembler(scheduledTasksRegistry);
     }
 
-    private static ThreadPoolTaskExecutor createThreadPoolExecutor() {
+    @Bean
+    public ThreadPoolTaskExecutor axelixThreadPoolTaskExecutor() {
         ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
         threadPoolTaskExecutor.setCorePoolSize(1);
         threadPoolTaskExecutor.setMaxPoolSize(3);
         threadPoolTaskExecutor.setAllowCoreThreadTimeOut(false);
         threadPoolTaskExecutor.setPrestartAllCoreThreads(true);
+        threadPoolTaskExecutor.setAwaitTerminationSeconds(30);
+        threadPoolTaskExecutor.setWaitForTasksToCompleteOnShutdown(true);
         return threadPoolTaskExecutor;
     }
 }

--- a/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -23,11 +23,10 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskHolder;
 
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
@@ -52,6 +51,9 @@ import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskReschedul
 @ConditionalOnAvailableEndpoint(endpoint = AxelixScheduledTasksEndpoint.class)
 public class ScheduledTaskManagementAutoConfiguration {
 
+    public static final String THREAD_POOL_TASK_EXECUTOR_QUALIFIER = "schedulingThreadPoolTaskExecutor";
+    public static final String TASK_SCHEDULER_QUALIFIER = "schedulingTaskScheduler";
+
     @Bean
     public ScheduledTasksRegistry scheduledTasksRegistry(ObjectProvider<ScheduledTaskHolder> taskHolders) {
         return new ScheduledTasksRegistry(taskHolders.orderedStream().toList());
@@ -61,19 +63,17 @@ public class ScheduledTaskManagementAutoConfiguration {
     public ScheduledTaskService scheduledTaskService(
             ScheduledTasksRegistry scheduledTasksRegistry,
             List<TaskRescheduler> taskReschedulers,
-            @Qualifier("axelixThreadPoolTaskExecutor") ThreadPoolTaskExecutor threadPoolTaskExecutor) {
+            @Qualifier(THREAD_POOL_TASK_EXECUTOR_QUALIFIER) ThreadPoolTaskExecutor threadPoolTaskExecutor) {
         return new ScheduledTaskService(scheduledTasksRegistry, taskReschedulers, threadPoolTaskExecutor);
     }
 
     @Bean
-    @ConditionalOnBean(TaskScheduler.class)
-    public TaskRescheduler intervalBasedTaskRescheduler(TaskScheduler scheduler) {
+    public TaskRescheduler intervalBasedTaskRescheduler(@Qualifier(TASK_SCHEDULER_QUALIFIER) TaskScheduler scheduler) {
         return new IntervalBasedTaskRescheduler(scheduler);
     }
 
     @Bean
-    @ConditionalOnBean(TaskScheduler.class)
-    public TaskRescheduler triggerBasedTaskRescheduler(TaskScheduler scheduler) {
+    public TaskRescheduler triggerBasedTaskRescheduler(@Qualifier(TASK_SCHEDULER_QUALIFIER) TaskScheduler scheduler) {
         return new TriggerBasedTaskRescheduler(scheduler);
     }
 
@@ -89,8 +89,16 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean(name = "axelixThreadPoolTaskExecutor")
-    public ThreadPoolTaskExecutor axelixThreadPoolTaskExecutor() {
+    @Qualifier(TASK_SCHEDULER_QUALIFIER)
+    public ThreadPoolTaskScheduler schedulingTaskScheduler() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(1);
+        return taskScheduler;
+    }
+
+    @Bean
+    @Qualifier(THREAD_POOL_TASK_EXECUTOR_QUALIFIER)
+    public ThreadPoolTaskExecutor schedulingThreadPoolTaskExecutor() {
         ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
         threadPoolTaskExecutor.setCorePoolSize(1);
         threadPoolTaskExecutor.setMaxPoolSize(3);

--- a/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -43,6 +43,7 @@ import com.axelixlabs.axelix.sbs.spring.core.scheduled.TriggerBasedTaskReschedul
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
+ * @author Dmitry Kiselev
  * @since 14.10.2025
  */
 @AutoConfiguration
@@ -56,13 +57,8 @@ public class ScheduledTaskManagementAutoConfiguration {
 
     @Bean
     public ScheduledTaskService scheduledTaskService(
-            ScheduledTasksRegistry scheduledTasksRegistry,
-            List<TaskRescheduler> taskReschedulers,
-            ObjectProvider<ThreadPoolTaskExecutor> taskExecutor) {
-        return new ScheduledTaskService(
-                scheduledTasksRegistry,
-                taskReschedulers,
-                taskExecutor.getIfAvailable() != null ? taskExecutor.getIfAvailable() : createThreadPoolExecutor());
+            ScheduledTasksRegistry scheduledTasksRegistry, List<TaskRescheduler> taskReschedulers) {
+        return new ScheduledTaskService(scheduledTasksRegistry, taskReschedulers, createThreadPoolExecutor());
     }
 
     @Bean

--- a/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
+++ b/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -88,6 +89,7 @@ public class ScheduledTaskManagementAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean(name = "axelixThreadPoolTaskExecutor")
     public ThreadPoolTaskExecutor axelixThreadPoolTaskExecutor() {
         ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
         threadPoolTaskExecutor.setCorePoolSize(1);

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -109,6 +109,30 @@ class ScheduledTaskManagementAutoConfigurationTest {
                 });
     }
 
+    @Test // GH-1485
+    void shouldCreateAllBeans_whenThereAreOtherThreadPoolTaskExecutorsInContext() {
+        // given: there are other ThreadPoolTaskExecutors in context
+
+        new ApplicationContextRunner()
+                .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
+                .withUserConfiguration(EnableSchedulingConfig.class)
+                .withUserConfiguration(ThreadPoolTaskExecutorsConfig.class)
+                .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                // when
+                .run(context -> {
+                    // then
+                    assertThat(context).hasSingleBean(ScheduledTasksRegistry.class);
+                    assertThat(context).hasSingleBean(ScheduledTaskService.class);
+                    assertThat(context).hasSingleBean(ScheduledTasksAssembler.class);
+                    assertThat(context).hasSingleBean(AxelixScheduledTasksEndpoint.class);
+
+                    assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
+                    assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
+                    assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
+                    assertThat(context).hasBean("axelixThreadPoolTaskExecutor");
+                });
+    }
+
     @TestConfiguration
     @EnableScheduling
     static class EnableSchedulingConfig {
@@ -116,6 +140,21 @@ class ScheduledTaskManagementAutoConfigurationTest {
         @Bean
         public TaskScheduler taskScheduler() {
             return new ThreadPoolTaskScheduler();
+        }
+    }
+
+    @TestConfiguration
+    @EnableScheduling
+    static class ThreadPoolTaskExecutorsConfig {
+
+        @Bean
+        public ThreadPoolTaskExecutor threadPoolTaskExecutor1() {
+            return new ThreadPoolTaskExecutor();
+        }
+
+        @Bean
+        public ThreadPoolTaskExecutor threadPoolTaskExecutor2() {
+            return new ThreadPoolTaskExecutor();
         }
     }
 }

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -89,7 +89,7 @@ class ScheduledTaskManagementAutoConfigurationTest {
     }
 
     @Test
-    void shouldActivateWithoutReschedulers_whenSchedulingNotEnabled() {
+    void shouldActivateReschedulers_backedByLocalScheduler_whenSchedulingNotEnabled() {
         // given
         new ApplicationContextRunner()
                 .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
@@ -104,8 +104,11 @@ class ScheduledTaskManagementAutoConfigurationTest {
                     assertThat(context).hasSingleBean(AxelixScheduledTasksEndpoint.class);
                     assertThat(context).hasSingleBean(ThreadPoolTaskExecutor.class);
 
-                    // no scheduling -> reschedulers are not created
-                    assertThat(context).getBeans(TaskRescheduler.class).isEmpty();
+                    // reschedulers are backed by the locally-declared TaskScheduler, so they are
+                    // created even without @EnableScheduling
+                    assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
+                    assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
+                    assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
                 });
     }
 
@@ -129,7 +132,10 @@ class ScheduledTaskManagementAutoConfigurationTest {
                     assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
                     assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
                     assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
-                    assertThat(context).hasBean("axelixThreadPoolTaskExecutor");
+
+                    // our executor is registered alongside the user-declared ones, and the
+                    // ScheduledTaskService is wired via @Qualifier despite the ambiguity
+                    assertThat(context).getBeans(ThreadPoolTaskExecutor.class).hasSize(3);
                 });
     }
 

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -54,7 +54,11 @@ class ScheduledTaskManagementAutoConfigurationTest {
 
     @Test
     void shouldCreateAllBeansInDefaultScenario() {
+        // given: ApplicationContextRunner configured with required properties and scheduling enabled
+
+        // when
         contextRunner.run(context -> {
+            // then
             assertThat(context).hasSingleBean(ScheduledTasksRegistry.class);
             assertThat(context).hasSingleBean(ScheduledTaskService.class);
             assertThat(context).hasSingleBean(ScheduledTasksAssembler.class);
@@ -63,50 +67,45 @@ class ScheduledTaskManagementAutoConfigurationTest {
             assertThat(context).getBeans(TaskRescheduler.class).hasSize(2);
             assertThat(context).hasSingleBean(IntervalBasedTaskRescheduler.class);
             assertThat(context).hasSingleBean(TriggerBasedTaskRescheduler.class);
+            assertThat(context).hasSingleBean(ThreadPoolTaskExecutor.class);
         });
     }
 
     @Test
     void shouldNotActivateAutoConfiguration_withoutRequiredProperty() {
+        // given
         new ApplicationContextRunner()
                 .withUserConfiguration(EnableSchedulingConfig.class)
                 .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                // when
                 .run(context -> {
+                    // then
                     assertThat(context).doesNotHaveBean(ScheduledTaskManagementAutoConfiguration.class);
                     assertThat(context).doesNotHaveBean(ScheduledTasksRegistry.class);
                     assertThat(context).doesNotHaveBean(ScheduledTaskService.class);
                     assertThat(context).doesNotHaveBean(AxelixScheduledTasksEndpoint.class);
+                    assertThat(context).doesNotHaveBean(ThreadPoolTaskExecutor.class);
                 });
     }
 
     @Test
     void shouldActivateWithoutReschedulers_whenSchedulingNotEnabled() {
+        // given
         new ApplicationContextRunner()
                 .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
                 .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                // when
                 .run(context -> {
+                    // then
                     // read path is available even without @EnableScheduling
                     assertThat(context).hasSingleBean(ScheduledTasksRegistry.class);
                     assertThat(context).hasSingleBean(ScheduledTaskService.class);
                     assertThat(context).hasSingleBean(ScheduledTasksAssembler.class);
                     assertThat(context).hasSingleBean(AxelixScheduledTasksEndpoint.class);
+                    assertThat(context).hasSingleBean(ThreadPoolTaskExecutor.class);
 
                     // no scheduling -> reschedulers are not created
                     assertThat(context).getBeans(TaskRescheduler.class).isEmpty();
-                });
-    }
-
-    @Test // GH-1485
-    void shouldCreateThreadPoolTaskExecutorAndNotUseAnyFromContext() {
-        new ApplicationContextRunner()
-                .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
-                .withUserConfiguration(ThreadPoolTaskExecutorsConfig.class)
-                .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
-                .run(context -> {
-                    assertThat(context)
-                            .getBean(ScheduledTaskService.class)
-                            .extracting("taskExecutor")
-                            .isNotIn(context.getBeansOfType(ThreadPoolTaskExecutor.class));
                 });
     }
 
@@ -117,21 +116,6 @@ class ScheduledTaskManagementAutoConfigurationTest {
         @Bean
         public TaskScheduler taskScheduler() {
             return new ThreadPoolTaskScheduler();
-        }
-    }
-
-    @TestConfiguration
-    @EnableScheduling
-    static class ThreadPoolTaskExecutorsConfig {
-
-        @Bean
-        public ThreadPoolTaskExecutor threadPoolTaskExecutor1() {
-            return new ThreadPoolTaskExecutor();
-        }
-
-        @Bean
-        public ThreadPoolTaskExecutor threadPoolTaskExecutor2() {
-            return new ThreadPoolTaskExecutor();
         }
     }
 }

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @since 10.02.2026
  * @author Nikita Kirillov
+ * @author Dmitry Kiselev
  */
 class ScheduledTaskManagementAutoConfigurationTest {
 
@@ -94,6 +96,20 @@ class ScheduledTaskManagementAutoConfigurationTest {
                 });
     }
 
+    @Test // GH-1485
+    void shouldCreateThreadPoolTaskExecutorAndNotUseAnyFromContext() {
+        new ApplicationContextRunner()
+                .withPropertyValues("management.endpoints.web.exposure.include=axelix-scheduled-tasks")
+                .withUserConfiguration(ThreadPoolTaskExecutorsConfig.class)
+                .withConfiguration(AutoConfigurations.of(ScheduledTaskManagementAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context)
+                            .getBean(ScheduledTaskService.class)
+                            .extracting("taskExecutor")
+                            .isNotIn(context.getBeansOfType(ThreadPoolTaskExecutor.class));
+                });
+    }
+
     @TestConfiguration
     @EnableScheduling
     static class EnableSchedulingConfig {
@@ -101,6 +117,21 @@ class ScheduledTaskManagementAutoConfigurationTest {
         @Bean
         public TaskScheduler taskScheduler() {
             return new ThreadPoolTaskScheduler();
+        }
+    }
+
+    @TestConfiguration
+    @EnableScheduling
+    static class ThreadPoolTaskExecutorsConfig {
+
+        @Bean
+        public ThreadPoolTaskExecutor threadPoolTaskExecutor1() {
+            return new ThreadPoolTaskExecutor();
+        }
+
+        @Bean
+        public ThreadPoolTaskExecutor threadPoolTaskExecutor2() {
+            return new ThreadPoolTaskExecutor();
         }
     }
 }


### PR DESCRIPTION
Closes #1485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled task management now consistently uses its dedicated executor and scheduler, avoiding conflicts with other application executors.
  * Reschedulers continue to work reliably when scheduling is disabled.
  * Improved application shutdown behavior by allowing scheduled tasks to finish gracefully.
  * The dedicated executor is available only when the required scheduling configuration is active.

* **Tests**
  * Added coverage across supported Spring Boot versions for executor isolation, scheduler behavior, graceful shutdown, and disabled-scheduling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->