### PR TITLE
Implement AutoCloseable interface for graceful resource cleanup in Scheduled tasks domain for SB 4

### DIFF
--- a/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistryTest.java
+++ b/sbs/axelix-spring-boot-2-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistryTest.java
@@ -114,12 +114,10 @@ class ScheduledTasksRegistryTest {
     @Test // GH-1497
     @DirtiesContext
     void shouldCancelAllManagedTasksWhenRegistryCloses() {
-        Collection<ManagedScheduledTask> managedTasks = taskRegistry.getAll();
-        assertThat(managedTasks).isNotEmpty();
-
         List<ManagedScheduledTask> tasksSnapshot = new ArrayList<>(taskRegistry.getAll());
+        assertThat(tasksSnapshot).isNotEmpty();
 
-        for (ManagedScheduledTask task : managedTasks) {
+        for (ManagedScheduledTask task : tasksSnapshot) {
             assertThat(task.isEnabled()).isTrue();
         }
 

--- a/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistryTest.java
+++ b/sbs/axelix-spring-boot-3-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistryTest.java
@@ -117,12 +117,10 @@ class ScheduledTasksRegistryTest {
     @Test // GH-1497
     @DirtiesContext
     void shouldCancelAllManagedTasksWhenRegistryCloses() {
-        Collection<ManagedScheduledTask> managedTasks = taskRegistry.getAll();
-        assertThat(managedTasks).isNotEmpty();
-
         List<ManagedScheduledTask> tasksSnapshot = new ArrayList<>(taskRegistry.getAll());
+        assertThat(tasksSnapshot).isNotEmpty();
 
-        for (ManagedScheduledTask task : managedTasks) {
+        for (ManagedScheduledTask task : tasksSnapshot) {
             assertThat(task.isEnabled()).isTrue();
         }
 

--- a/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/DefaultScheduledTasksAssembler.java
+++ b/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/DefaultScheduledTasksAssembler.java
@@ -33,8 +33,9 @@ import com.axelixlabs.axelix.common.api.ServiceScheduledTasks;
  *
  * @author Sergey Cherkasov
  * @author Mikhail Polivakha
+ * @author Vyacheslav Yanin
  */
-public class DefaultScheduledTasksAssembler implements ScheduledTasksAssembler {
+public class DefaultScheduledTasksAssembler implements ScheduledTasksAssembler, AutoCloseable {
 
     private final ScheduledTasksRegistry registry;
 
@@ -121,5 +122,12 @@ public class DefaultScheduledTasksAssembler implements ScheduledTasksAssembler {
                 null,
                 null,
                 managedScheduledTask.isEnabled());
+    }
+
+    @Override
+    public void close() {
+        if (this.registry != null) {
+            this.registry.close();
+        }
     }
 }

--- a/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ManagedScheduledTask.java
+++ b/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ManagedScheduledTask.java
@@ -38,8 +38,9 @@ import org.springframework.util.ReflectionUtils;
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Chaerkasov
+ * @author Vyacheslav Yanin
  */
-public class ManagedScheduledTask {
+public class ManagedScheduledTask implements AutoCloseable {
 
     /**
      * Reflection field access to the package-private 'future' field in {@link ScheduledTask}.
@@ -131,6 +132,13 @@ public class ManagedScheduledTask {
             throw new IllegalStateException("Failed to set 'future' in ScheduledTask", e);
         } catch (InvocationTargetException | InstantiationException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (this.scheduledTask != null) {
+            this.scheduledTask.cancel();
         }
     }
 }

--- a/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskService.java
+++ b/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskService.java
@@ -41,8 +41,9 @@ import org.springframework.scheduling.support.CronTrigger;
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
  * @author Sergey Chaerkasov
+ * @author Vyacheslav Yanin
  */
-public final class ScheduledTaskService {
+public final class ScheduledTaskService implements AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(ScheduledTaskService.class);
 
@@ -196,6 +197,13 @@ public final class ScheduledTaskService {
                     "Cancelled task future: {} (mayInterrupt: {}, success: {})", managedTask.getId(), force, cancelled);
         } else {
             log.debug("No future to cancel for task: {}", managedTask.getId());
+        }
+    }
+
+    @Override
+    public void close() {
+        if (this.registry != null) {
+            this.registry.close();
         }
     }
 }

--- a/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistry.java
+++ b/sbs/axelix-spring-boot-4-starter/src/main/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistry.java
@@ -40,8 +40,9 @@ import org.springframework.scheduling.config.Task;
  * @since 14.10.2025
  * @author Nikita Kirillov
  * @author Mikhail Polivakha
+ * @author Vyacheslav Yanin
  */
-public class ScheduledTasksRegistry implements ApplicationListener<ContextRefreshedEvent> {
+public class ScheduledTasksRegistry implements ApplicationListener<ContextRefreshedEvent>, AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(ScheduledTasksRegistry.class);
 
@@ -81,5 +82,20 @@ public class ScheduledTasksRegistry implements ApplicationListener<ContextRefres
         Task t = task.getTask();
         Runnable r = t.getRunnable();
         return r.toString();
+    }
+
+    @Override
+    public void close() {
+        log.info("Closing ScheduledTasksRegistry, cancelling {} managed tasks", tasks.size());
+        for (ManagedScheduledTask task : tasks.values()) {
+            if (task != null) {
+                try {
+                    task.close();
+                } catch (Exception e) {
+                    log.error("Failed to close managed scheduled task with id: {}", task.getId(), e);
+                }
+            }
+        }
+        tasks.clear();
     }
 }

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -25,11 +25,13 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.AxelixScheduledTasksEndpoint;
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.IntervalBasedTaskRescheduler;
+import com.axelixlabs.axelix.sbs.spring.core.scheduled.ManagedScheduledTask;
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTaskService;
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksAssembler;
 import com.axelixlabs.axelix.sbs.spring.core.scheduled.ScheduledTasksRegistry;
@@ -44,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since 10.02.2026
  * @author Nikita Kirillov
  * @author Dmitry Kiselev
+ * @author Vyacheslav Yanin
  */
 class ScheduledTaskManagementAutoConfigurationTest {
 
@@ -139,6 +142,24 @@ class ScheduledTaskManagementAutoConfigurationTest {
                 });
     }
 
+    @Test // GH-1497
+    void shouldCancelAllManagedTasksWhenContextCloses() {
+        contextRunner.run(context -> {
+            ScheduledTasksRegistry registry = context.getBean(ScheduledTasksRegistry.class);
+
+            assertThat(registry.getAll()).isNotEmpty();
+            for (ManagedScheduledTask task : registry.getAll()) {
+                assertThat(task.isEnabled()).isTrue();
+            }
+
+            context.close();
+
+            for (ManagedScheduledTask task : registry.getAll()) {
+                assertThat(task.isEnabled()).isFalse();
+            }
+        });
+    }
+
     @TestConfiguration
     @EnableScheduling
     static class EnableSchedulingConfig {
@@ -147,6 +168,10 @@ class ScheduledTaskManagementAutoConfigurationTest {
         public TaskScheduler taskScheduler() {
             return new ThreadPoolTaskScheduler();
         }
+
+        // simulation of schedule tasks
+        @Scheduled(fixedDelay = 10000)
+        public void someMockTask() {}
     }
 
     @TestConfiguration

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/autoconfiguration/ScheduledTaskManagementAutoConfigurationTest.java
@@ -17,6 +17,9 @@
  */
 package com.axelixlabs.axelix.sbs.spring.autoconfiguration;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -147,14 +150,16 @@ class ScheduledTaskManagementAutoConfigurationTest {
         contextRunner.run(context -> {
             ScheduledTasksRegistry registry = context.getBean(ScheduledTasksRegistry.class);
 
-            assertThat(registry.getAll()).isNotEmpty();
-            for (ManagedScheduledTask task : registry.getAll()) {
+            Collection<ManagedScheduledTask> snapshot = new ArrayList<>(registry.getAll());
+
+            assertThat(snapshot).isNotEmpty();
+            for (ManagedScheduledTask task : snapshot) {
                 assertThat(task.isEnabled()).isTrue();
             }
 
             context.close();
 
-            for (ManagedScheduledTask task : registry.getAll()) {
+            for (ManagedScheduledTask task : snapshot) {
                 assertThat(task.isEnabled()).isFalse();
             }
         });

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskServiceTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskServiceTest.java
@@ -20,6 +20,7 @@ package com.axelixlabs.axelix.sbs.spring.core.scheduled;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -55,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @since 14.10.2025
  * @author Nikita Kirillov
  * @author Sergey Cherkasov
+ * @author Vyacheslav Yanin
  */
 @SpringBootTest
 @Import(ScheduledTaskServiceTest.ScheduledTaskServiceTestConfiguration.class)
@@ -266,6 +268,23 @@ class ScheduledTaskServiceTest {
         // then task exists and was executed
         taskRegistry.find(FIXED_RATE_TASK_ID_FOR_EXECUTE).orElseThrow();
         assertThat(fixedRateFlagForExecute).isTrue();
+    }
+
+    @Test // GH-1497
+    @DirtiesContext
+    void shouldCancelAllTasksAndClearRegistryWhenServiceCloses() {
+        Optional<ManagedScheduledTask> taskBefore = taskService.find(CRON_TASK_ID);
+        assertThat(taskBefore).isPresent();
+        assertThat(taskBefore.get().isEnabled()).isTrue();
+
+        ManagedScheduledTask managedTask = taskBefore.get();
+
+        taskService.close();
+
+        assertThat(managedTask.isEnabled()).isFalse();
+
+        Optional<ManagedScheduledTask> taskAfter = taskService.find(CRON_TASK_ID);
+        assertThat(taskAfter).isEmpty();
     }
 
     @TestConfiguration

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskServiceTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTaskServiceTest.java
@@ -271,7 +271,6 @@ class ScheduledTaskServiceTest {
     }
 
     @Test // GH-1497
-    @DirtiesContext
     void shouldCancelAllTasksAndClearRegistryWhenServiceCloses() {
         Optional<ManagedScheduledTask> taskBefore = taskService.find(CRON_TASK_ID);
         assertThat(taskBefore).isPresent();

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistryTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistryTest.java
@@ -18,6 +18,7 @@
 package com.axelixlabs.axelix.sbs.spring.core.scheduled;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -42,6 +43,7 @@ import org.springframework.scheduling.config.FixedRateTask;
 import org.springframework.scheduling.config.ScheduledTask;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.scheduling.config.TriggerTask;
+import org.springframework.test.annotation.DirtiesContext;
 
 import com.axelixlabs.axelix.sbs.spring.core.IgnoreTestContextArchitecture;
 
@@ -53,6 +55,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @since 14.10.2025
  * @author Nikita Kirillov
+ * @author Vyacheslav Yanin
  */
 @SpringBootTest
 @Import(ScheduledTasksRegistryTest.ScheduledTaskRegistryTestConfiguration.class)
@@ -109,6 +112,26 @@ class ScheduledTasksRegistryTest {
                         task -> assertThat(task).isInstanceOf(FixedDelayTask.class),
                         task -> assertThat(task).isInstanceOf(FixedRateTask.class),
                         task -> assertThat(task).isInstanceOf(TriggerTask.class).isNotInstanceOf(CronTask.class));
+    }
+
+    @Test // GH-1497
+    @DirtiesContext
+    void shouldCancelAllManagedTasksWhenRegistryCloses() {
+        Collection<ManagedScheduledTask> managedTasks = taskRegistry.getAll();
+        assertThat(managedTasks).isNotEmpty();
+
+        List<ManagedScheduledTask> tasksSnapshot = new ArrayList<>(taskRegistry.getAll());
+
+        for (ManagedScheduledTask task : managedTasks) {
+            assertThat(task.isEnabled()).isTrue();
+        }
+
+        taskRegistry.close();
+
+        for (ManagedScheduledTask task : tasksSnapshot) {
+            assertThat(task.isEnabled()).isFalse();
+        }
+        assertThat(taskRegistry.getAll()).isEmpty();
     }
 
     @TestConfiguration

--- a/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistryTest.java
+++ b/sbs/axelix-spring-boot-4-starter/src/test/java/com/axelixlabs/axelix/sbs/spring/core/scheduled/ScheduledTasksRegistryTest.java
@@ -117,12 +117,10 @@ class ScheduledTasksRegistryTest {
     @Test // GH-1497
     @DirtiesContext
     void shouldCancelAllManagedTasksWhenRegistryCloses() {
-        Collection<ManagedScheduledTask> managedTasks = taskRegistry.getAll();
-        assertThat(managedTasks).isNotEmpty();
-
         List<ManagedScheduledTask> tasksSnapshot = new ArrayList<>(taskRegistry.getAll());
+        assertThat(tasksSnapshot).isNotEmpty();
 
-        for (ManagedScheduledTask task : managedTasks) {
+        for (ManagedScheduledTask task : tasksSnapshot) {
             assertThat(task.isEnabled()).isTrue();
         }
 


### PR DESCRIPTION
Introduce automatic management of scheduled tasks lifecycles by leveraging Spring's default shutdown hooks. This ensures all active scheduled futures are explicitly cancelled and memory-managed registries are cleared upon application context termination.

Integration tests using ApplicationContextRunner and DirtiesContext have been added to verify that task states transition cleanly during the shutdown phase.

Close #1497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle controls for scheduled tasks and their registries.
  * Scheduled tasks are automatically cancelled and removed when services or application contexts close.
  * Shutdown handling records closure activity and continues safely if an individual task fails.

* **Bug Fixes**
  * Ensured managed scheduled tasks are disabled after registry or service shutdown.

* **Tests**
  * Added coverage for task lifecycle behavior before and after application shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->