### PR TITLE
GH-1496: Document OTLP metrics export for Master

### DIFF
--- a/docs/docs/setting-up-master-ui/configuring-master/configuring-master.mdx
+++ b/docs/docs/setting-up-master-ui/configuring-master/configuring-master.mdx
@@ -293,6 +293,49 @@ axelix:
           region: eu-west-1
 ```
 
+#### OTLP
+
+<UpcomingReleaseNotice />
+
+Master can push its own JVM, HTTP, database-pool, and other Micrometer metrics to an OTLP-compatible collector over
+HTTP/protobuf. This exports metrics produced by Master itself, not metrics read from services connected through an
+Axelix starter. Export is disabled by default, so upgrading Master does not create outbound telemetry traffic.
+
+<div className={styles.ConfigTable}>
+
+| Property                                      | Default                            | Description                                                                                   |
+|-----------------------------------------------|------------------------------------|-----------------------------------------------------------------------------------------------|
+| `axelix.master.metrics.otlp.enabled`          | `false`                            | Enables periodic OTLP metrics export.                                                         |
+| `axelix.master.metrics.otlp.url`              | `http://localhost:4318/v1/metrics` | Complete HTTP/protobuf metrics endpoint. Include the `/v1/metrics` path.                       |
+| `axelix.master.metrics.otlp.step`             | `1m`                               | Interval between exports, expressed as a Spring `Duration`.                                   |
+| `axelix.master.metrics.otlp.headers.*`        | empty                              | Custom request headers, for example an authorization header. Inject secret values at runtime. |
+| `axelix.master.metrics.otlp.compression-mode` | `none`                             | Request compression mode: `none` or `gzip`.                                                   |
+
+</div>
+
+```yaml
+axelix:
+  master:
+    metrics:
+      otlp:
+        enabled: true
+        url: http://otel-collector:4318/v1/metrics
+        step: 30s
+        headers:
+          Authorization: ${OTLP_AUTHORIZATION_HEADER}
+```
+
+The same settings can be supplied through environment variables:
+
+```bash
+AXELIX_MASTER_METRICS_OTLP_ENABLED=true
+AXELIX_MASTER_METRICS_OTLP_URL=http://otel-collector:4318/v1/metrics
+AXELIX_MASTER_METRICS_OTLP_HEADERS_AUTHORIZATION="Bearer my-token"
+```
+
+Prefer injecting authentication headers from your deployment platform's secret store instead of committing them to a
+configuration file.
+
 ## Run as a JAR
 
 Use this when you want the lightest possible runtime — a single process on a machine you already manage, no container

--- a/docs/docs/setting-up-master-ui/configuring-master/configuring-master.mdx
+++ b/docs/docs/setting-up-master-ui/configuring-master/configuring-master.mdx
@@ -299,7 +299,7 @@ axelix:
 
 Master can push its own JVM, HTTP, database-pool, and other Micrometer metrics to an OTLP-compatible collector over
 HTTP/protobuf. This exports metrics produced by Master itself, not metrics read from services connected through an
-Axelix starter. Export is disabled by default, so upgrading Master does not create outbound telemetry traffic.
+Axelix starter. Export of metrics via OTLP is disabled by default (see properties below).
 
 <div className={styles.ConfigTable}>
 
@@ -325,13 +325,9 @@ axelix:
           Authorization: ${OTLP_AUTHORIZATION_HEADER}
 ```
 
-The same settings can be supplied through environment variables:
-
-```bash
-AXELIX_MASTER_METRICS_OTLP_ENABLED=true
-AXELIX_MASTER_METRICS_OTLP_URL=http://otel-collector:4318/v1/metrics
-AXELIX_MASTER_METRICS_OTLP_HEADERS_AUTHORIZATION="Bearer my-token"
-```
+These settings can equally be supplied as environment variables or JVM system properties — see [Supplying
+properties](#supplying-properties) for the relaxed-binding rules that map, for example,
+`axelix.master.metrics.otlp.enabled` to `AXELIX_MASTER_METRICS_OTLP_ENABLED`.
 
 Prefer injecting authentication headers from your deployment platform's secret store instead of committing them to a
 configuration file.

--- a/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-master-ui/configuring-master/configuring-master.mdx
+++ b/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-master-ui/configuring-master/configuring-master.mdx
@@ -305,6 +305,49 @@ axelix:
           region: eu-west-1
 ```
 
+#### OTLP
+
+<UpcomingReleaseNotice />
+
+Master может отправлять собственные метрики JVM, HTTP, пула соединений с базой данных и другие метрики Micrometer в
+OTLP-совместимый коллектор по HTTP/protobuf. Экспортируются метрики самого Master, а не метрики сервисов, подключённых
+через стартер Axelix. По умолчанию экспорт выключен, поэтому обновление Master не создаёт исходящий трафик телеметрии.
+
+<div className={styles.ConfigTable}>
+
+| Свойство                                      | По умолчанию                       | Описание                                                                                                           |
+|-----------------------------------------------|------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `axelix.master.metrics.otlp.enabled`          | `false`                            | Включает периодический экспорт метрик через OTLP.                                                                  |
+| `axelix.master.metrics.otlp.url`              | `http://localhost:4318/v1/metrics` | Полный адрес HTTP/protobuf для метрик. Добавьте путь `/v1/metrics`.                                                 |
+| `axelix.master.metrics.otlp.step`             | `1m`                               | Интервал между отправками в формате Spring `Duration`.                                                             |
+| `axelix.master.metrics.otlp.headers.*`        | пусто                              | Дополнительные заголовки запроса, например заголовок авторизации. Передавайте секретные значения во время запуска. |
+| `axelix.master.metrics.otlp.compression-mode` | `none`                             | Режим сжатия запроса: `none` или `gzip`.                                                                            |
+
+</div>
+
+```yaml
+axelix:
+  master:
+    metrics:
+      otlp:
+        enabled: true
+        url: http://otel-collector:4318/v1/metrics
+        step: 30s
+        headers:
+          Authorization: ${OTLP_AUTHORIZATION_HEADER}
+```
+
+Эти же настройки можно передать через переменные окружения:
+
+```bash
+AXELIX_MASTER_METRICS_OTLP_ENABLED=true
+AXELIX_MASTER_METRICS_OTLP_URL=http://otel-collector:4318/v1/metrics
+AXELIX_MASTER_METRICS_OTLP_HEADERS_AUTHORIZATION="Bearer my-token"
+```
+
+Заголовки авторизации лучше передавать из хранилища секретов вашей платформы развёртывания, а не сохранять в файле
+конфигурации.
+
 ## Запуск как JAR
 
 Используйте этот вариант, когда вам нужна максимально лёгкая среда выполнения — один процесс на машине, которой вы уже

--- a/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-master-ui/configuring-master/configuring-master.mdx
+++ b/docs/i18n/ru/docusaurus-plugin-content-docs/current/setting-up-master-ui/configuring-master/configuring-master.mdx
@@ -311,7 +311,7 @@ axelix:
 
 Master может отправлять собственные метрики JVM, HTTP, пула соединений с базой данных и другие метрики Micrometer в
 OTLP-совместимый коллектор по HTTP/protobuf. Экспортируются метрики самого Master, а не метрики сервисов, подключённых
-через стартер Axelix. По умолчанию экспорт выключен, поэтому обновление Master не создаёт исходящий трафик телеметрии.
+через стартер Axelix. По умолчанию экспорт в OTel Collector выключен (см. таблицу ниже).
 
 <div className={styles.ConfigTable}>
 
@@ -337,13 +337,9 @@ axelix:
           Authorization: ${OTLP_AUTHORIZATION_HEADER}
 ```
 
-Эти же настройки можно передать через переменные окружения:
-
-```bash
-AXELIX_MASTER_METRICS_OTLP_ENABLED=true
-AXELIX_MASTER_METRICS_OTLP_URL=http://otel-collector:4318/v1/metrics
-AXELIX_MASTER_METRICS_OTLP_HEADERS_AUTHORIZATION="Bearer my-token"
-```
+Эти же настройки можно передать через переменные окружения или системные свойства JVM — см. [Способы задания
+свойств](#способы-задания-свойств), где описаны правила нестрогого связывания, которые сопоставляют, например,
+`axelix.master.metrics.otlp.enabled` с `AXELIX_MASTER_METRICS_OTLP_ENABLED`.
 
 Заголовки авторизации лучше передавать из хранилища секретов вашей платформы развёртывания, а не сохранять в файле
 конфигурации.


### PR DESCRIPTION
Documents the OTLP metrics export configuration introduced in companion PR #1527.

- Adds an OTLP subsection next to Prometheus under Metrics on the English and Russian Configuring Master pages.
- Marks the feature as upcoming.
- Includes YAML and environment-variable examples.
- Documents `/v1/metrics`, custom headers, compression, and runtime secret injection.

Tests:
- `npm --prefix docs run build`

Companion implementation: #1527

Refs #1496

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for exporting Master metrics through OTLP over HTTP/protobuf.
  * Documented configuration options for enabling exports, collector URLs, intervals, custom headers, and compression.
  * Added YAML and environment-variable examples, including secure handling of authentication headers.
  * Provided the same configuration guidance in Russian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->