### PR TITLE
Updated version references from 1.0.0-M1 to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ interface. Pick whichever shape matches how you ship the rest of your services.
 java \
   -Daxelix.master.auth.jwt.algorithm=HMAC512 \
   -Daxelix.master.auth.jwt.signing-key=replace-with-a-long-random-secret \
-  -jar axelix-1.0.0-M1.jar
+  -jar axelix-1.0.0.jar
 ```
 
 **With Docker.** The release image is published to GitHub Container Registry:
@@ -121,7 +121,7 @@ docker run --rm -p 8080:8080 \
     -Daxelix.master.auth.jwt.algorithm=HMAC512 \
     -Daxelix.master.auth.jwt.signing-key=replace-with-a-long-random-secret \
     -Daxelix.master.auth.options.super-admin.credentials.password=replace-me" \
-  ghcr.io/axelixlabs/axelix:1.0.0-M1
+  ghcr.io/axelixlabs/axelix:1.0.0
 ```
 
 **On Kubernetes.** Install the first-party Helm chart, which also wires the RBAC needed for

--- a/docs/docs/setting-up-master-ui/configuring-master/configuring-master.mdx
+++ b/docs/docs/setting-up-master-ui/configuring-master/configuring-master.mdx
@@ -15,7 +15,7 @@ A few facts to fix in your head before you copy any of the snippets below — th
 - **Database**: Master supports three engines, picked automatically from the JDBC URL prefix — **SQLite**
   (`jdbc:sqlite:`), **PostgreSQL** (`jdbc:postgresql:`), and **MySQL** (`jdbc:mysql:`). The default is SQLite, with a
   file named `axelix.db` next to the working directory. Liquibase runs schema migrations on every startup.
-- **Front-end assets**: the `axelix-1.0.0-M1.jar` and the published Docker image both bundle the UI — there is nothing
+- **Front-end assets**: the `axelix-1.0.0.jar` and the published Docker image both bundle the UI — there is nothing
   extra to wire up for the web interface.
 - **Authentication**: Master ships with a built-in super-admin account `admin / admin` and an unset JWT signing key. In
   any non-throwaway environment you must change both — see [Configuration reference](#configuration-reference).
@@ -197,7 +197,7 @@ runtime involved.
 
 ### 1. Download the JAR
 
-Grab the `axelix-1.0.0-M1.jar` attached to the release you want from the [Releases
+Grab the `axelix-1.0.0.jar` attached to the release you want from the [Releases
 page](https://github.com/axelixlabs/axelix/releases). The published artifact already bundles the UI, so there is nothing
 else to build.
 
@@ -209,7 +209,7 @@ Provide a JWT signing key and an algorithm. Everything else can stay on defaults
 java \
   -Daxelix.master.auth.jwt.algorithm=HMAC512 \
   -Daxelix.master.auth.jwt.signing-key=replace-with-a-long-random-secret \
-  -jar axelix-1.0.0-M1.jar
+  -jar axelix-1.0.0.jar
 ```
 
 Master is then reachable at `http://localhost:8080`. Sign in with the super-admin credentials you configured.
@@ -356,11 +356,11 @@ Use this when you want a single, immutable artifact that already bundles both Ma
 The release pipeline publishes the image to GitHub Container Registry:
 
 ```
-ghcr.io/axelixlabs/axelix:1.0.0-M1
+ghcr.io/axelixlabs/axelix:1.0.0
 ```
 
 :::note
-The snippets below pin `1.0.0-M1` for illustration. Check the [Releases
+The snippets below pin `1.0.0` for illustration. Check the [Releases
 page](https://github.com/axelixlabs/axelix/releases) for the latest published tag and substitute it in your own
 commands.
 :::
@@ -375,7 +375,7 @@ docker run --rm -p 8080:8080 \
     -Daxelix.master.auth.jwt.algorithm=HMAC512 \
     -Daxelix.master.auth.jwt.signing-key=replace-with-a-long-random-secret \
     -Daxelix.master.auth.options.super-admin.credentials.password=replace-me" \
-  ghcr.io/axelixlabs/axelix:1.0.0-M1
+  ghcr.io/axelixlabs/axelix:1.0.0
 ```
 
 A few notes about this command:
@@ -394,7 +394,7 @@ Use this when you want Master plus an external database in one declarative file 
 self-hosted deployment.
 
 The example below is a complete stack you can drop into a new `docker-compose.yaml`, edit, and start with `docker
-compose up -d`. The `master` service is pinned to `1.0.0-M1` here — swap in the latest tag from the [Releases
+compose up -d`. The `master` service is pinned to `1.0.0` here — swap in the latest tag from the [Releases
 page](https://github.com/axelixlabs/axelix/releases) before shipping.
 
 ```yaml title="docker-compose.yaml"
@@ -414,7 +414,7 @@ services:
       retries: 10
 
   master:
-    image: ghcr.io/axelixlabs/axelix:1.0.0-M1
+    image: ghcr.io/axelixlabs/axelix:1.0.0
     depends_on:
       postgres:
         condition: service_healthy
@@ -563,7 +563,7 @@ spec:
       serviceAccountName: axelix-master
       containers:
         - name: axelix-master
-          image: ghcr.io/axelixlabs/axelix:1.0.0-M1
+          image: ghcr.io/axelixlabs/axelix:1.0.0
 ```
 
 In K8S, a Role is a namespaced object, so repeat the Role and RoleBinding once per namespace in `filters.namespaces`, all referencing

--- a/docs/docs/setting-up-master-ui/migrations/migrations.mdx
+++ b/docs/docs/setting-up-master-ui/migrations/migrations.mdx
@@ -97,7 +97,7 @@ java \
   -Daxelix.master.database.password=... \
   -Daxelix.master.migrations.username=axelix_migrator \
   -Daxelix.master.migrations.password=... \
-  -jar axelix-1.0.0-M1.jar
+  -jar axelix-1.0.0.jar
 ```
 
 ### Run with Docker
@@ -113,7 +113,7 @@ docker run --rm -p 8080:8080 \
     -Daxelix.master.database.password=... \
     -Daxelix.master.migrations.username=axelix_migrator \
     -Daxelix.master.migrations.password=..." \
-  ghcr.io/axelixlabs/axelix:1.0.0-M1
+  ghcr.io/axelixlabs/axelix:1.0.0
 ```
 
 ### Run with Docker Compose
@@ -123,7 +123,7 @@ Add the migration properties to the `master` service's `JAVA_TOOL_OPTIONS`, alon
 ```yaml title="docker-compose.yaml"
 services:
   master:
-    image: ghcr.io/axelixlabs/axelix:1.0.0-M1
+    image: ghcr.io/axelixlabs/axelix:1.0.0
     ports:
       - "8080:8080"
     environment:

--- a/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-master-ui/configuring-master/configuring-master.mdx
+++ b/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-master-ui/configuring-master/configuring-master.mdx
@@ -17,7 +17,7 @@ import styles from './styles.module.css';
 - **База данных**: Master поддерживает три движка, которые выбираются автоматически по префиксу URL-адреса JDBC —
   **SQLite** (`jdbc:sqlite:`), **PostgreSQL** (`jdbc:postgresql:`), **MySQL** (`jdbc:mysql:`). По умолчанию используется
   SQLite с файлом `axelix.db` в рабочем каталоге. Liquibase выполняет миграцию схемы при каждом запуске.
-- **Веб-интерфейс**: `axelix-1.0.0-M1.jar` и опубликованный образ Docker содержат пользовательский интерфейс — для
+- **Веб-интерфейс**: `axelix-1.0.0.jar` и опубликованный образ Docker содержат пользовательский интерфейс — для
   подключения веб-интерфейса ничего дополнительно настраивать не нужно.
 - **Аутентификация**: в Master встроена учётная запись суперадминистратора `admin / admin` и не заданный ключ для
   подписи JWT. В любой среде, кроме тестовой, необходимо изменить оба параметра — см. [Справочник по
@@ -206,7 +206,7 @@ Starter](../../setting-up-spring-boot-service/configuring-axelix-starter/configu
 
 ### 1. Скачайте JAR
 
-Возьмите `axelix-1.0.0-M1.jar`, прикреплённый к нужному вам релизу, со [страницы
+Возьмите `axelix-1.0.0.jar`, прикреплённый к нужному вам релизу, со [страницы
 релизов](https://github.com/axelixlabs/axelix/releases). Опубликованный артефакт уже включает пользовательский
 интерфейс, поэтому ничего больше собирать не нужно.
 
@@ -218,7 +218,7 @@ Starter](../../setting-up-spring-boot-service/configuring-axelix-starter/configu
 java \
   -Daxelix.master.auth.jwt.algorithm=HMAC512 \
   -Daxelix.master.auth.jwt.signing-key=replace-with-a-long-random-secret \
-  -jar axelix-1.0.0-M1.jar
+  -jar axelix-1.0.0.jar
 ```
 
 После этого Master доступен по адресу `http://localhost:8080`. Войдите с учётными данными суперадминистратора, которые
@@ -367,11 +367,11 @@ axelix.master.auth.cookie.secure=true
 Конвейер выпуска публикует образ в GitHub Container Registry:
 
 ```
-ghcr.io/axelixlabs/axelix:1.0.0-M1
+ghcr.io/axelixlabs/axelix:1.0.0
 ```
 
 :::note
-Приведённые ниже фрагменты кода содержат `1.0.0-M1` для наглядности. Проверьте [страницу
+Приведённые ниже фрагменты кода содержат `1.0.0` для наглядности. Проверьте [страницу
 релизов](https://github.com/axelixlabs/axelix/releases) на актуальную опубликованную метку и подставьте её в свои
 команды.
 :::
@@ -386,7 +386,7 @@ docker run --rm -p 8080:8080 \
     -Daxelix.master.auth.jwt.algorithm=HMAC512 \
     -Daxelix.master.auth.jwt.signing-key=replace-with-a-long-random-secret \
     -Daxelix.master.auth.options.super-admin.credentials.password=replace-me" \
-  ghcr.io/axelixlabs/axelix:1.0.0-M1
+  ghcr.io/axelixlabs/axelix:1.0.0
 ```
 
 Несколько примечаний об этой команде:
@@ -405,7 +405,7 @@ docker run --rm -p 8080:8080 \
 для небольшого self-hosted развёртывания.
 
 Приведённый ниже пример представляет собой готовый стек, который можно положить в новый `docker-compose.yaml`,
-отредактировать и запустить с помощью `docker compose up -d`. Сервис `master` здесь зафиксирован на `1.0.0-M1` —
+отредактировать и запустить с помощью `docker compose up -d`. Сервис `master` здесь зафиксирован на `1.0.0` —
 подставьте актуальную метку со [страницы релизов](https://github.com/axelixlabs/axelix/releases) перед отправкой в
 продакшен.
 
@@ -426,7 +426,7 @@ services:
       retries: 10
 
   master:
-    image: ghcr.io/axelixlabs/axelix:1.0.0-M1
+    image: ghcr.io/axelixlabs/axelix:1.0.0
     depends_on:
       postgres:
         condition: service_healthy
@@ -578,7 +578,7 @@ spec:
       serviceAccountName: axelix-master
       containers:
         - name: axelix-master
-          image: ghcr.io/axelixlabs/axelix:1.0.0-M1
+          image: ghcr.io/axelixlabs/axelix:1.0.0
 ```
 
 В Kubernetes Role — это объект, привязанный к пространству имён, поэтому повторите Role и RoleBinding по одному разу на

--- a/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-master-ui/migrations/migrations.mdx
+++ b/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-master-ui/migrations/migrations.mdx
@@ -101,7 +101,7 @@ java \
   -Daxelix.master.database.password=... \
   -Daxelix.master.migrations.username=axelix_migrator \
   -Daxelix.master.migrations.password=... \
-  -jar axelix-1.0.0-M1.jar
+  -jar axelix-1.0.0.jar
 ```
 
 ### Запуск в Docker
@@ -117,7 +117,7 @@ docker run --rm -p 8080:8080 \
     -Daxelix.master.database.password=... \
     -Daxelix.master.migrations.username=axelix_migrator \
     -Daxelix.master.migrations.password=..." \
-  ghcr.io/axelixlabs/axelix:1.0.0-M1
+  ghcr.io/axelixlabs/axelix:1.0.0
 ```
 
 ### Запуск с Docker Compose
@@ -127,7 +127,7 @@ docker run --rm -p 8080:8080 \
 ```yaml title="docker-compose.yaml"
 services:
   master:
-    image: ghcr.io/axelixlabs/axelix:1.0.0-M1
+    image: ghcr.io/axelixlabs/axelix:1.0.0
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
Replaces the `1.0.0-M1` milestone version with the `1.0.0` release version across README and the Master setup docs (JAR filename and Docker image tag examples), including the Russian i18n copies.  