### PR TITLE
GH-1540 Roles must grant the authorities they derive from other roles

### DIFF
--- a/common/src/main/java/com/axelixlabs/axelix/common/auth/core/Role.java
+++ b/common/src/main/java/com/axelixlabs/axelix/common/auth/core/Role.java
@@ -37,9 +37,8 @@ public interface Role {
     String getName();
 
     /**
-     * Authorities this role grants on its own, without the ones it reaches through its {@link #getComponents()
-     * components}. Meant for whoever stores or serializes the role as it stands; whoever decides what the holder of
-     * the role may do wants {@link #getEffectiveAuthorities()} instead.
+     * Returns the direct role's authorities, i.e. authorities this role grants on its
+     * own, without the ones that are inherited from other {@link #getComponents()}.
      *
      * @return immutable set of {@link Authority} objects associated with this role
      */
@@ -57,12 +56,8 @@ public interface Role {
     Set<Role> getComponents();
 
     /**
-     * Everything this role grants: its own {@link #getAuthorities() authorities} united with the ones of every role
-     * reachable through its {@link #getComponents() components}, however deep. An authority is not copied into the
-     * deriving role, so granting one to a component shows up here at once.
-     *
-     * <p>No visited set is kept on the way down: a composite is assembled bottom-up out of immutable roles, so the
-     * graph of objects cannot close a cycle whatever the data it was assembled from said.</p>
+     * Everything this role grants: its own {@link #getAuthorities() authorities} combined with the ones of every role
+     * reachable through its {@link #getComponents() components}, however deep.
      *
      * @return immutable set of every {@link Authority} the role grants, directly or through a component
      */

--- a/common/src/main/java/com/axelixlabs/axelix/common/auth/core/Role.java
+++ b/common/src/main/java/com/axelixlabs/axelix/common/auth/core/Role.java
@@ -17,6 +17,7 @@
  */
 package com.axelixlabs.axelix.common.auth.core;
 
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -36,7 +37,9 @@ public interface Role {
     String getName();
 
     /**
-     * Authorities of a given role.
+     * Authorities this role grants on its own, without the ones it reaches through its {@link #getComponents()
+     * components}. Meant for whoever stores or serializes the role as it stands; whoever decides what the holder of
+     * the role may do wants {@link #getEffectiveAuthorities()} instead.
      *
      * @return immutable set of {@link Authority} objects associated with this role
      */
@@ -52,4 +55,24 @@ public interface Role {
      * @return immutable set of {@link Role} objects included in this role
      */
     Set<Role> getComponents();
+
+    /**
+     * Everything this role grants: its own {@link #getAuthorities() authorities} united with the ones of every role
+     * reachable through its {@link #getComponents() components}, however deep. An authority is not copied into the
+     * deriving role, so granting one to a component shows up here at once.
+     *
+     * <p>No visited set is kept on the way down: a composite is assembled bottom-up out of immutable roles, so the
+     * graph of objects cannot close a cycle whatever the data it was assembled from said.</p>
+     *
+     * @return immutable set of every {@link Authority} the role grants, directly or through a component
+     */
+    default Set<Authority> getEffectiveAuthorities() {
+        Set<Authority> all = new HashSet<>(getAuthorities());
+
+        for (Role component : getComponents()) {
+            all.addAll(component.getEffectiveAuthorities());
+        }
+
+        return Set.copyOf(all);
+    }
 }

--- a/common/src/main/java/com/axelixlabs/axelix/common/auth/service/DefaultAuthorizer.java
+++ b/common/src/main/java/com/axelixlabs/axelix/common/auth/service/DefaultAuthorizer.java
@@ -17,13 +17,11 @@
  */
 package com.axelixlabs.axelix.common.auth.service;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.axelixlabs.axelix.common.auth.core.Authority;
 import com.axelixlabs.axelix.common.auth.core.AuthorizationRequest;
-import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.common.auth.core.User;
 import com.axelixlabs.axelix.common.auth.exception.AuthorizationException;
 
@@ -44,7 +42,7 @@ public class DefaultAuthorizer implements Authorizer {
         }
 
         Set<String> userAuthorities = user.getRoles().stream()
-                .flatMap(role -> collectAuthorities(role).stream())
+                .flatMap(role -> role.getEffectiveAuthorities().stream())
                 .map(Authority::getName)
                 .collect(Collectors.toSet());
 
@@ -54,15 +52,5 @@ public class DefaultAuthorizer implements Authorizer {
         if (!userAuthorities.containsAll(requiredNames)) {
             throw new AuthorizationException("Access denied: missing required authorities " + requiredNames, user);
         }
-    }
-
-    private Set<Authority> collectAuthorities(Role role) {
-        Set<Authority> all = new HashSet<>(role.getAuthorities());
-
-        for (Role component : role.getComponents()) {
-            all.addAll(collectAuthorities(component));
-        }
-
-        return all;
     }
 }

--- a/common/src/test/java/com/axelixlabs/axelix/common/auth/core/DefaultRoleTest.java
+++ b/common/src/test/java/com/axelixlabs/axelix/common/auth/core/DefaultRoleTest.java
@@ -34,45 +34,45 @@ class DefaultRoleTest {
     @Test
     void shouldReturnItsOwnAuthoritiesWhenItDerivesFromNobody() {
         // given.
-        Role role = new DefaultRole("VIEWER", Set.of(DefaultAuthority.CACHES_TOGGLE));
+        Role role = new DefaultRole("VIEWER", Set.of(OssAuthority.CACHES_TOGGLE));
 
         // when & then.
         assertThat(role.getEffectiveAuthorities())
                 .extracting(Authority::getName)
-                .containsExactly(DefaultAuthority.CACHES_TOGGLE.name());
+                .containsExactly(OssAuthority.CACHES_TOGGLE.name());
     }
 
     @Test
     void shouldUniteTheAuthoritiesOfTheWholeChainItDerivesFrom() {
         // given. C derives from B, B derives from A
-        Role a = new DefaultRole("A", Set.of(DefaultAuthority.ENV_VALUES_READ));
-        Role b = new DefaultRole("B", Set.of(DefaultAuthority.CACHES_CLEAR), Set.of(a));
-        Role c = new DefaultRole("C", Set.of(DefaultAuthority.GARBAGE_COLLECTOR), Set.of(b));
+        Role grandParent = new DefaultRole("A", Set.of(OssAuthority.ENV_VALUES_READ));
+        Role parent = new DefaultRole("B", Set.of(OssAuthority.CACHES_CLEAR), Set.of(grandParent));
+        Role child = new DefaultRole("C", Set.of(OssAuthority.GARBAGE_COLLECTOR), Set.of(parent));
 
         // when & then. The walk goes all the way down rather than one level
-        assertThat(c.getEffectiveAuthorities())
+        assertThat(child.getEffectiveAuthorities())
                 .extracting(Authority::getName)
                 .containsExactlyInAnyOrder(
-                        DefaultAuthority.GARBAGE_COLLECTOR.name(),
-                        DefaultAuthority.CACHES_CLEAR.name(),
-                        DefaultAuthority.ENV_VALUES_READ.name());
+                        OssAuthority.GARBAGE_COLLECTOR.name(),
+                        OssAuthority.CACHES_CLEAR.name(),
+                        OssAuthority.ENV_VALUES_READ.name());
     }
 
     @Test
     void shouldCountTheRoleReachedThroughSeveralBranchesOnce() {
         // given. A diamond: the top role is reached through both of them
-        Role top = new DefaultRole("TOP", Set.of(DefaultAuthority.ENV_VALUES_READ));
-        Role left = new DefaultRole("LEFT", Set.of(DefaultAuthority.CACHES_CLEAR), Set.of(top));
-        Role right = new DefaultRole("RIGHT", Set.of(DefaultAuthority.CACHES_TOGGLE), Set.of(top));
-        Role bottom = new DefaultRole("BOTTOM", Set.of(DefaultAuthority.GARBAGE_COLLECTOR), Set.of(left, right));
+        Role top = new DefaultRole("TOP", Set.of(OssAuthority.ENV_VALUES_READ));
+        Role left = new DefaultRole("LEFT", Set.of(OssAuthority.CACHES_CLEAR), Set.of(top));
+        Role right = new DefaultRole("RIGHT", Set.of(OssAuthority.CACHES_TOGGLE), Set.of(top));
+        Role bottom = new DefaultRole("BOTTOM", Set.of(OssAuthority.GARBAGE_COLLECTOR), Set.of(left, right));
 
         // when & then. Reaching the same authority twice neither duplicates it nor loses the rest
         assertThat(bottom.getEffectiveAuthorities())
                 .extracting(Authority::getName)
                 .containsExactlyInAnyOrder(
-                        DefaultAuthority.GARBAGE_COLLECTOR.name(),
-                        DefaultAuthority.CACHES_CLEAR.name(),
-                        DefaultAuthority.CACHES_TOGGLE.name(),
-                        DefaultAuthority.ENV_VALUES_READ.name());
+                        OssAuthority.GARBAGE_COLLECTOR.name(),
+                        OssAuthority.CACHES_CLEAR.name(),
+                        OssAuthority.CACHES_TOGGLE.name(),
+                        OssAuthority.ENV_VALUES_READ.name());
     }
 }

--- a/common/src/test/java/com/axelixlabs/axelix/common/auth/core/DefaultRoleTest.java
+++ b/common/src/test/java/com/axelixlabs/axelix/common/auth/core/DefaultRoleTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.common.auth.core;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests of {@link Role#getEffectiveAuthorities()}, the single definition of what a role grants. Everyone who
+ * decides what the holder of a role may do goes through it, so the union it returns is what access ends up being.
+ *
+ * @author Sergey Cherkasov
+ */
+class DefaultRoleTest {
+
+    @Test
+    void shouldReturnItsOwnAuthoritiesWhenItDerivesFromNobody() {
+        // given.
+        Role role = new DefaultRole("VIEWER", Set.of(DefaultAuthority.CACHES_TOGGLE));
+
+        // when & then.
+        assertThat(role.getEffectiveAuthorities())
+                .extracting(Authority::getName)
+                .containsExactly(DefaultAuthority.CACHES_TOGGLE.name());
+    }
+
+    @Test
+    void shouldUniteTheAuthoritiesOfTheWholeChainItDerivesFrom() {
+        // given. C derives from B, B derives from A
+        Role a = new DefaultRole("A", Set.of(DefaultAuthority.ENV_VALUES_READ));
+        Role b = new DefaultRole("B", Set.of(DefaultAuthority.CACHES_CLEAR), Set.of(a));
+        Role c = new DefaultRole("C", Set.of(DefaultAuthority.GARBAGE_COLLECTOR), Set.of(b));
+
+        // when & then. The walk goes all the way down rather than one level
+        assertThat(c.getEffectiveAuthorities())
+                .extracting(Authority::getName)
+                .containsExactlyInAnyOrder(
+                        DefaultAuthority.GARBAGE_COLLECTOR.name(),
+                        DefaultAuthority.CACHES_CLEAR.name(),
+                        DefaultAuthority.ENV_VALUES_READ.name());
+    }
+
+    @Test
+    void shouldCountTheRoleReachedThroughSeveralBranchesOnce() {
+        // given. A diamond: the top role is reached through both of them
+        Role top = new DefaultRole("TOP", Set.of(DefaultAuthority.ENV_VALUES_READ));
+        Role left = new DefaultRole("LEFT", Set.of(DefaultAuthority.CACHES_CLEAR), Set.of(top));
+        Role right = new DefaultRole("RIGHT", Set.of(DefaultAuthority.CACHES_TOGGLE), Set.of(top));
+        Role bottom = new DefaultRole("BOTTOM", Set.of(DefaultAuthority.GARBAGE_COLLECTOR), Set.of(left, right));
+
+        // when & then. Reaching the same authority twice neither duplicates it nor loses the rest
+        assertThat(bottom.getEffectiveAuthorities())
+                .extracting(Authority::getName)
+                .containsExactlyInAnyOrder(
+                        DefaultAuthority.GARBAGE_COLLECTOR.name(),
+                        DefaultAuthority.CACHES_CLEAR.name(),
+                        DefaultAuthority.CACHES_TOGGLE.name(),
+                        DefaultAuthority.ENV_VALUES_READ.name());
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserApi.java
@@ -49,7 +49,7 @@ import com.axelixlabs.axelix.master.api.external.swagger.DefaultApiResponse;
 import com.axelixlabs.axelix.master.exception.auth.InvalidCredentialsException;
 import com.axelixlabs.axelix.master.service.auth.CookieService;
 import com.axelixlabs.axelix.master.service.auth.provider.UserAuthenticator;
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 
 /**
  * The API for working with users.

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApi.java
@@ -40,7 +40,7 @@ import com.axelixlabs.axelix.master.api.external.swagger.DefaultApiResponse;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.SecurityAutoConfiguration;
 import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 
 /**
  * The API to manage users (view, create, delete, update).

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackController.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackController.java
@@ -48,7 +48,7 @@ import com.axelixlabs.axelix.master.service.auth.oauth.OidcIdTokenClaimsValidato
 import com.axelixlabs.axelix.master.service.auth.oauth.Tokens;
 import com.axelixlabs.axelix.master.service.auth.oauth.UserInfoJsonAccessor;
 import com.axelixlabs.axelix.master.service.auth.oauth.ValidatedOidcIdentity;
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 import com.axelixlabs.axelix.master.service.transport.BadRequestException;
 
 import static com.axelixlabs.axelix.master.autoconfiguration.auth.SecurityAutoConfiguration.OAUTH_LOGIN_PROPERTIES_PREFIX;

--- a/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/SecurityAutoConfiguration.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/auth/SecurityAutoConfiguration.java
@@ -79,8 +79,8 @@ import com.axelixlabs.axelix.master.service.auth.provider.CompositeUserAuthentic
 import com.axelixlabs.axelix.master.service.auth.provider.DatabaseUserAuthenticator;
 import com.axelixlabs.axelix.master.service.auth.provider.SuperAdminUserAuthenticator;
 import com.axelixlabs.axelix.master.service.auth.provider.UserAuthenticator;
-import com.axelixlabs.axelix.master.service.state.RoleService;
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.RoleService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 
 /**
  * Autoconfiguration for security.

--- a/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/EmailAlreadyExistsException.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/EmailAlreadyExistsException.java
@@ -17,7 +17,7 @@
  */
 package com.axelixlabs.axelix.master.exception.auth;
 
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 
 /**
  * Thrown when attempting to create a user with an email that is already taken.

--- a/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UserInvalidValueException.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UserInvalidValueException.java
@@ -20,7 +20,7 @@ package com.axelixlabs.axelix.master.exception.auth;
 import org.jspecify.annotations.Nullable;
 
 import com.axelixlabs.axelix.master.domain.UserEntity;
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 
 /**
  * Thrown if one of the provided values is invalid for writing to {@link UserEntity}.

--- a/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UsernameAlreadyExistsException.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UsernameAlreadyExistsException.java
@@ -17,7 +17,7 @@
  */
 package com.axelixlabs.axelix.master.exception.auth;
 
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 
 /**
  * Thrown when attempting to create a user with a username that is already taken.

--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/RoleRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/RoleRepository.java
@@ -34,45 +34,22 @@ import com.axelixlabs.axelix.master.domain.RoleEntity;
  */
 public interface RoleRepository extends ListCrudRepository<RoleEntity, String> {
 
-    /**
-     * Reads the role with the given name together with the names of the authorities it grants, in a single query.
-     *
-     * <p>The join is a {@code LEFT} join, so a role that grants no authority still yields a single row (with a
-     * {@code null} authority name). An empty result therefore means no role with such a name exists.</p>
-     *
-     * @param name Name of the role.
-     * @return One row per granted authority, a single {@code null}-authority row if the role grants none, or an empty
-     *         list if no role with such a name exists.
-     */
     @Query("""
-            SELECT r.name AS role_name, a.name AS authority_name
+            SELECT r.id AS role_id, r.name AS role_name, a.name AS authority_name
             FROM roles r
             LEFT JOIN roles_authorities ra ON ra.role_id = r.id
             LEFT JOIN authorities a ON a.id = ra.authority_id
-            WHERE r.name = :name
             """)
-    List<RoleWithAuthorityName> findWithAuthoritiesByName(@Param("name") String name);
+    List<RoleWithAuthorityName> findAllWithAuthorities();
 
-    /**
-     * @param userId ID of the user.
-     * @return One row per (role, granted-authority) pair, a single {@code null}-authority row for a role that grants
-     *         none, or an empty list if the user has no roles assigned.
-     */
-    @Query("""
-            SELECT r.name AS role_name, a.name AS authority_name
-            FROM users_roles ur
-            JOIN roles r ON r.id = ur.role_id
-            LEFT JOIN roles_authorities ra ON ra.role_id = r.id
-            LEFT JOIN authorities a ON a.id = ra.authority_id
-            WHERE ur.user_id = :userId
-            """)
-    List<RoleWithAuthorityName> findWithAuthoritiesByUserId(@Param("userId") String userId);
+    @Query("SELECT role_id AS role_id, parent_role_id AS parent_role_id FROM roles_parents")
+    List<RoleParentBond> findAllParentBonds();
 
-    /**
-     * A single (role, granted-authority-name) row of {@link #findWithAuthoritiesByName(String)}.
-     *
-     * @param roleName      Name of the role.
-     * @param authorityName Name of one authority the role grants, or {@code null} if the role grants none.
-     */
-    record RoleWithAuthorityName(String roleName, @Nullable String authorityName) {}
+    @Query("SELECT role_id FROM users_roles WHERE user_id = :userId")
+    List<String> findRoleIdsOfUser(@Param("userId") String userId);
+
+    record RoleWithAuthorityName(
+            String roleId, String roleName, @Nullable String authorityName) {}
+
+    record RoleParentBond(String roleId, String parentRoleId) {}
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/DefaultCookieService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/DefaultCookieService.java
@@ -54,7 +54,7 @@ public class DefaultCookieService implements CookieService {
     @Override
     public ResponseCookie buildAuthoritiesMetadataCookie(Set<Role> roles) {
         String authoritiesJsonArray = roles.stream()
-                .flatMap(role -> role.getAuthorities().stream())
+                .flatMap(role -> role.getEffectiveAuthorities().stream())
                 .map(Authority::getName)
                 .distinct()
                 .collect(Collectors.joining(",", "[", "]"));

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/UserInfoJsonAccessor.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/oauth/UserInfoJsonAccessor.java
@@ -26,13 +26,14 @@ import org.slf4j.LoggerFactory;
 import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.properties.OAuth2Properties;
 import com.axelixlabs.axelix.master.exception.auth.OidcRoleExtractionException;
-import com.axelixlabs.axelix.master.service.state.RoleService;
+import com.axelixlabs.axelix.master.service.state.auth.RoleService;
 
 /**
  * Accessor for the JSON response of the {@code /userinfo} OIDC endpoint.
  *
  * @author Mikhail Polivakha
  */
+// TODO: we need to extract an interface here to clearly define the contract.
 public class UserInfoJsonAccessor {
 
     private static final String DEFAULT_ROLE_NAME = "VIEWER";

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/provider/CompositeUserAuthenticator.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/provider/CompositeUserAuthenticator.java
@@ -37,7 +37,7 @@ public class CompositeUserAuthenticator implements UserAuthenticator {
     }
 
     @Override
-    public @Nullable User authenticate(String username, String password) {
+    public @Nullable User authenticate(String username, String password) throws IllegalStateException {
         for (var userAuthenticator : userAuthenticators) {
             User authenticatedUser = userAuthenticator.authenticate(username, password);
 

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/provider/DatabaseUserAuthenticator.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/provider/DatabaseUserAuthenticator.java
@@ -27,8 +27,8 @@ import com.axelixlabs.axelix.common.auth.core.User;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserStatus;
 import com.axelixlabs.axelix.master.exception.auth.UserSuspendedException;
-import com.axelixlabs.axelix.master.service.state.RoleService;
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.RoleService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 
 /**
  * {@link UserAuthenticator} that authenticates a given user against the users stored in the database.
@@ -50,7 +50,7 @@ public class DatabaseUserAuthenticator implements UserAuthenticator {
     }
 
     @Override
-    public @Nullable User authenticate(String username, String password) {
+    public @Nullable User authenticate(String username, String password) throws IllegalStateException {
 
         // TODO:
         //  Maybe we can load user with his roles already here with one query?

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/provider/SuperAdminUserAuthenticator.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/provider/SuperAdminUserAuthenticator.java
@@ -20,16 +20,14 @@ package com.axelixlabs.axelix.master.service.auth.provider;
 import java.util.Objects;
 import java.util.Set;
 
-import jakarta.annotation.PostConstruct;
-
-import org.jspecify.annotations.Nullable;
-
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.DefaultUser;
 import com.axelixlabs.axelix.common.auth.core.User;
 import com.axelixlabs.axelix.common.auth.service.AuthoritiesManager;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.properties.SuperAdminConfigurationProperties;
 import com.axelixlabs.axelix.master.service.auth.encoder.SuperAdminPasswordEncoder;
+import jakarta.annotation.PostConstruct;
+import org.jspecify.annotations.Nullable;
 
 /**
  * {@link UserAuthenticator} that authenticates Super Admin.

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/provider/SuperAdminUserAuthenticator.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/provider/SuperAdminUserAuthenticator.java
@@ -20,14 +20,16 @@ package com.axelixlabs.axelix.master.service.auth.provider;
 import java.util.Objects;
 import java.util.Set;
 
+import jakarta.annotation.PostConstruct;
+
+import org.jspecify.annotations.Nullable;
+
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.DefaultUser;
 import com.axelixlabs.axelix.common.auth.core.User;
 import com.axelixlabs.axelix.common.auth.service.AuthoritiesManager;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.properties.SuperAdminConfigurationProperties;
 import com.axelixlabs.axelix.master.service.auth.encoder.SuperAdminPasswordEncoder;
-import jakarta.annotation.PostConstruct;
-import org.jspecify.annotations.Nullable;
 
 /**
  * {@link UserAuthenticator} that authenticates Super Admin.

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/provider/UserAuthenticator.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/provider/UserAuthenticator.java
@@ -36,8 +36,12 @@ public interface UserAuthenticator {
      * @param username the user's username.
      * @param password the user's password.
      *
+     * @throws IllegalStateException in case implementation cannot assemble the {@link User} due to the fact that
+     *                               its state is corrupted for any reason, e.g. the graph roles of the given user
+     *                               contains the cycle.
+     *
      * @return the authenticated {@link User}, or null, if the user with such credentials pair was not found.
      */
     @Nullable
-    User authenticate(String username, String password);
+    User authenticate(String username, String password) throws IllegalStateException;
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseRoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseRoleService.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseRoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/DatabaseRoleService.java
@@ -17,8 +17,9 @@
  */
 package com.axelixlabs.axelix.master.service.state;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -36,11 +37,12 @@ import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.common.auth.service.AuthoritiesManager;
 import com.axelixlabs.axelix.master.repository.RoleRepository;
+import com.axelixlabs.axelix.master.repository.RoleRepository.RoleParentBond;
 import com.axelixlabs.axelix.master.repository.RoleRepository.RoleWithAuthorityName;
 
 /**
- * JDBC-based implementation of {@link RoleService} that reads roles from the {@code roles}, {@code roles_authorities}
- * and {@code authorities} tables.
+ * JDBC-based implementation of {@link RoleService} that reads roles from the {@code roles}, {@code roles_authorities},
+ * {@code roles_parents} and {@code authorities} tables.
  *
  * @author Sergey Cherkasov
  */
@@ -59,35 +61,83 @@ public class DatabaseRoleService implements RoleService {
 
     @Override
     public Optional<Role> findByName(String name) {
-        List<RoleWithAuthorityName> rows = roleRepository.findWithAuthoritiesByName(name);
+        RoleGraph graph = readGraph();
 
-        if (rows.isEmpty()) {
-            return Optional.empty();
-        }
-
-        Set<Authority> authorities = rows.stream()
-                .flatMap(row -> Optional.ofNullable(row.authorityName()).stream())
-                .map(authoritiesManager::decode)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
-
-        return Optional.of(new DefaultRole(name, authorities));
+        return findRoleId(graph, name).flatMap(roleId -> composeRole(graph, roleId));
     }
 
     @Override
     public Set<Role> findRolesOfUser(String userId) {
-        List<RoleWithAuthorityName> rows = roleRepository.findWithAuthoritiesByUserId(userId);
-        Map<String, Set<Authority>> authoritiesByRole = new LinkedHashMap<>();
+        RoleGraph graph = readGraph();
 
-        for (RoleWithAuthorityName row : rows) {
-            Set<Authority> authorities = authoritiesByRole.computeIfAbsent(row.roleName(), _ -> new HashSet<>());
-            if (row.authorityName() != null) {
-                Optional.ofNullable(authoritiesManager.decode(row.authorityName()))
-                        .ifPresent(authorities::add);
-            }
-        }
-        return authoritiesByRole.entrySet().stream()
-                .map(entry -> (Role) new DefaultRole(entry.getKey(), entry.getValue()))
+        return roleRepository.findRoleIdsOfUser(userId).stream()
+                .map(roleId -> composeRole(graph, roleId))
+                .flatMap(Optional::stream)
                 .collect(Collectors.toSet());
     }
+
+    private RoleGraph readGraph() {
+        Map<String, String> names = new HashMap<>();
+        Map<String, Set<Authority>> authorities = new HashMap<>();
+
+        for (RoleWithAuthorityName row : roleRepository.findAllWithAuthorities()) {
+            names.put(row.roleId(), row.roleName());
+            Set<Authority> granted = authorities.computeIfAbsent(row.roleId(), _ -> new HashSet<>());
+
+            if (row.authorityName() != null) {
+                String authorityName = row.authorityName();
+                granted.add(() -> authorityName);
+            }
+        }
+
+        Map<String, List<String>> parents = new HashMap<>();
+
+        for (RoleParentBond bond : roleRepository.findAllParentBonds()) {
+            parents.computeIfAbsent(bond.roleId(), _ -> new ArrayList<>()).add(bond.parentRoleId());
+        }
+
+        return new RoleGraph(names, authorities, parents);
+    }
+
+    private Optional<String> findRoleId(RoleGraph graph, String roleName) {
+        return graph.names().entrySet().stream()
+                .filter(entry -> entry.getValue().equals(roleName))
+                .map(Map.Entry::getKey)
+                .findFirst();
+    }
+
+    private Optional<Role> composeRole(RoleGraph graph, String roleId) {
+        return composeRole(graph, roleId, new HashSet<>());
+    }
+
+    private Optional<Role> composeRole(RoleGraph graph, String roleId, Set<String> derivationPath) {
+        String roleName = graph.names().get(roleId);
+
+        // The roles, the bonds and the roles of the user are three separate reads rather than one snapshot, so an id
+        // can point at a role the roles query did not return. Such a role is left out - this runs on the login path,
+        // and it is not worth an unresolvable id there
+        if (roleName == null) {
+            return Optional.empty();
+        }
+
+        derivationPath.add(roleId);
+        Set<Role> components = new HashSet<>();
+
+        for (String parentRoleId : graph.parents().getOrDefault(roleId, List.of())) {
+            if (derivationPath.add(parentRoleId)) {
+                composeRole(graph, parentRoleId, derivationPath).ifPresent(components::add);
+                derivationPath.remove(parentRoleId);
+            }
+        }
+
+        derivationPath.remove(roleId);
+
+        return Optional.of(new DefaultRole(roleName, graph.authorities().getOrDefault(roleId, Set.of()), components));
+    }
+
+    /**
+     * The roles and the bonds between them, as read from the database, ready to be resolved into composite roles.
+     */
+    private record RoleGraph(
+            Map<String, String> names, Map<String, Set<Authority>> authorities, Map<String, List<String>> parents) {}
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DatabaseUserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DatabaseUserService.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.master.service.state;
+package com.axelixlabs.axelix.master.service.state.auth;
 
 import java.time.Instant;
 import java.util.Collections;

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DefaultRoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DefaultRoleService.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.master.service.state;
+package com.axelixlabs.axelix.master.service.state.auth;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,41 +41,40 @@ import com.axelixlabs.axelix.master.repository.RoleRepository.RoleWithAuthorityN
 
 /**
  * JDBC-based implementation of {@link RoleService} that reads roles from the {@code roles}, {@code roles_authorities},
- * {@code roles_parents} and {@code authorities} tables.
+ * {@code roles_parents} and {@code directAuthorities} tables.
  *
  * @author Sergey Cherkasov
+ * @author Mikhail Polivakha
  */
 @Service
 @NullMarked
 @Transactional
-public class DatabaseRoleService implements RoleService {
+public class DefaultRoleService implements RoleService {
 
     private final RoleRepository roleRepository;
     private final AuthoritiesManager authoritiesManager;
 
-    public DatabaseRoleService(RoleRepository roleRepository, AuthoritiesManager authoritiesManager) {
+    public DefaultRoleService(RoleRepository roleRepository, AuthoritiesManager authoritiesManager) {
         this.roleRepository = roleRepository;
         this.authoritiesManager = authoritiesManager;
     }
 
     @Override
-    public Optional<Role> findByName(String name) {
-        RoleGraph graph = readGraph();
-
-        return findRoleId(graph, name).flatMap(roleId -> composeRole(graph, roleId));
+    public Optional<Role> findByName(String name) throws IllegalStateException {
+        return getGraph().composeRoleFromName(name);
     }
 
     @Override
-    public Set<Role> findRolesOfUser(String userId) {
-        RoleGraph graph = readGraph();
+    public Set<Role> findRolesOfUser(String userId) throws IllegalStateException {
+        RoleGraph graph = getGraph();
 
         return roleRepository.findRoleIdsOfUser(userId).stream()
-                .map(roleId -> composeRole(graph, roleId))
+                .map(graph::composeRole)
                 .flatMap(Optional::stream)
                 .collect(Collectors.toSet());
     }
 
-    private RoleGraph readGraph() {
+    private RoleGraph getGraph() {
         Map<String, String> names = new HashMap<>();
         Map<String, Set<Authority>> authorities = new HashMap<>();
 
@@ -84,8 +83,9 @@ public class DatabaseRoleService implements RoleService {
             Set<Authority> granted = authorities.computeIfAbsent(row.roleId(), _ -> new HashSet<>());
 
             if (row.authorityName() != null) {
-                String authorityName = row.authorityName();
-                granted.add(() -> authorityName);
+                Optional
+                    .ofNullable(authoritiesManager.decode(row.authorityName()))
+                    .ifPresent(granted::add);
             }
         }
 
@@ -98,45 +98,55 @@ public class DatabaseRoleService implements RoleService {
         return new RoleGraph(names, authorities, parents);
     }
 
-    private Optional<String> findRoleId(RoleGraph graph, String roleName) {
-        return graph.names().entrySet().stream()
-                .filter(entry -> entry.getValue().equals(roleName))
-                .map(Map.Entry::getKey)
-                .findFirst();
-    }
-
-    private Optional<Role> composeRole(RoleGraph graph, String roleId) {
-        return composeRole(graph, roleId, new HashSet<>());
-    }
-
-    private Optional<Role> composeRole(RoleGraph graph, String roleId, Set<String> derivationPath) {
-        String roleName = graph.names().get(roleId);
-
-        // The roles, the bonds and the roles of the user are three separate reads rather than one snapshot, so an id
-        // can point at a role the roles query did not return. Such a role is left out - this runs on the login path,
-        // and it is not worth an unresolvable id there
-        if (roleName == null) {
-            return Optional.empty();
-        }
-
-        derivationPath.add(roleId);
-        Set<Role> components = new HashSet<>();
-
-        for (String parentRoleId : graph.parents().getOrDefault(roleId, List.of())) {
-            if (derivationPath.add(parentRoleId)) {
-                composeRole(graph, parentRoleId, derivationPath).ifPresent(components::add);
-                derivationPath.remove(parentRoleId);
-            }
-        }
-
-        derivationPath.remove(roleId);
-
-        return Optional.of(new DefaultRole(roleName, graph.authorities().getOrDefault(roleId, Set.of()), components));
-    }
-
     /**
      * The roles and the bonds between them, as read from the database, ready to be resolved into composite roles.
      */
     private record RoleGraph(
-            Map<String, String> names, Map<String, Set<Authority>> authorities, Map<String, List<String>> parents) {}
+        Map<String, String> roleIdToName,
+        Map<String, Set<Authority>> directAuthorities,
+        Map<String, List<String>> directParents) {
+
+        private Optional<String> findRoleId(String roleName) {
+            return roleIdToName.entrySet().stream()
+                .filter(entry -> entry.getValue().equals(roleName))
+                .map(Map.Entry::getKey)
+                .findFirst();
+        }
+
+        private Optional<Role> composeRoleFromName(String roleName) {
+            return findRoleId(roleName).flatMap(roleId -> composeRole(roleId, new HashSet<>()));
+        }
+
+        private Optional<Role> composeRole(String roleId) {
+            return composeRole(roleId, new HashSet<>());
+        }
+
+        private Optional<Role> composeRole(String roleId, Set<String> visited) {
+            String roleName = roleIdToName.get(roleId);
+
+            if (roleName == null) {
+                return Optional.empty();
+            }
+
+            visited.add(roleId);
+            Set<Role> components = new HashSet<>();
+
+            for (String parentRoleId : directParents.getOrDefault(roleId, List.of())) {
+                if (visited.add(parentRoleId)) {
+                    composeRole(parentRoleId, visited).ifPresent(components::add);
+                } else {
+                    // TODO:
+                    //  ideally, we would want to create a descriptive message here explaining what
+                    //  roles create a cycle. Like message with "A --> B --> C --> A" or something.
+                    throw new IllegalStateException(
+                        "Unable to resolve the state of the Role '%s': ".formatted(roleName) +
+                        "it's ancestry create a cycle");
+                }
+            }
+
+            return Optional.of(
+                new DefaultRole(roleName, directAuthorities.getOrDefault(roleId, Set.of()), components)
+            );
+        }
+    }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DefaultRoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DefaultRoleService.java
@@ -17,11 +17,14 @@
  */
 package com.axelixlabs.axelix.master.service.state.auth;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -83,9 +86,8 @@ public class DefaultRoleService implements RoleService {
             Set<Authority> granted = authorities.computeIfAbsent(row.roleId(), _ -> new HashSet<>());
 
             if (row.authorityName() != null) {
-                Optional
-                    .ofNullable(authoritiesManager.decode(row.authorityName()))
-                    .ifPresent(granted::add);
+                Optional.ofNullable(authoritiesManager.decode(row.authorityName()))
+                        .ifPresent(granted::add);
             }
         }
 
@@ -102,51 +104,80 @@ public class DefaultRoleService implements RoleService {
      * The roles and the bonds between them, as read from the database, ready to be resolved into composite roles.
      */
     private record RoleGraph(
-        Map<String, String> roleIdToName,
-        Map<String, Set<Authority>> directAuthorities,
-        Map<String, List<String>> directParents) {
+            Map<String, String> roleIdToName,
+            Map<String, Set<Authority>> directAuthorities,
+            Map<String, List<String>> directParents) {
 
         private Optional<String> findRoleId(String roleName) {
             return roleIdToName.entrySet().stream()
-                .filter(entry -> entry.getValue().equals(roleName))
-                .map(Map.Entry::getKey)
-                .findFirst();
+                    .filter(entry -> entry.getValue().equals(roleName))
+                    .map(Map.Entry::getKey)
+                    .findFirst();
         }
 
         private Optional<Role> composeRoleFromName(String roleName) {
-            return findRoleId(roleName).flatMap(roleId -> composeRole(roleId, new HashSet<>()));
+            return findRoleId(roleName).flatMap(this::composeRole);
         }
 
         private Optional<Role> composeRole(String roleId) {
-            return composeRole(roleId, new HashSet<>());
+            return composeRole(roleId, new HashMap<>(), new ArrayDeque<>());
         }
 
-        private Optional<Role> composeRole(String roleId, Set<String> visited) {
+        /**
+         * Resolves the role identified by {@code roleId} into a composite {@link Role}, walking its ancestry
+         * depth-first while guarding against cycles - the roles are meant to form a DAG. The algorithm below
+         * is just a simple DFS with coloring (where we store already fully traversed vertexes, colloquially called
+         * "Black", and those where we have not yet finished the traversal, colloquially called "Grey")
+         * <p>
+         * The two structures track the two states a DFS needs. A role sitting in {@code resolved} is done: it, along
+         * with its whole ancestry, has been composed, so reaching it again is legitimate (a diamond simply unions the
+         * authorities) and the memoised role is returned as is. A role sitting in {@code stack} is on the current DFS
+         * traversal stack, so an edge back into it is a back-edge and therefore proves a cycle, on which we bail out with an
+         * {@link IllegalStateException}. A role in neither is untouched and gets visited.
+         *
+         * @param resolved the roles already composed, memoised so a shared ancestor is built only once
+         * @param stack     the ids of the roles currently on the DFS stack, in order, used both to spot a back-edge
+         *                 and to describe the cycle it closes
+         */
+        private Optional<Role> composeRole(String roleId, Map<String, Role> resolved, Deque<String> stack) {
             String roleName = roleIdToName.get(roleId);
 
             if (roleName == null) {
                 return Optional.empty();
             }
 
-            visited.add(roleId);
+            Role alreadyResolved = resolved.get(roleId);
+
+            if (alreadyResolved != null) {
+                return Optional.of(alreadyResolved);
+            }
+
+            stack.addLast(roleId);
             Set<Role> components = new HashSet<>();
 
             for (String parentRoleId : directParents.getOrDefault(roleId, List.of())) {
-                if (visited.add(parentRoleId)) {
-                    composeRole(parentRoleId, visited).ifPresent(components::add);
-                } else {
-                    // TODO:
-                    //  ideally, we would want to create a descriptive message here explaining what
-                    //  roles create a cycle. Like message with "A --> B --> C --> A" or something.
-                    throw new IllegalStateException(
-                        "Unable to resolve the state of the Role '%s': ".formatted(roleName) +
-                        "it's ancestry create a cycle");
+                if (stack.contains(parentRoleId)) {
+                    throw cycleDetected(stack, parentRoleId);
                 }
+                composeRole(parentRoleId, resolved, stack).ifPresent(components::add);
             }
 
-            return Optional.of(
-                new DefaultRole(roleName, directAuthorities.getOrDefault(roleId, Set.of()), components)
-            );
+            Role role = new DefaultRole(roleName, directAuthorities.getOrDefault(roleId, Set.of()), components);
+
+            stack.removeLast();
+            resolved.put(roleId, role);
+
+            return Optional.of(role);
+        }
+
+        private IllegalStateException cycleDetected(Deque<String> path, String duplicatedRoleId) {
+            List<String> ids = new ArrayList<>(path);
+            String cycle = ids.subList(ids.indexOf(duplicatedRoleId), ids.size()).stream()
+                    .map(id -> Objects.requireNonNull(roleIdToName.get(id)))
+                    .collect(Collectors.joining(" --> "));
+
+            return new IllegalStateException("Unable to resolve the state of the roles: their ancestry forms a cycle: "
+                    + cycle + " --> " + roleIdToName.get(duplicatedRoleId));
         }
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/RoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/RoleService.java
@@ -20,11 +20,10 @@ package com.axelixlabs.axelix.master.service.state.auth;
 import java.util.Optional;
 import java.util.Set;
 
-import com.axelixlabs.axelix.common.auth.core.User;
-import com.axelixlabs.axelix.master.service.auth.provider.SuperAdminUserAuthenticator;
 import org.jspecify.annotations.NullMarked;
 
 import com.axelixlabs.axelix.common.auth.core.Role;
+import com.axelixlabs.axelix.master.service.auth.provider.SuperAdminUserAuthenticator;
 
 /**
  * Service that resolves the roles Axelix Master knows about.

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/RoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/RoleService.java
@@ -15,11 +15,13 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.master.service.state;
+package com.axelixlabs.axelix.master.service.state.auth;
 
 import java.util.Optional;
 import java.util.Set;
 
+import com.axelixlabs.axelix.common.auth.core.User;
+import com.axelixlabs.axelix.master.service.auth.provider.SuperAdminUserAuthenticator;
 import org.jspecify.annotations.NullMarked;
 
 import com.axelixlabs.axelix.common.auth.core.Role;
@@ -29,10 +31,11 @@ import com.axelixlabs.axelix.common.auth.core.Role;
  *
  * <p>Roles are stored in the database: the built-in {@code ADMIN}, {@code EDITOR} and {@code VIEWER} roles are
  * inserted by a Liquibase migration, any other role is created by Axelix Enterprise. Note that the internal
- * {@code SUPER_ADMIN} and {@code MANAGED_SERVICE} roles are <strong>not</strong> resolvable through this service:
- * they are never persisted and never assigned to a managed user.</p>
+ * {@link SuperAdminUserAuthenticator#SUPER_ADMIN_ROLE_NAME} and {@code MANAGED_SERVICE} roles are <strong>not</strong>
+ * resolvable through this service: they are never persisted and never assigned to a managed user.</p>
  *
  * @author Sergey Cherkasov
+ * @author Mikhail Polivakha
  */
 @NullMarked
 public interface RoleService {
@@ -40,16 +43,24 @@ public interface RoleService {
     /**
      * Looks up a role by its exact name.
      *
+     * @throws IllegalStateException in case implementation cannot assemble the {@link Role} due to the fact that
+     *                               its state is corrupted for any reason, e.g. the graph roles of the given user
+     *                               contains the cycle.
+     *
      * @param name Name of the role to look up.
      * @return The role, or {@link Optional#empty()} if no role with such a name exists.
      */
-    Optional<Role> findByName(String name);
+    Optional<Role> findByName(String name) throws IllegalStateException;
 
     /**
      * Looks up roles that belong to the given user.
      *
+     * @throws IllegalStateException in case implementation cannot assemble the {@link Role} due to the fact that
+     *                               its state is corrupted for any reason, e.g. the graph roles of the given user
+     *                               contains the cycle.
+     *
      * @param userId the ID of the user whose roles we want to fetch.
      * @return Roles of the user.
      */
-    Set<Role> findRolesOfUser(String userId);
+    Set<Role> findRolesOfUser(String userId) throws IllegalStateException;
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/UserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/UserService.java
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.axelixlabs.axelix.master.service.state;
+package com.axelixlabs.axelix.master.service.state.auth;
 
 import java.time.Instant;
 import java.util.List;

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserApiTest.java
@@ -48,7 +48,7 @@ import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserStatus;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.service.auth.MasterWebEndpoints;
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 import com.axelixlabs.axelix.master.utils.IdentityAwareTestRestTemplate;
 import com.axelixlabs.axelix.master.utils.TestRestTemplateBuilder;
 import com.axelixlabs.axelix.master.utils.auth.AbstractProtectedEndpointTest;

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
@@ -39,7 +39,7 @@ import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.domain.UserStatus;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.service.auth.MasterWebEndpoints;
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 import com.axelixlabs.axelix.master.utils.IdentityAwareTestRestTemplate;
 import com.axelixlabs.axelix.master.utils.TestRestTemplateBuilder;
 import com.axelixlabs.axelix.master.utils.auth.AbstractProtectedEndpointTest;

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
@@ -59,7 +59,7 @@ import com.axelixlabs.axelix.master.service.auth.oauth.OidcIdTokenClaimsValidato
 import com.axelixlabs.axelix.master.service.auth.oauth.Tokens;
 import com.axelixlabs.axelix.master.service.auth.oauth.UserInfoJsonAccessor;
 import com.axelixlabs.axelix.master.service.auth.oauth.ValidatedOidcIdentity;
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 import com.axelixlabs.axelix.master.utils.auth.AbstractProtectedEndpointTest;
 
 import static com.axelixlabs.axelix.master.autoconfiguration.mcp.McpAutoConfiguration.MCP_CONFIGURATION_PROPERTIES_PREFIX;

--- a/master/src/test/java/com/axelixlabs/axelix/master/autoconfiguration/auth/SecurityAutoConfigurationTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/autoconfiguration/auth/SecurityAutoConfigurationTest.java
@@ -59,8 +59,8 @@ import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcMetadataProvider;
 import com.axelixlabs.axelix.master.service.auth.provider.DatabaseUserAuthenticator;
 import com.axelixlabs.axelix.master.service.auth.provider.SuperAdminUserAuthenticator;
-import com.axelixlabs.axelix.master.service.state.RoleService;
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.RoleService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 
 import static com.axelixlabs.axelix.master.autoconfiguration.auth.SecurityAutoConfiguration.OAUTH_LOGIN_PROPERTIES_PREFIX;
 import static com.axelixlabs.axelix.master.autoconfiguration.auth.SecurityAutoConfiguration.SUPER_ADMIN_LOGIN_PROPERTIES_PREFIX;

--- a/master/src/test/java/com/axelixlabs/axelix/master/filter/auth/AbstractMcpAuthorizationFilterTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/filter/auth/AbstractMcpAuthorizationFilterTest.java
@@ -63,7 +63,7 @@ import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
 import com.axelixlabs.axelix.master.service.auth.oauth.UserInfoJsonAccessor;
 import com.axelixlabs.axelix.master.service.state.InstanceRegistry;
-import com.axelixlabs.axelix.master.service.state.UserService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 import com.axelixlabs.axelix.master.utils.CapturingIamMcpInterceptor;
 import com.axelixlabs.axelix.master.utils.TestInstanceFactory;
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/DefaultCookieServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/DefaultCookieServiceTest.java
@@ -99,6 +99,29 @@ class DefaultCookieServiceTest {
     }
 
     @Test
+    void buildAuthoritiesMetadataCookie_WithInheritedAuthorities_IncludesTheOnesReachedThroughTheComponents() {
+        // given. The front-end decides what to show from this cookie, so an inherited authority has to reach it just
+        // like a direct one
+        Role parent = new DefaultRole("PARENT", Set.of(DefaultAuthority.ENV_VALUES_READ));
+        Role grandParent = new DefaultRole("GRAND_PARENT", Set.of(DefaultAuthority.CACHES_CLEAR));
+        Role targetRole = new DefaultRole(
+                "OBSERVER",
+                Set.of(DefaultAuthority.CACHES_TOGGLE),
+                Set.of(new DefaultRole("PARENT", parent.getAuthorities(), Set.of(grandParent))));
+
+        // when.
+        ResponseCookie authoritiesCookie = cookieService.buildAuthoritiesMetadataCookie(Set.of(targetRole));
+        String decodedValue =
+                new String(Base64.getDecoder().decode(authoritiesCookie.getValue()), StandardCharsets.UTF_8);
+
+        // then. Own, inherited and inherited-transitively alike
+        assertThat(decodedValue)
+                .contains(DefaultAuthority.CACHES_TOGGLE.name())
+                .contains(DefaultAuthority.ENV_VALUES_READ.name())
+                .contains(DefaultAuthority.CACHES_CLEAR.name());
+    }
+
+    @Test
     void buildAuthoritiesMetadataCookie_WithNoAuthorities_ReturnsBase64EncodedJsonEmptyArrayCookie() {
         // given.
         Role targetRole = new DefaultRole("VIEWER", Set.of());

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/auth/DefaultCookieServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/auth/DefaultCookieServiceTest.java
@@ -102,23 +102,22 @@ class DefaultCookieServiceTest {
     void buildAuthoritiesMetadataCookie_WithInheritedAuthorities_IncludesTheOnesReachedThroughTheComponents() {
         // given. The front-end decides what to show from this cookie, so an inherited authority has to reach it just
         // like a direct one
-        Role parent = new DefaultRole("PARENT", Set.of(DefaultAuthority.ENV_VALUES_READ));
-        Role grandParent = new DefaultRole("GRAND_PARENT", Set.of(DefaultAuthority.CACHES_CLEAR));
-        Role targetRole = new DefaultRole(
-                "OBSERVER",
-                Set.of(DefaultAuthority.CACHES_TOGGLE),
-                Set.of(new DefaultRole("PARENT", parent.getAuthorities(), Set.of(grandParent))));
+        Role grandParent = new DefaultRole("GRAND_PARENT", Set.of(OssAuthority.CACHES_CLEAR));
+        Role child = new DefaultRole(
+                "CHILD",
+                Set.of(OssAuthority.CACHES_TOGGLE),
+                Set.of(new DefaultRole("PARENT", Set.of(OssAuthority.ENV_VALUES_READ), Set.of(grandParent))));
 
         // when.
-        ResponseCookie authoritiesCookie = cookieService.buildAuthoritiesMetadataCookie(Set.of(targetRole));
+        ResponseCookie authoritiesCookie = cookieService.buildAuthoritiesMetadataCookie(Set.of(child));
         String decodedValue =
                 new String(Base64.getDecoder().decode(authoritiesCookie.getValue()), StandardCharsets.UTF_8);
 
         // then. Own, inherited and inherited-transitively alike
         assertThat(decodedValue)
-                .contains(DefaultAuthority.CACHES_TOGGLE.name())
-                .contains(DefaultAuthority.ENV_VALUES_READ.name())
-                .contains(DefaultAuthority.CACHES_CLEAR.name());
+                .contains(OssAuthority.CACHES_TOGGLE.name())
+                .contains(OssAuthority.ENV_VALUES_READ.name())
+                .contains(OssAuthority.CACHES_CLEAR.name());
     }
 
     @Test

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseRoleServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseRoleServiceTest.java
@@ -31,7 +31,7 @@ import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
 import org.springframework.jdbc.core.simple.JdbcClient;
 
 import com.axelixlabs.axelix.common.auth.core.Authority;
-import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
+import com.axelixlabs.axelix.common.auth.core.OssAuthority;
 import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.common.testfixtures.TestRoles;
 import com.axelixlabs.axelix.master.domain.RoleEntity;
@@ -191,31 +191,33 @@ class DatabaseRoleServiceTest {
         @Test
         void shouldExposeTheRoleItDerivesFromAsAComponent() {
             // given.
-            String parentId = customRole("PARENT", DefaultAuthority.CACHES_CLEAR);
-            String childId = customRole("CHILD", DefaultAuthority.GARBAGE_COLLECTOR);
+            String parentId = customRole("PARENT", OssAuthority.CACHES_CLEAR);
+            String childId = customRole("CHILD", OssAuthority.GARBAGE_COLLECTOR);
             deriveFrom(childId, parentId);
 
             // when.
             Role child = roleService.findByName("CHILD").orElseThrow();
 
             // then. The parent is a component rather than its authorities being copied into the child
-            assertThat(child.getAuthorities()).extracting(Authority::getName).containsExactly("GARBAGE_COLLECTOR");
+            assertThat(child.getAuthorities())
+                    .extracting(Authority::getName)
+                    .containsExactly(OssAuthority.GARBAGE_COLLECTOR.getName());
             assertThat(child.getComponents()).singleElement().satisfies(parent -> {
                 assertThat(parent.getName()).isEqualTo("PARENT");
                 assertThat(parent.getAuthorities())
                         .extracting(Authority::getName)
-                        .containsExactly("CACHES_CLEAR");
+                        .containsExactly(OssAuthority.CACHES_CLEAR.getName());
             });
         }
 
         @Test
         void shouldResolveTheBondsTransitively() {
             // given. C derives from B, B derives from A
-            String roleA = customRole("ROLE A", DefaultAuthority.ENV_VALUES_READ);
-            String roleB = customRole("ROLE B", DefaultAuthority.CACHES_CLEAR);
-            String roleC = customRole("ROLE C", DefaultAuthority.GARBAGE_COLLECTOR);
-            deriveFrom(roleB, roleA);
-            deriveFrom(roleC, roleB);
+            String grandParent = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            String parent = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
+            String child = customRole("ROLE C", OssAuthority.GARBAGE_COLLECTOR);
+            deriveFrom(parent, grandParent);
+            deriveFrom(child, parent);
 
             // when.
             Role c = roleService.findByName("ROLE C").orElseThrow();
@@ -223,16 +225,19 @@ class DatabaseRoleServiceTest {
             // then.
             assertThat(c.getEffectiveAuthorities())
                     .extracting(Authority::getName)
-                    .containsExactlyInAnyOrder("GARBAGE_COLLECTOR", "CACHES_CLEAR", "ENV_VALUES_READ");
+                    .containsExactlyInAnyOrder(
+                            OssAuthority.GARBAGE_COLLECTOR.getName(),
+                            OssAuthority.CACHES_CLEAR.getName(),
+                            OssAuthority.ENV_VALUES_READ.getName());
         }
 
         @Test
         void shouldUnionTheAuthoritiesReachedThroughSeveralChains() {
             // given. A diamond: the top role is reached through both branches
-            String top = customRole("TOP", DefaultAuthority.ENV_VALUES_READ);
-            String left = customRole("LEFT", DefaultAuthority.CACHES_CLEAR);
-            String right = customRole("RIGHT", DefaultAuthority.CACHES_TOGGLE);
-            String bottom = customRole("BOTTOM", DefaultAuthority.GARBAGE_COLLECTOR);
+            String top = customRole("TOP", OssAuthority.ENV_VALUES_READ);
+            String left = customRole("LEFT", OssAuthority.CACHES_CLEAR);
+            String right = customRole("RIGHT", OssAuthority.CACHES_TOGGLE);
+            String bottom = customRole("BOTTOM", OssAuthority.GARBAGE_COLLECTOR);
             deriveFrom(left, top);
             deriveFrom(right, top);
             deriveFrom(bottom, left);
@@ -244,15 +249,19 @@ class DatabaseRoleServiceTest {
             // then. Reaching the same authority twice is not an error, it is simply unioned
             assertThat(role.getEffectiveAuthorities())
                     .extracting(Authority::getName)
-                    .containsExactlyInAnyOrder("GARBAGE_COLLECTOR", "CACHES_CLEAR", "CACHES_TOGGLE", "ENV_VALUES_READ");
+                    .containsExactlyInAnyOrder(
+                            OssAuthority.GARBAGE_COLLECTOR.getName(),
+                            OssAuthority.CACHES_CLEAR.getName(),
+                            OssAuthority.CACHES_TOGGLE.getName(),
+                            OssAuthority.ENV_VALUES_READ.getName());
         }
 
         @Test
         void shouldTerminateOnABondCycleWrittenAroundTheApplication() {
             // given. Neither lane can write this, but a hand-written row could - and the resolution runs on the
             // login path, so looping here would leave nobody able to log in
-            String roleA = customRole("ROLE A", DefaultAuthority.ENV_VALUES_READ);
-            String roleB = customRole("ROLE B", DefaultAuthority.CACHES_CLEAR);
+            String roleA = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            String roleB = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
             deriveFrom(roleA, roleB);
             deriveFrom(roleB, roleA);
 
@@ -262,14 +271,15 @@ class DatabaseRoleServiceTest {
             // then. The walk stops at the repeated role, so the authorities are still resolved
             assertThat(a.getEffectiveAuthorities())
                     .extracting(Authority::getName)
-                    .containsExactlyInAnyOrder("ENV_VALUES_READ", "CACHES_CLEAR");
+                    .containsExactlyInAnyOrder(
+                            OssAuthority.ENV_VALUES_READ.getName(), OssAuthority.CACHES_CLEAR.getName());
         }
 
         @Test
         void shouldResolveTheBondsOfEveryRoleTheUserHolds() {
             // given.
-            String parentId = customRole("PARENT", DefaultAuthority.CACHES_CLEAR);
-            String childId = customRole("CHILD", DefaultAuthority.GARBAGE_COLLECTOR);
+            String parentId = customRole("PARENT", OssAuthority.CACHES_CLEAR);
+            String childId = customRole("CHILD", OssAuthority.GARBAGE_COLLECTOR);
             deriveFrom(childId, parentId);
 
             userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "CHILD");
@@ -283,10 +293,11 @@ class DatabaseRoleServiceTest {
                     .singleElement()
                     .satisfies(role -> assertThat(role.getEffectiveAuthorities())
                             .extracting(Authority::getName)
-                            .containsExactlyInAnyOrder("GARBAGE_COLLECTOR", "CACHES_CLEAR"));
+                            .containsExactlyInAnyOrder(
+                                    OssAuthority.GARBAGE_COLLECTOR.getName(), OssAuthority.CACHES_CLEAR.getName()));
         }
 
-        private String customRole(String name, DefaultAuthority authority) {
+        private String customRole(String name, OssAuthority authority) {
             String id = UUID.randomUUID().toString();
 
             jdbcAggregateTemplate.insert(new RoleEntity(id, name, "Description", RoleOrigin.WEB_UI));

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseRoleServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseRoleServiceTest.java
@@ -19,6 +19,7 @@ package com.axelixlabs.axelix.master.service.state;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,10 +27,15 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
+import org.springframework.jdbc.core.simple.JdbcClient;
 
 import com.axelixlabs.axelix.common.auth.core.Authority;
+import com.axelixlabs.axelix.common.auth.core.DefaultAuthority;
 import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.common.testfixtures.TestRoles;
+import com.axelixlabs.axelix.master.domain.RoleEntity;
+import com.axelixlabs.axelix.master.domain.RoleOrigin;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.utils.database.DatabaseMatrixTest;
@@ -53,6 +59,12 @@ class DatabaseRoleServiceTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private JdbcAggregateTemplate jdbcAggregateTemplate;
+
+    @Autowired
+    private JdbcClient jdbcClient;
 
     @Nested
     class FindByName {
@@ -150,6 +162,148 @@ class DatabaseRoleServiceTest {
                     .filter(role -> role.getName().equals(name))
                     .findFirst()
                     .orElseThrow();
+        }
+    }
+
+    /**
+     * The bonds of {@code roles_parents} are resolved into the components of the role, which is what makes an
+     * inherited authority reach the checks. The built-in roles carry no bonds, so nothing else in this class covers
+     * it.
+     */
+    @Nested
+    class Inheritance {
+
+        @BeforeEach
+        @AfterEach
+        void cleanCustomRoles() {
+            userRepository.findAll().forEach(user -> userService.deleteById(user.id()));
+            jdbcClient.sql("DELETE FROM roles_parents").update();
+            jdbcClient
+                    .sql("DELETE FROM roles_authorities WHERE role_id IN (SELECT id FROM roles WHERE role_origin <> ?)")
+                    .param(RoleOrigin.BUILT_IN.name())
+                    .update();
+            jdbcClient
+                    .sql("DELETE FROM roles WHERE role_origin <> ?")
+                    .param(RoleOrigin.BUILT_IN.name())
+                    .update();
+        }
+
+        @Test
+        void shouldExposeTheRoleItDerivesFromAsAComponent() {
+            // given.
+            String parentId = customRole("PARENT", DefaultAuthority.CACHES_CLEAR);
+            String childId = customRole("CHILD", DefaultAuthority.GARBAGE_COLLECTOR);
+            deriveFrom(childId, parentId);
+
+            // when.
+            Role child = roleService.findByName("CHILD").orElseThrow();
+
+            // then. The parent is a component rather than its authorities being copied into the child
+            assertThat(child.getAuthorities()).extracting(Authority::getName).containsExactly("GARBAGE_COLLECTOR");
+            assertThat(child.getComponents()).singleElement().satisfies(parent -> {
+                assertThat(parent.getName()).isEqualTo("PARENT");
+                assertThat(parent.getAuthorities())
+                        .extracting(Authority::getName)
+                        .containsExactly("CACHES_CLEAR");
+            });
+        }
+
+        @Test
+        void shouldResolveTheBondsTransitively() {
+            // given. C derives from B, B derives from A
+            String roleA = customRole("ROLE A", DefaultAuthority.ENV_VALUES_READ);
+            String roleB = customRole("ROLE B", DefaultAuthority.CACHES_CLEAR);
+            String roleC = customRole("ROLE C", DefaultAuthority.GARBAGE_COLLECTOR);
+            deriveFrom(roleB, roleA);
+            deriveFrom(roleC, roleB);
+
+            // when.
+            Role c = roleService.findByName("ROLE C").orElseThrow();
+
+            // then.
+            assertThat(c.getEffectiveAuthorities())
+                    .extracting(Authority::getName)
+                    .containsExactlyInAnyOrder("GARBAGE_COLLECTOR", "CACHES_CLEAR", "ENV_VALUES_READ");
+        }
+
+        @Test
+        void shouldUnionTheAuthoritiesReachedThroughSeveralChains() {
+            // given. A diamond: the top role is reached through both branches
+            String top = customRole("TOP", DefaultAuthority.ENV_VALUES_READ);
+            String left = customRole("LEFT", DefaultAuthority.CACHES_CLEAR);
+            String right = customRole("RIGHT", DefaultAuthority.CACHES_TOGGLE);
+            String bottom = customRole("BOTTOM", DefaultAuthority.GARBAGE_COLLECTOR);
+            deriveFrom(left, top);
+            deriveFrom(right, top);
+            deriveFrom(bottom, left);
+            deriveFrom(bottom, right);
+
+            // when.
+            Role role = roleService.findByName("BOTTOM").orElseThrow();
+
+            // then. Reaching the same authority twice is not an error, it is simply unioned
+            assertThat(role.getEffectiveAuthorities())
+                    .extracting(Authority::getName)
+                    .containsExactlyInAnyOrder("GARBAGE_COLLECTOR", "CACHES_CLEAR", "CACHES_TOGGLE", "ENV_VALUES_READ");
+        }
+
+        @Test
+        void shouldTerminateOnABondCycleWrittenAroundTheApplication() {
+            // given. Neither lane can write this, but a hand-written row could - and the resolution runs on the
+            // login path, so looping here would leave nobody able to log in
+            String roleA = customRole("ROLE A", DefaultAuthority.ENV_VALUES_READ);
+            String roleB = customRole("ROLE B", DefaultAuthority.CACHES_CLEAR);
+            deriveFrom(roleA, roleB);
+            deriveFrom(roleB, roleA);
+
+            // when.
+            Role a = roleService.findByName("ROLE A").orElseThrow();
+
+            // then. The walk stops at the repeated role, so the authorities are still resolved
+            assertThat(a.getEffectiveAuthorities())
+                    .extracting(Authority::getName)
+                    .containsExactlyInAnyOrder("ENV_VALUES_READ", "CACHES_CLEAR");
+        }
+
+        @Test
+        void shouldResolveTheBondsOfEveryRoleTheUserHolds() {
+            // given.
+            String parentId = customRole("PARENT", DefaultAuthority.CACHES_CLEAR);
+            String childId = customRole("CHILD", DefaultAuthority.GARBAGE_COLLECTOR);
+            deriveFrom(childId, parentId);
+
+            userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "CHILD");
+            String userId = userRepository.findByUsername("alice").orElseThrow().id();
+
+            // when.
+            Set<Role> roles = roleService.findRolesOfUser(userId);
+
+            // then.
+            assertThat(roles)
+                    .singleElement()
+                    .satisfies(role -> assertThat(role.getEffectiveAuthorities())
+                            .extracting(Authority::getName)
+                            .containsExactlyInAnyOrder("GARBAGE_COLLECTOR", "CACHES_CLEAR"));
+        }
+
+        private String customRole(String name, DefaultAuthority authority) {
+            String id = UUID.randomUUID().toString();
+
+            jdbcAggregateTemplate.insert(new RoleEntity(id, name, "Description", RoleOrigin.WEB_UI));
+            jdbcClient
+                    .sql("INSERT INTO roles_authorities (role_id, authority_id)"
+                            + " SELECT ?, id FROM authorities WHERE name = ?")
+                    .params(id, authority.name())
+                    .update();
+
+            return id;
+        }
+
+        private void deriveFrom(String roleId, String parentRoleId) {
+            jdbcClient
+                    .sql("INSERT INTO roles_parents (role_id, parent_role_id) VALUES (?, ?)")
+                    .params(roleId, parentRoleId)
+                    .update();
         }
     }
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import com.axelixlabs.axelix.master.service.state.auth.DatabaseUserService;
-import com.axelixlabs.axelix.master.service.state.auth.UserService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +39,8 @@ import com.axelixlabs.axelix.master.exception.auth.UserNotFoundException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 import com.axelixlabs.axelix.master.exception.auth.UsernameAlreadyExistsException;
 import com.axelixlabs.axelix.master.repository.UserRepository;
+import com.axelixlabs.axelix.master.service.state.auth.DatabaseUserService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 import com.axelixlabs.axelix.master.utils.database.DatabaseMatrixTest;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.axelixlabs.axelix.master.service.state.auth.DatabaseUserService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DefaultRoleServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DefaultRoleServiceTest.java
@@ -21,9 +21,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import com.axelixlabs.axelix.master.service.state.auth.DefaultRoleService;
-import com.axelixlabs.axelix.master.service.state.auth.RoleService;
-import com.axelixlabs.axelix.master.service.state.auth.UserService;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +39,9 @@ import com.axelixlabs.axelix.master.domain.RoleEntity;
 import com.axelixlabs.axelix.master.domain.RoleOrigin;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.repository.UserRepository;
+import com.axelixlabs.axelix.master.service.state.auth.DefaultRoleService;
+import com.axelixlabs.axelix.master.service.state.auth.RoleService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
 import com.axelixlabs.axelix.master.utils.database.DatabaseMatrixTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -292,6 +292,21 @@ class DefaultRoleServiceTest {
     @Nested
     class Cycles {
 
+        @BeforeEach
+        @AfterEach
+        void cleanCustomRoles() {
+            userRepository.findAll().forEach(user -> userService.deleteById(user.id()));
+            jdbcClient.sql("DELETE FROM roles_parents").update();
+            jdbcClient
+                    .sql("DELETE FROM roles_authorities WHERE role_id IN (SELECT id FROM roles WHERE role_origin <> ?)")
+                    .param(RoleOrigin.BUILT_IN.name())
+                    .update();
+            jdbcClient
+                    .sql("DELETE FROM roles WHERE role_origin <> ?")
+                    .param(RoleOrigin.BUILT_IN.name())
+                    .update();
+        }
+
         @Test
         void shouldTerminateOnABondCycleWrittenAroundTheApplication() {
             // given. Neither lane can write this, but a hand-written row could - and the resolution runs on the
@@ -307,6 +322,99 @@ class DefaultRoleServiceTest {
             // then.
             assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
         }
+
+        @Test
+        void shouldTerminateOnARoleThatDerivesFromItself() {
+            // given. A self-loop is the shortest cycle a hand-written row can introduce
+            String role = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            createBond(role, role);
+
+            // when.
+            ThrowableAssert.ThrowingCallable callable = () -> roleService.findByName("ROLE A");
+
+            // then.
+            assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void shouldTerminateOnACycleSpanningThreeRoles() {
+            // given. A --> B --> C --> A
+            String roleA = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            String roleB = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
+            String roleC = customRole("ROLE C", OssAuthority.CACHES_TOGGLE);
+            createBond(roleA, roleB);
+            createBond(roleB, roleC);
+            createBond(roleC, roleA);
+
+            // when.
+            ThrowableAssert.ThrowingCallable callable = () -> roleService.findByName("ROLE A");
+
+            // then. The message spells out the offending chain to make the hand-written row diagnosable
+            assertThatThrownBy(callable)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("ROLE A --> ROLE B --> ROLE C --> ROLE A");
+        }
+
+        @Test
+        void shouldTerminateWhenTheCycleSitsAboveTheQueriedRole() {
+            // given. The queried role is itself acyclic, but its ancestry loops: LEAF --> A --> B --> A
+            String leaf = customRole("LEAF", OssAuthority.GARBAGE_COLLECTOR);
+            String roleA = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            String roleB = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
+            createBond(leaf, roleA);
+            createBond(roleA, roleB);
+            createBond(roleB, roleA);
+
+            // when.
+            ThrowableAssert.ThrowingCallable callable = () -> roleService.findByName("LEAF");
+
+            // then.
+            assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void shouldTerminateWhenResolvingTheRolesOfAUserCaughtInACycle() {
+            // given. The cycle is reached through the other resolution entry point - the login path
+            String roleA = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            String roleB = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
+            createBond(roleA, roleB);
+            createBond(roleB, roleA);
+
+            userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "ROLE A");
+            String userId = userRepository.findByUsername("alice").orElseThrow().id();
+
+            // when.
+            ThrowableAssert.ThrowingCallable callable = () -> roleService.findRolesOfUser(userId);
+
+            // then.
+            assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void shouldNotReportACycleForADiamondSharedAncestor() {
+            // given. A diamond reaches the same ancestor through two branches - that is a DAG, not a cycle, and the
+            // colouring must not mistake the second visit for a back-edge
+            String top = customRole("TOP", OssAuthority.ENV_VALUES_READ);
+            String left = customRole("LEFT", OssAuthority.CACHES_CLEAR);
+            String right = customRole("RIGHT", OssAuthority.CACHES_TOGGLE);
+            String bottom = customRole("BOTTOM", OssAuthority.GARBAGE_COLLECTOR);
+            createBond(left, top);
+            createBond(right, top);
+            createBond(bottom, left);
+            createBond(bottom, right);
+
+            // when.
+            Role role = roleService.findByName("BOTTOM").orElseThrow();
+
+            // then.
+            assertThat(role.getEffectiveAuthorities())
+                    .extracting(Authority::getName)
+                    .containsExactlyInAnyOrder(
+                            OssAuthority.GARBAGE_COLLECTOR.getName(),
+                            OssAuthority.CACHES_CLEAR.getName(),
+                            OssAuthority.CACHES_TOGGLE.getName(),
+                            OssAuthority.ENV_VALUES_READ.getName());
+        }
     }
 
     private String customRole(String name, OssAuthority authority) {
@@ -314,19 +422,19 @@ class DefaultRoleServiceTest {
 
         jdbcAggregateTemplate.insert(new RoleEntity(id, name, "Description", RoleOrigin.WEB_UI));
         jdbcClient
-            .sql("INSERT INTO roles_authorities (role_id, authority_id)"
-                + " SELECT ?, id FROM authorities WHERE name = ?")
-            .params(id, authority.name())
-            .update();
+                .sql("INSERT INTO roles_authorities (role_id, authority_id)"
+                        + " SELECT ?, id FROM authorities WHERE name = ?")
+                .params(id, authority.name())
+                .update();
 
         return id;
     }
 
     private void createBond(String childId, String parentRoleId) {
         jdbcClient
-            .sql("INSERT INTO roles_parents (role_id, parent_role_id) VALUES (?, ?)")
-            .params(childId, parentRoleId)
-            .update();
+                .sql("INSERT INTO roles_parents (role_id, parent_role_id) VALUES (?, ?)")
+                .params(childId, parentRoleId)
+                .update();
     }
 
     private static void assertGrantsSameAs(Role actual, Role expected) {

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DefaultRoleServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DefaultRoleServiceTest.java
@@ -21,6 +21,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import com.axelixlabs.axelix.master.service.state.auth.DefaultRoleService;
+import com.axelixlabs.axelix.master.service.state.auth.RoleService;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -41,15 +45,16 @@ import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.utils.database.DatabaseMatrixTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Integration tests of {@link DatabaseRoleService}.
+ * Integration tests of {@link DefaultRoleService}.
  *
  * @author Sergey Cherkasov
  * @author Mikhail Polivakha
  */
 @DatabaseMatrixTest
-class DatabaseRoleServiceTest {
+class DefaultRoleServiceTest {
 
     @Autowired
     private RoleService roleService;
@@ -193,7 +198,7 @@ class DatabaseRoleServiceTest {
             // given.
             String parentId = customRole("PARENT", OssAuthority.CACHES_CLEAR);
             String childId = customRole("CHILD", OssAuthority.GARBAGE_COLLECTOR);
-            deriveFrom(childId, parentId);
+            createBond(childId, parentId);
 
             // when.
             Role child = roleService.findByName("CHILD").orElseThrow();
@@ -216,8 +221,8 @@ class DatabaseRoleServiceTest {
             String grandParent = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
             String parent = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
             String child = customRole("ROLE C", OssAuthority.GARBAGE_COLLECTOR);
-            deriveFrom(parent, grandParent);
-            deriveFrom(child, parent);
+            createBond(parent, grandParent);
+            createBond(child, parent);
 
             // when.
             Role c = roleService.findByName("ROLE C").orElseThrow();
@@ -238,10 +243,10 @@ class DatabaseRoleServiceTest {
             String left = customRole("LEFT", OssAuthority.CACHES_CLEAR);
             String right = customRole("RIGHT", OssAuthority.CACHES_TOGGLE);
             String bottom = customRole("BOTTOM", OssAuthority.GARBAGE_COLLECTOR);
-            deriveFrom(left, top);
-            deriveFrom(right, top);
-            deriveFrom(bottom, left);
-            deriveFrom(bottom, right);
+            createBond(left, top);
+            createBond(right, top);
+            createBond(bottom, left);
+            createBond(bottom, right);
 
             // when.
             Role role = roleService.findByName("BOTTOM").orElseThrow();
@@ -257,30 +262,11 @@ class DatabaseRoleServiceTest {
         }
 
         @Test
-        void shouldTerminateOnABondCycleWrittenAroundTheApplication() {
-            // given. Neither lane can write this, but a hand-written row could - and the resolution runs on the
-            // login path, so looping here would leave nobody able to log in
-            String roleA = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
-            String roleB = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
-            deriveFrom(roleA, roleB);
-            deriveFrom(roleB, roleA);
-
-            // when.
-            Role a = roleService.findByName("ROLE A").orElseThrow();
-
-            // then. The walk stops at the repeated role, so the authorities are still resolved
-            assertThat(a.getEffectiveAuthorities())
-                    .extracting(Authority::getName)
-                    .containsExactlyInAnyOrder(
-                            OssAuthority.ENV_VALUES_READ.getName(), OssAuthority.CACHES_CLEAR.getName());
-        }
-
-        @Test
         void shouldResolveTheBondsOfEveryRoleTheUserHolds() {
             // given.
             String parentId = customRole("PARENT", OssAuthority.CACHES_CLEAR);
             String childId = customRole("CHILD", OssAuthority.GARBAGE_COLLECTOR);
-            deriveFrom(childId, parentId);
+            createBond(childId, parentId);
 
             userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "CHILD");
             String userId = userRepository.findByUsername("alice").orElseThrow().id();
@@ -296,26 +282,51 @@ class DatabaseRoleServiceTest {
                             .containsExactlyInAnyOrder(
                                     OssAuthority.GARBAGE_COLLECTOR.getName(), OssAuthority.CACHES_CLEAR.getName()));
         }
+    }
 
-        private String customRole(String name, OssAuthority authority) {
-            String id = UUID.randomUUID().toString();
+    /**
+     * Dedicated nested class that covers the case when roles DAG for any reason creates a cycle. If the role is created by
+     * any standard means that cannot/should not happen, but in any case, we may have a bug, or somebody may alter the state
+     * of the database directly so we have to cover that as well.
+     */
+    @Nested
+    class Cycles {
 
-            jdbcAggregateTemplate.insert(new RoleEntity(id, name, "Description", RoleOrigin.WEB_UI));
-            jdbcClient
-                    .sql("INSERT INTO roles_authorities (role_id, authority_id)"
-                            + " SELECT ?, id FROM authorities WHERE name = ?")
-                    .params(id, authority.name())
-                    .update();
+        @Test
+        void shouldTerminateOnABondCycleWrittenAroundTheApplication() {
+            // given. Neither lane can write this, but a hand-written row could - and the resolution runs on the
+            // login path, so looping here would leave nobody able to log in
+            String roleA = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            String roleB = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
+            createBond(roleA, roleB);
+            createBond(roleB, roleA);
 
-            return id;
+            // when.
+            ThrowableAssert.ThrowingCallable callable = () -> roleService.findByName("ROLE A");
+
+            // then.
+            assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
         }
+    }
 
-        private void deriveFrom(String roleId, String parentRoleId) {
-            jdbcClient
-                    .sql("INSERT INTO roles_parents (role_id, parent_role_id) VALUES (?, ?)")
-                    .params(roleId, parentRoleId)
-                    .update();
-        }
+    private String customRole(String name, OssAuthority authority) {
+        String id = UUID.randomUUID().toString();
+
+        jdbcAggregateTemplate.insert(new RoleEntity(id, name, "Description", RoleOrigin.WEB_UI));
+        jdbcClient
+            .sql("INSERT INTO roles_authorities (role_id, authority_id)"
+                + " SELECT ?, id FROM authorities WHERE name = ?")
+            .params(id, authority.name())
+            .update();
+
+        return id;
+    }
+
+    private void createBond(String childId, String parentRoleId) {
+        jdbcClient
+            .sql("INSERT INTO roles_parents (role_id, parent_role_id) VALUES (?, ?)")
+            .params(childId, parentRoleId)
+            .update();
     }
 
     private static void assertGrantsSameAs(Role actual, Role expected) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added effective permissions inherited through nested roles.
  * User permissions and authority metadata now include inherited authorities.
  * Role lookups support complete hierarchies and multiple inheritance paths.
  * Added detection and reporting for circular role relationships.

* **Bug Fixes**
  * Prevented duplicate permissions across multiple inheritance paths.

* **Tests**
  * Added coverage for nested, transitive, and diamond-shaped inheritance, circular relationships, and inherited user permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->