### PR TITLE
GH-1492 Move the built-in roles from Java constants into the database

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/domain/RoleEntity.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/domain/RoleEntity.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+/**
+ * Persistent role record, holding the columns of the {@code roles} table itself.
+ *
+ * @param id          Unique identifier of the role. Serves as the primary key.
+ * @param name        Unique name of the role (e.g. {@code ADMIN}, {@code EDITOR}, {@code VIEWER}).
+ * @param description Human-readable description of what the role allows.
+ * @param roleOrigin  Origin of the role.
+ *
+ * @author Sergey Cherkasov
+ */
+@Table("roles")
+public record RoleEntity(@Id String id, String name, String description, RoleOrigin roleOrigin) {}

--- a/master/src/main/java/com/axelixlabs/axelix/master/domain/RoleOrigin.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/domain/RoleOrigin.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.domain;
+
+/**
+ * Origin of a role, i.e. where the role came from initially.
+ *
+ * @author Sergey Cherkasov
+ */
+public enum RoleOrigin {
+    /**
+     * Default role.
+     */
+    BUILT_IN,
+
+    /**
+     * Role created by a user through the Axelix Master UI.
+     */
+    WEB_UI,
+
+    /**
+     * Role declared in a roles YAML manifest.
+     */
+    YAML
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/domain/UserRoleName.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/domain/UserRoleName.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.domain;
+
+/**
+ * Single role assignment, used to read the assignments of many users at once without a query per user.
+ *
+ * @param userId   Identifier of the user the role is granted to.
+ * @param roleName Name of the granted role.
+ *
+ * @author Sergey Cherkasov
+ */
+public record UserRoleName(String userId, String roleName) {}

--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/RoleRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/RoleRepository.java
@@ -18,7 +18,8 @@
 package com.axelixlabs.axelix.master.repository;
 
 import java.util.List;
-import java.util.Optional;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.ListCrudRepository;
@@ -33,20 +34,30 @@ import com.axelixlabs.axelix.master.domain.RoleEntity;
  */
 public interface RoleRepository extends ListCrudRepository<RoleEntity, String> {
 
-    Optional<RoleEntity> findByName(@Param("name") String name);
-
     /**
-     * Reads the names of the authorities granted to the role with the given name.
+     * Reads the role with the given name together with the names of the authorities it grants, in a single query.
+     *
+     * <p>The join is a {@code LEFT} join, so a role that grants no authority still yields a single row (with a
+     * {@code null} authority name). An empty result therefore means no role with such a name exists.</p>
      *
      * @param name Name of the role.
-     * @return Names of the granted authorities, empty if the role grants none or does not exist.
+     * @return One row per granted authority, a single {@code null}-authority row if the role grants none, or an empty
+     *         list if no role with such a name exists.
      */
     @Query("""
-            SELECT a.name
+            SELECT r.name AS role_name, a.name AS authority_name
             FROM roles r
-            JOIN roles_authorities ra ON ra.role_id = r.id
-            JOIN authorities a ON a.id = ra.authority_id
+            LEFT JOIN roles_authorities ra ON ra.role_id = r.id
+            LEFT JOIN authorities a ON a.id = ra.authority_id
             WHERE r.name = :name
             """)
-    List<String> findAuthorityNamesByRoleName(@Param("name") String name);
+    List<RoleWithAuthorityName> findWithAuthoritiesByName(@Param("name") String name);
+
+    /**
+     * A single (role, granted-authority-name) row of {@link #findWithAuthoritiesByName(String)}.
+     *
+     * @param roleName      Name of the role.
+     * @param authorityName Name of one authority the role grants, or {@code null} if the role grants none.
+     */
+    record RoleWithAuthorityName(String roleName, @Nullable String authorityName) {}
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/RoleRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/RoleRepository.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jdbc.repository.query.Query;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import com.axelixlabs.axelix.master.domain.RoleEntity;
+
+/**
+ * Repository for {@link RoleEntity} aggregate.
+ *
+ * @author Sergey Cherkasov
+ */
+public interface RoleRepository extends ListCrudRepository<RoleEntity, String> {
+
+    Optional<RoleEntity> findByName(@Param("name") String name);
+
+    /**
+     * Reads the names of the authorities granted to the role with the given name.
+     *
+     * @param name Name of the role.
+     * @return Names of the granted authorities, empty if the role grants none or does not exist.
+     */
+    @Query("""
+            SELECT a.name
+            FROM roles r
+            JOIN roles_authorities ra ON ra.role_id = r.id
+            JOIN authorities a ON a.id = ra.authority_id
+            WHERE r.name = :name
+            """)
+    List<String> findAuthorityNamesByRoleName(@Param("name") String name);
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseRoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseRoleService.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.service.state;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.axelixlabs.axelix.common.auth.core.Authority;
+import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
+import com.axelixlabs.axelix.common.auth.core.DefaultRole;
+import com.axelixlabs.axelix.common.auth.core.Role;
+import com.axelixlabs.axelix.master.domain.RoleEntity;
+import com.axelixlabs.axelix.master.repository.RoleRepository;
+
+/**
+ * JDBC-based implementation of {@link RoleService} that reads roles from the {@code roles}, {@code roles_authorities}
+ * and {@code authorities} tables.
+ *
+ * @author Sergey Cherkasov
+ */
+@Service
+@NullMarked
+@Transactional
+public class DatabaseRoleService implements RoleService {
+
+    private final RoleRepository roleRepository;
+
+    public DatabaseRoleService(RoleRepository roleRepository) {
+        this.roleRepository = roleRepository;
+    }
+
+    @Override
+    public Optional<Role> findByName(String name) {
+        return roleRepository.findByName(name).map(this::toRole);
+    }
+
+    private Role toRole(RoleEntity roleEntity) {
+        return new DefaultRole(roleEntity.name(), resolveAuthorities(roleEntity.name()));
+    }
+
+    private Set<Authority> resolveAuthorities(String roleName) {
+        return roleRepository.findAuthorityNamesByRoleName(roleName).stream()
+                .map(this::safeAuthorityFromString)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+
+    @Nullable
+    private Authority safeAuthorityFromString(String name) {
+        try {
+            return DefaultAuthority.valueOf(name);
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseRoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseRoleService.java
@@ -17,23 +17,21 @@
  */
 package com.axelixlabs.axelix.master.service.state;
 
-import java.util.Objects;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.axelixlabs.axelix.common.auth.core.Authority;
-import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.Role;
-import com.axelixlabs.axelix.master.domain.RoleEntity;
 import com.axelixlabs.axelix.master.repository.RoleRepository;
+import com.axelixlabs.axelix.master.repository.RoleRepository.RoleWithAuthorityName;
 
 /**
  * JDBC-based implementation of {@link RoleService} that reads roles from the {@code roles}, {@code roles_authorities}
@@ -54,26 +52,14 @@ public class DatabaseRoleService implements RoleService {
 
     @Override
     public Optional<Role> findByName(String name) {
-        return roleRepository.findByName(name).map(this::toRole);
-    }
-
-    private Role toRole(RoleEntity roleEntity) {
-        return new DefaultRole(roleEntity.name(), resolveAuthorities(roleEntity.name()));
-    }
-
-    private Set<Authority> resolveAuthorities(String roleName) {
-        return roleRepository.findAuthorityNamesByRoleName(roleName).stream()
-                .map(this::safeAuthorityFromString)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
-    }
-
-    @Nullable
-    private Authority safeAuthorityFromString(String name) {
-        try {
-            return DefaultAuthority.valueOf(name);
-        } catch (IllegalArgumentException ignored) {
-            return null;
+        List<RoleWithAuthorityName> rows = roleRepository.findWithAuthoritiesByName(name);
+        if (rows.isEmpty()) {
+            return Optional.empty();
         }
+        Set<Authority> authorities = rows.stream()
+                .flatMap(row -> Optional.ofNullable(row.authorityName()).stream())
+                .map(authorityName -> (Authority) () -> authorityName)
+                .collect(Collectors.toSet());
+        return Optional.of(new DefaultRole(name, authorities));
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/RoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/RoleService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.service.state;
+
+import java.util.Optional;
+
+import org.jspecify.annotations.NullMarked;
+
+import com.axelixlabs.axelix.common.auth.core.Role;
+
+/**
+ * Service that resolves the roles Axelix Master knows about.
+ *
+ * <p>Roles are stored in the database: the built-in {@code ADMIN}, {@code EDITOR} and {@code VIEWER} roles are
+ * inserted by a Liquibase migration, any other role is created by Axelix Enterprise. Note that the internal
+ * {@code SUPER_ADMIN} and {@code MANAGED_SERVICE} roles are <strong>not</strong> resolvable through this service:
+ * they are never persisted and never assigned to a managed user.</p>
+ *
+ * @author Sergey Cherkasov
+ */
+@NullMarked
+public interface RoleService {
+
+    /**
+     * Looks up a role by its exact name.
+     *
+     * @param name Name of the role to look up.
+     * @return The role, or {@link Optional#empty()} if no role with such a name exists.
+     */
+    Optional<Role> findByName(String name);
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/UserRoleName.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/UserRoleName.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.master.domain;
+package com.axelixlabs.axelix.master.service.state;
 
 /**
  * Single role assignment, used to read the assignments of many users at once without a query per user.

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.1/002-create-roles-table.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.1/002-create-roles-table.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-002-mysql-create-roles-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="roles"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="roles">
+      <column name="id" type="VARCHAR(36)">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles"/>
+      </column>
+      <column name="name" type="VARCHAR(255)">
+        <constraints nullable="false" unique="true" uniqueConstraintName="uq_roles_name"/>
+      </column>
+      <column name="description" type="TEXT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="role_origin" type="VARCHAR(255)">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.1/003-create-authorities-table.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.1/003-create-authorities-table.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-003-mysql-create-authorities-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="authorities"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="authorities">
+      <column name="id" type="VARCHAR(36)">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_authorities"/>
+      </column>
+      <column name="name" type="VARCHAR(255)">
+        <constraints nullable="false" unique="true" uniqueConstraintName="uq_authorities_name"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.1/004-create-roles-authorities-table.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.1/004-create-roles-authorities-table.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-004-mysql-create-roles-authorities-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="roles_authorities"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="roles_authorities">
+      <column name="role_id" type="VARCHAR(36)">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_authorities"
+                     foreignKeyName="fk_roles_authorities_role" references="roles(id)" deleteCascade="true"/>
+      </column>
+      <column name="authority_id" type="VARCHAR(36)">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_authorities"
+                     foreignKeyName="fk_roles_authorities_authority" references="authorities(id)" deleteCascade="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.1/004-create-roles-authorities-table.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.1/004-create-roles-authorities-table.xml
@@ -15,13 +15,18 @@
 
     <createTable tableName="roles_authorities">
       <column name="role_id" type="VARCHAR(36)">
-        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_authorities"
-                     foreignKeyName="fk_roles_authorities_role" references="roles(id)" deleteCascade="true"/>
+        <constraints nullable="false"
+                     foreignKeyName="fk_roles_authorities_role" references="roles(id)"/>
       </column>
       <column name="authority_id" type="VARCHAR(36)">
-        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_authorities"
-                     foreignKeyName="fk_roles_authorities_authority" references="authorities(id)" deleteCascade="true"/>
+        <constraints nullable="false"
+                     foreignKeyName="fk_roles_authorities_authority" references="authorities(id)"/>
       </column>
     </createTable>
+
+    <addPrimaryKey
+            tableName="roles_authorities"
+            columnNames="role_id, authority_id"
+            constraintName="pk_roles_authorities"/>
   </changeSet>
 </databaseChangeLog>

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.1/005-create-users-roles-table.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.1/005-create-users-roles-table.xml
@@ -15,13 +15,18 @@
 
     <createTable tableName="users_roles">
       <column name="user_id" type="VARCHAR(36)">
-        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_users_roles"
-                     foreignKeyName="fk_users_roles_user" references="users(id)" deleteCascade="true"/>
+        <constraints nullable="false"
+                     foreignKeyName="fk_users_roles_user" references="users(id)"/>
       </column>
       <column name="role_id" type="VARCHAR(36)">
-        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_users_roles"
-                     foreignKeyName="fk_users_roles_role" references="roles(id)" deleteCascade="true"/>
+        <constraints nullable="false"
+                     foreignKeyName="fk_users_roles_role" references="roles(id)"/>
       </column>
     </createTable>
+
+    <addPrimaryKey
+            tableName="users_roles"
+            columnNames="user_id, role_id"
+            constraintName="pk_users_roles"/>
   </changeSet>
 </databaseChangeLog>

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.1/005-create-users-roles-table.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.1/005-create-users-roles-table.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-005-mysql-create-users-roles-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="users_roles"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="users_roles">
+      <column name="user_id" type="VARCHAR(36)">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_users_roles"
+                     foreignKeyName="fk_users_roles_user" references="users(id)" deleteCascade="true"/>
+      </column>
+      <column name="role_id" type="VARCHAR(36)">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_users_roles"
+                     foreignKeyName="fk_users_roles_role" references="roles(id)" deleteCascade="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.1/006-create-roles-parents-table.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.1/006-create-roles-parents-table.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-006-mysql-create-roles-parents-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="roles_parents"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="roles_parents">
+      <column name="role_id" type="VARCHAR(36)">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_parents"
+                     foreignKeyName="fk_roles_parents_role" references="roles(id)" deleteCascade="true"/>
+      </column>
+      <column name="parent_role_id" type="VARCHAR(36)">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_parents"
+                     foreignKeyName="fk_roles_parents_parent" references="roles(id)" deleteCascade="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.1/006-create-roles-parents-table.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.1/006-create-roles-parents-table.xml
@@ -15,13 +15,18 @@
 
     <createTable tableName="roles_parents">
       <column name="role_id" type="VARCHAR(36)">
-        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_parents"
-                     foreignKeyName="fk_roles_parents_role" references="roles(id)" deleteCascade="true"/>
+        <constraints nullable="false"
+                     foreignKeyName="fk_roles_parents_role" references="roles(id)"/>
       </column>
       <column name="parent_role_id" type="VARCHAR(36)">
-        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_parents"
-                     foreignKeyName="fk_roles_parents_parent" references="roles(id)" deleteCascade="true"/>
+        <constraints nullable="false"
+                     foreignKeyName="fk_roles_parents_parent" references="roles(id)"/>
       </column>
     </createTable>
+
+    <addPrimaryKey
+            tableName="roles_parents"
+            columnNames="role_id, parent_role_id"
+            constraintName="pk_roles_parents"/>
   </changeSet>
 </databaseChangeLog>

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.1/007-insert-default-authorities.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.1/007-insert-default-authorities.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-007-mysql-insert-default-authorities" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <rowCount tableName="authorities" expectedRows="0"/>
+    </preConditions>
+
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a1"/>
+      <column name="name" value="ENV_VALUES_READ"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a2"/>
+      <column name="name" value="CONFIG_PROPS_VALUES_READ"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a3"/>
+      <column name="name" value="SCHEDULED_TASKS_MODIFY"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a4"/>
+      <column name="name" value="CACHES_CLEAR"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a5"/>
+      <column name="name" value="CACHES_TOGGLE"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a6"/>
+      <column name="name" value="GARBAGE_COLLECTOR"/>
+    </insert>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.1/008-insert-default-roles.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.1/008-insert-default-roles.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-008-mysql-insert-default-roles" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <rowCount tableName="roles" expectedRows="0"/>
+    </preConditions>
+
+    <insert tableName="roles">
+      <column name="id" value="00000000-0000-0000-0000-0000000000b1"/>
+      <column name="name" value="VIEWER"/>
+      <column name="description" value="Read-only access to the monitored applications."/>
+      <column name="role_origin" value="BUILT_IN"/>
+    </insert>
+    <insert tableName="roles">
+      <column name="id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="name" value="EDITOR"/>
+      <column name="description" value="Performs runtime operations on the monitored applications, including destructive ones such as clearing caches."/>
+      <column name="role_origin" value="BUILT_IN"/>
+    </insert>
+    <insert tableName="roles">
+      <column name="id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="name" value="ADMIN"/>
+      <column name="description" value="Everything an editor can do, plus reading sensitive configuration values."/>
+      <column name="role_origin" value="BUILT_IN"/>
+    </insert>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.1/009-insert-default-roles-authorities.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.1/009-insert-default-roles-authorities.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-009-mysql-insert-default-roles-authorities" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <rowCount tableName="roles_authorities" expectedRows="0"/>
+    </preConditions>
+
+    <!-- VIEWER has no authorities. -->
+
+    <!-- EDITOR. -->
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a3"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a4"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a5"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a6"/>
+    </insert>
+
+    <!-- ADMIN. -->
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a3"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a4"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a5"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a6"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a1"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a2"/>
+    </insert>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/mysql/changelog/1.1/010-migrate-user-roles-to-users-roles.xml
+++ b/master/src/main/resources/db/changelog/mysql/changelog/1.1/010-migrate-user-roles-to-users-roles.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-010-mysql-migrate-user-roles-to-users-roles" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <rowCount tableName="users_roles" expectedRows="0"/>
+    </preConditions>
+
+    <comment>
+      Fills users_roles from the legacy users.roles JSON column. The column itself is intentionally left in place:
+      it is kept up to date so that a rollback to a previous Axelix version does not lose the role assignments.
+    </comment>
+
+    <sql>
+      INSERT INTO users_roles (user_id, role_id)
+      SELECT DISTINCT u.id, r.id
+      FROM users u
+      JOIN JSON_TABLE(u.roles, '$[*]' COLUMNS (role_name VARCHAR(255) PATH '$')) AS jt
+      JOIN roles r ON r.name = UPPER(TRIM(jt.role_name))
+      WHERE u.roles IS NOT NULL AND u.roles &lt;&gt; '';
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.1/002-create-roles-table.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.1/002-create-roles-table.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-002-postgres-create-roles-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="roles"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="roles">
+      <column name="id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles"/>
+      </column>
+      <column name="name" type="TEXT">
+        <constraints nullable="false" unique="true" uniqueConstraintName="uq_roles_name"/>
+      </column>
+      <column name="description" type="TEXT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="role_origin" type="TEXT">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.1/003-create-authorities-table.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.1/003-create-authorities-table.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-003-postgres-create-authorities-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="authorities"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="authorities">
+      <column name="id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_authorities"/>
+      </column>
+      <column name="name" type="TEXT">
+        <constraints nullable="false" unique="true" uniqueConstraintName="uq_authorities_name"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.1/004-create-roles-authorities-table.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.1/004-create-roles-authorities-table.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-004-postgres-create-roles-authorities-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="roles_authorities"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="roles_authorities">
+      <column name="role_id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_authorities"
+                     foreignKeyName="fk_roles_authorities_role" references="roles(id)" deleteCascade="true"/>
+      </column>
+      <column name="authority_id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_authorities"
+                     foreignKeyName="fk_roles_authorities_authority" references="authorities(id)" deleteCascade="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.1/004-create-roles-authorities-table.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.1/004-create-roles-authorities-table.xml
@@ -15,13 +15,18 @@
 
     <createTable tableName="roles_authorities">
       <column name="role_id" type="TEXT">
-        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_authorities"
-                     foreignKeyName="fk_roles_authorities_role" references="roles(id)" deleteCascade="true"/>
+        <constraints nullable="false"
+                     foreignKeyName="fk_roles_authorities_role" references="roles(id)"/>
       </column>
       <column name="authority_id" type="TEXT">
-        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_authorities"
-                     foreignKeyName="fk_roles_authorities_authority" references="authorities(id)" deleteCascade="true"/>
+        <constraints nullable="false"
+                     foreignKeyName="fk_roles_authorities_authority" references="authorities(id)"/>
       </column>
     </createTable>
+
+    <addPrimaryKey
+            tableName="roles_authorities"
+            columnNames="role_id, authority_id"
+            constraintName="pk_roles_authorities"/>
   </changeSet>
 </databaseChangeLog>

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.1/005-create-users-roles-table.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.1/005-create-users-roles-table.xml
@@ -15,13 +15,18 @@
 
     <createTable tableName="users_roles">
       <column name="user_id" type="TEXT">
-        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_users_roles"
-                     foreignKeyName="fk_users_roles_user" references="users(id)" deleteCascade="true"/>
+        <constraints nullable="false"
+                     foreignKeyName="fk_users_roles_user" references="users(id)"/>
       </column>
       <column name="role_id" type="TEXT">
-        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_users_roles"
-                     foreignKeyName="fk_users_roles_role" references="roles(id)" deleteCascade="true"/>
+        <constraints nullable="false"
+                     foreignKeyName="fk_users_roles_role" references="roles(id)"/>
       </column>
     </createTable>
+
+    <addPrimaryKey
+            tableName="users_roles"
+            columnNames="user_id, role_id"
+            constraintName="pk_users_roles"/>
   </changeSet>
 </databaseChangeLog>

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.1/005-create-users-roles-table.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.1/005-create-users-roles-table.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-005-postgres-create-users-roles-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="users_roles"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="users_roles">
+      <column name="user_id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_users_roles"
+                     foreignKeyName="fk_users_roles_user" references="users(id)" deleteCascade="true"/>
+      </column>
+      <column name="role_id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_users_roles"
+                     foreignKeyName="fk_users_roles_role" references="roles(id)" deleteCascade="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.1/006-create-roles-parents-table.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.1/006-create-roles-parents-table.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-006-postgres-create-roles-parents-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="roles_parents"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="roles_parents">
+      <column name="role_id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_parents"
+                     foreignKeyName="fk_roles_parents_role" references="roles(id)" deleteCascade="true"/>
+      </column>
+      <column name="parent_role_id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_parents"
+                     foreignKeyName="fk_roles_parents_parent" references="roles(id)" deleteCascade="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.1/006-create-roles-parents-table.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.1/006-create-roles-parents-table.xml
@@ -15,13 +15,18 @@
 
     <createTable tableName="roles_parents">
       <column name="role_id" type="TEXT">
-        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_parents"
-                     foreignKeyName="fk_roles_parents_role" references="roles(id)" deleteCascade="true"/>
+        <constraints nullable="false"
+                     foreignKeyName="fk_roles_parents_role" references="roles(id)"/>
       </column>
       <column name="parent_role_id" type="TEXT">
-        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_parents"
-                     foreignKeyName="fk_roles_parents_parent" references="roles(id)" deleteCascade="true"/>
+        <constraints nullable="false"
+                     foreignKeyName="fk_roles_parents_parent" references="roles(id)"/>
       </column>
     </createTable>
+
+    <addPrimaryKey
+            tableName="roles_parents"
+            columnNames="role_id, parent_role_id"
+            constraintName="pk_roles_parents"/>
   </changeSet>
 </databaseChangeLog>

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.1/007-insert-default-authorities.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.1/007-insert-default-authorities.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-007-postgres-insert-default-authorities" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <rowCount tableName="authorities" expectedRows="0"/>
+    </preConditions>
+
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a1"/>
+      <column name="name" value="ENV_VALUES_READ"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a2"/>
+      <column name="name" value="CONFIG_PROPS_VALUES_READ"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a3"/>
+      <column name="name" value="SCHEDULED_TASKS_MODIFY"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a4"/>
+      <column name="name" value="CACHES_CLEAR"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a5"/>
+      <column name="name" value="CACHES_TOGGLE"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a6"/>
+      <column name="name" value="GARBAGE_COLLECTOR"/>
+    </insert>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.1/008-insert-default-roles.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.1/008-insert-default-roles.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-008-postgres-insert-default-roles" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <rowCount tableName="roles" expectedRows="0"/>
+    </preConditions>
+
+    <insert tableName="roles">
+      <column name="id" value="00000000-0000-0000-0000-0000000000b1"/>
+      <column name="name" value="VIEWER"/>
+      <column name="description" value="Read-only access to the monitored applications."/>
+      <column name="role_origin" value="BUILT_IN"/>
+    </insert>
+    <insert tableName="roles">
+      <column name="id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="name" value="EDITOR"/>
+      <column name="description" value="Performs runtime operations on the monitored applications, including destructive ones such as clearing caches."/>
+      <column name="role_origin" value="BUILT_IN"/>
+    </insert>
+    <insert tableName="roles">
+      <column name="id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="name" value="ADMIN"/>
+      <column name="description" value="Everything an editor can do, plus reading sensitive configuration values."/>
+      <column name="role_origin" value="BUILT_IN"/>
+    </insert>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.1/009-insert-default-roles-authorities.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.1/009-insert-default-roles-authorities.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-009-postgres-insert-default-roles-authorities" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <rowCount tableName="roles_authorities" expectedRows="0"/>
+    </preConditions>
+
+    <!-- VIEWER has no authorities. -->
+
+    <!-- EDITOR. -->
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a3"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a4"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a5"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a6"/>
+    </insert>
+
+    <!-- ADMIN. -->
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a3"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a4"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a5"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a6"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a1"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a2"/>
+    </insert>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/postgres/changelog/1.1/010-migrate-user-roles-to-users-roles.xml
+++ b/master/src/main/resources/db/changelog/postgres/changelog/1.1/010-migrate-user-roles-to-users-roles.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-010-postgres-migrate-user-roles-to-users-roles" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <rowCount tableName="users_roles" expectedRows="0"/>
+    </preConditions>
+
+    <comment>
+      Fills users_roles from the legacy users.roles JSON column. The column itself is intentionally left in place:
+      it is kept up to date so that a rollback to a previous Axelix version does not lose the role assignments.
+    </comment>
+
+    <sql>
+      INSERT INTO users_roles (user_id, role_id)
+      SELECT DISTINCT u.id, r.id
+      FROM users u
+      CROSS JOIN LATERAL jsonb_array_elements_text(u.roles::jsonb) AS role_name
+      JOIN roles r ON r.name = UPPER(TRIM(role_name))
+      WHERE u.roles IS NOT NULL AND u.roles &lt;&gt; '';
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.1/002-create-roles-table.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.1/002-create-roles-table.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-002-sqlite-create-roles-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="roles"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="roles">
+      <column name="id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles"/>
+      </column>
+      <column name="name" type="TEXT">
+        <constraints nullable="false" unique="true" uniqueConstraintName="uq_roles_name"/>
+      </column>
+      <column name="description" type="TEXT">
+        <constraints nullable="false"/>
+      </column>
+      <column name="role_origin" type="TEXT">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.1/003-create-authorities-table.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.1/003-create-authorities-table.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-003-sqlite-create-authorities-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="authorities"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="authorities">
+      <column name="id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_authorities"/>
+      </column>
+      <column name="name" type="TEXT">
+        <constraints nullable="false" unique="true" uniqueConstraintName="uq_authorities_name"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.1/004-create-roles-authorities-table.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.1/004-create-roles-authorities-table.xml
@@ -16,11 +16,11 @@
     <createTable tableName="roles_authorities">
       <column name="role_id" type="TEXT">
         <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_authorities"
-                     foreignKeyName="fk_roles_authorities_role" references="roles(id)" deleteCascade="true"/>
+                     foreignKeyName="fk_roles_authorities_role" references="roles(id)"/>
       </column>
       <column name="authority_id" type="TEXT">
         <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_authorities"
-                     foreignKeyName="fk_roles_authorities_authority" references="authorities(id)" deleteCascade="true"/>
+                     foreignKeyName="fk_roles_authorities_authority" references="authorities(id)"/>
       </column>
     </createTable>
   </changeSet>

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.1/004-create-roles-authorities-table.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.1/004-create-roles-authorities-table.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-004-sqlite-create-roles-authorities-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="roles_authorities"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="roles_authorities">
+      <column name="role_id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_authorities"
+                     foreignKeyName="fk_roles_authorities_role" references="roles(id)" deleteCascade="true"/>
+      </column>
+      <column name="authority_id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_authorities"
+                     foreignKeyName="fk_roles_authorities_authority" references="authorities(id)" deleteCascade="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.1/005-create-users-roles-table.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.1/005-create-users-roles-table.xml
@@ -16,11 +16,11 @@
     <createTable tableName="users_roles">
       <column name="user_id" type="TEXT">
         <constraints nullable="false" primaryKey="true" primaryKeyName="pk_users_roles"
-                     foreignKeyName="fk_users_roles_user" references="users(id)" deleteCascade="true"/>
+                     foreignKeyName="fk_users_roles_user" references="users(id)"/>
       </column>
       <column name="role_id" type="TEXT">
         <constraints nullable="false" primaryKey="true" primaryKeyName="pk_users_roles"
-                     foreignKeyName="fk_users_roles_role" references="roles(id)" deleteCascade="true"/>
+                     foreignKeyName="fk_users_roles_role" references="roles(id)"/>
       </column>
     </createTable>
   </changeSet>

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.1/005-create-users-roles-table.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.1/005-create-users-roles-table.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-005-sqlite-create-users-roles-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="users_roles"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="users_roles">
+      <column name="user_id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_users_roles"
+                     foreignKeyName="fk_users_roles_user" references="users(id)" deleteCascade="true"/>
+      </column>
+      <column name="role_id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_users_roles"
+                     foreignKeyName="fk_users_roles_role" references="roles(id)" deleteCascade="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.1/006-create-roles-parents-table.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.1/006-create-roles-parents-table.xml
@@ -16,11 +16,11 @@
     <createTable tableName="roles_parents">
       <column name="role_id" type="TEXT">
         <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_parents"
-                     foreignKeyName="fk_roles_parents_role" references="roles(id)" deleteCascade="true"/>
+                     foreignKeyName="fk_roles_parents_role" references="roles(id)"/>
       </column>
       <column name="parent_role_id" type="TEXT">
         <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_parents"
-                     foreignKeyName="fk_roles_parents_parent" references="roles(id)" deleteCascade="true"/>
+                     foreignKeyName="fk_roles_parents_parent" references="roles(id)"/>
       </column>
     </createTable>
   </changeSet>

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.1/006-create-roles-parents-table.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.1/006-create-roles-parents-table.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-006-sqlite-create-roles-parents-table" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <not>
+        <tableExists tableName="roles_parents"/>
+      </not>
+    </preConditions>
+
+    <createTable tableName="roles_parents">
+      <column name="role_id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_parents"
+                     foreignKeyName="fk_roles_parents_role" references="roles(id)" deleteCascade="true"/>
+      </column>
+      <column name="parent_role_id" type="TEXT">
+        <constraints nullable="false" primaryKey="true" primaryKeyName="pk_roles_parents"
+                     foreignKeyName="fk_roles_parents_parent" references="roles(id)" deleteCascade="true"/>
+      </column>
+    </createTable>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.1/007-insert-default-authorities.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.1/007-insert-default-authorities.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-007-sqlite-insert-default-authorities" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <rowCount tableName="authorities" expectedRows="0"/>
+    </preConditions>
+
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a1"/>
+      <column name="name" value="ENV_VALUES_READ"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a2"/>
+      <column name="name" value="CONFIG_PROPS_VALUES_READ"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a3"/>
+      <column name="name" value="SCHEDULED_TASKS_MODIFY"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a4"/>
+      <column name="name" value="CACHES_CLEAR"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a5"/>
+      <column name="name" value="CACHES_TOGGLE"/>
+    </insert>
+    <insert tableName="authorities">
+      <column name="id" value="00000000-0000-0000-0000-0000000000a6"/>
+      <column name="name" value="GARBAGE_COLLECTOR"/>
+    </insert>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.1/008-insert-default-roles.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.1/008-insert-default-roles.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-008-sqlite-insert-default-roles" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <rowCount tableName="roles" expectedRows="0"/>
+    </preConditions>
+
+    <insert tableName="roles">
+      <column name="id" value="00000000-0000-0000-0000-0000000000b1"/>
+      <column name="name" value="VIEWER"/>
+      <column name="description" value="Read-only access to the monitored applications."/>
+      <column name="role_origin" value="BUILT_IN"/>
+    </insert>
+    <insert tableName="roles">
+      <column name="id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="name" value="EDITOR"/>
+      <column name="description" value="Performs runtime operations on the monitored applications, including destructive ones such as clearing caches."/>
+      <column name="role_origin" value="BUILT_IN"/>
+    </insert>
+    <insert tableName="roles">
+      <column name="id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="name" value="ADMIN"/>
+      <column name="description" value="Everything an editor can do, plus reading sensitive configuration values."/>
+      <column name="role_origin" value="BUILT_IN"/>
+    </insert>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.1/009-insert-default-roles-authorities.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.1/009-insert-default-roles-authorities.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-009-sqlite-insert-default-roles-authorities" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <rowCount tableName="roles_authorities" expectedRows="0"/>
+    </preConditions>
+
+    <!-- VIEWER has no authorities. -->
+
+    <!-- EDITOR. -->
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a3"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a4"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a5"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b2"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a6"/>
+    </insert>
+
+    <!-- ADMIN. -->
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a3"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a4"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a5"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a6"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a1"/>
+    </insert>
+    <insert tableName="roles_authorities">
+      <column name="role_id" value="00000000-0000-0000-0000-0000000000b3"/>
+      <column name="authority_id" value="00000000-0000-0000-0000-0000000000a2"/>
+    </insert>
+  </changeSet>
+</databaseChangeLog>

--- a/master/src/main/resources/db/changelog/sqlite/changelog/1.1/010-migrate-user-roles-to-users-roles.xml
+++ b/master/src/main/resources/db/changelog/sqlite/changelog/1.1/010-migrate-user-roles-to-users-roles.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+            http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="1.1-010-sqlite-migrate-user-roles-to-users-roles" author="Axelix Team">
+    <preConditions onFail="MARK_RAN" onError="HALT">
+      <rowCount tableName="users_roles" expectedRows="0"/>
+    </preConditions>
+
+    <comment>
+      Fills users_roles from the legacy users.roles JSON column. The column itself is intentionally left in place:
+      it is kept up to date so that a rollback to a previous Axelix version does not lose the role assignments.
+    </comment>
+
+    <sql>
+      INSERT INTO users_roles (user_id, role_id)
+      SELECT DISTINCT u.id, r.id
+      FROM users u
+      JOIN json_each(u.roles) AS role_name
+      JOIN roles r ON r.name = UPPER(TRIM(role_name.value))
+      WHERE u.roles IS NOT NULL AND u.roles &lt;&gt; '';
+    </sql>
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent role management with role lookup and authority resolution.
  * Added built-in `VIEWER`, `EDITOR`, and `ADMIN` roles.
  * Added default authorities and role-based authority assignments.
  * Added support for role origins including built-in, web interface, and YAML.
  * Added role inheritance and user-role assignment support.

* **Database**
  * Added migrations for roles, authorities, relationships, and legacy role data across supported databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->