### PR TITLE
GH-1559 Add the roles feed to the external API

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/ApiPaths.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/ApiPaths.java
@@ -55,6 +55,14 @@ public final class ApiPaths {
         public static final String GET_USER_BY_ID = "/users/feed/{userId}";
     }
 
+    public static final class RolesApi {
+
+        /**
+         * Endpoint to retrieve the feed of the roles.
+         */
+        public static final String ROLES_FEED = "/roles/feed";
+    }
+
     public static final class UsersManagementApi {
 
         /**

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/RolesApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/RolesApi.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.api.external.endpoint;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.axelixlabs.axelix.master.api.external.ApiPaths;
+import com.axelixlabs.axelix.master.api.external.ExternalApiRestController;
+import com.axelixlabs.axelix.master.api.external.response.RoleFeedResponse;
+import com.axelixlabs.axelix.master.api.external.swagger.DefaultApiResponse;
+import com.axelixlabs.axelix.master.service.state.auth.RoleService;
+
+/**
+ * The API for working with roles.
+ *
+ * @author Sergey Cherkasov
+ */
+@Tag(name = "API for working with Roles", description = "The endpoints for listing the roles Axelix Master knows about")
+@ExternalApiRestController
+public class RolesApi {
+
+    private final RoleService roleService;
+
+    public RolesApi(RoleService roleService) {
+        this.roleService = roleService;
+    }
+
+    @DefaultApiResponse(summary = "Retrieve all roles feed")
+    @ApiResponse(
+            description = "OK",
+            responseCode = "200",
+            content =
+                    @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = RoleFeedResponse.class))))
+    @GetMapping(path = ApiPaths.RolesApi.ROLES_FEED)
+    public ResponseEntity<List<RoleFeedResponse>> getRolesFeed() {
+        List<RoleFeedResponse> roles =
+                roleService.getRolesFeed().stream().map(RoleFeedResponse::from).toList();
+
+        return ResponseEntity.ok(roles);
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/RolesApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/RolesApi.java
@@ -19,19 +19,12 @@ package com.axelixlabs.axelix.master.api.external.endpoint;
 
 import java.util.List;
 
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 
 import com.axelixlabs.axelix.master.api.external.ApiPaths;
 import com.axelixlabs.axelix.master.api.external.ExternalApiRestController;
 import com.axelixlabs.axelix.master.api.external.response.RoleFeedResponse;
-import com.axelixlabs.axelix.master.api.external.swagger.DefaultApiResponse;
 import com.axelixlabs.axelix.master.service.state.auth.RoleService;
 
 /**
@@ -39,7 +32,6 @@ import com.axelixlabs.axelix.master.service.state.auth.RoleService;
  *
  * @author Sergey Cherkasov
  */
-@Tag(name = "API for working with Roles", description = "The endpoints for listing the roles Axelix Master knows about")
 @ExternalApiRestController
 public class RolesApi {
 
@@ -49,14 +41,6 @@ public class RolesApi {
         this.roleService = roleService;
     }
 
-    @DefaultApiResponse(summary = "Retrieve all roles feed")
-    @ApiResponse(
-            description = "OK",
-            responseCode = "200",
-            content =
-                    @Content(
-                            mediaType = "application/json",
-                            array = @ArraySchema(schema = @Schema(implementation = RoleFeedResponse.class))))
     @GetMapping(path = ApiPaths.RolesApi.ROLES_FEED)
     public ResponseEntity<List<RoleFeedResponse>> getRolesFeed() {
         List<RoleFeedResponse> roles =

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/response/RoleFeedResponse.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/response/RoleFeedResponse.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.api.external.response;
+
+import com.axelixlabs.axelix.master.domain.RoleFeed;
+
+/**
+ * Public view of a single role.
+ *
+ * @param id           Unique identifier of the role.
+ * @param name         Unique name of the role.
+ * @param membersCount Number of users the role is assigned to.
+ * @param description  Human-readable description of what the role allows.
+ *
+ * @author Sergey Cherkasov
+ */
+public record RoleFeedResponse(String id, String name, int membersCount, String description) {
+
+    public static RoleFeedResponse from(RoleFeed role) {
+        return new RoleFeedResponse(role.id(), role.name(), role.membersCount(), role.description());
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/domain/RoleFeed.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/domain/RoleFeed.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.domain;
+
+/**
+ * A single entry of the roles feed: one role, seen from the outside.
+ *
+ * @param id           Unique identifier of the role.
+ * @param name         Unique name of the role.
+ * @param membersCount Number of users the role is assigned to.
+ * @param description  Human-readable description of what the role allows.
+ *
+ * @author Sergey Cherkasov
+ */
+public record RoleFeed(String id, String name, int membersCount, String description) {}

--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/RoleRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/RoleRepository.java
@@ -48,8 +48,19 @@ public interface RoleRepository extends ListCrudRepository<RoleEntity, String> {
     @Query("SELECT role_id FROM users_roles WHERE user_id = :userId")
     List<String> findRoleIdsOfUser(@Param("userId") String userId);
 
+    @Query("SELECT role_id AS role_id, COUNT(*) AS members FROM users_roles GROUP BY role_id")
+    List<RoleMembers> findAllMembersCounts();
+
     record RoleWithAuthorityName(
             String roleId, String roleName, @Nullable String authorityName) {}
 
     record RoleParentBond(String roleId, String parentRoleId) {}
+
+    /**
+     * Number of users a role is assigned to.
+     *
+     * @param roleId  Identifier of the role.
+     * @param members Number of users the role is assigned to.
+     */
+    record RoleMembers(String roleId, int members) {}
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/auth/MasterWebEndpoints.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/auth/MasterWebEndpoints.java
@@ -226,6 +226,10 @@ public final class MasterWebEndpoints {
     public static final MasterWebEndpoint LOGOUT =
             register("auth:logout", HttpMethod.POST, ApiPaths.UsersApi.LOGOUT, null);
 
+    // Roles
+    public static final MasterWebEndpoint ROLES_READ =
+            register("roles:read", HttpMethod.GET, ApiPaths.RolesApi.ROLES_FEED, OssAuthority.USERS_VIEW);
+
     // Oidc/Oauth
     public static final MasterWebEndpoint OIDC_AUTH_COMPLETE =
             register("oidc:auth:complete", HttpMethod.GET, ApiPaths.OAuth2Api.CALLBACK, null);

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DefaultRoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DefaultRoleService.java
@@ -38,7 +38,9 @@ import com.axelixlabs.axelix.common.auth.core.Authority;
 import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.common.auth.service.AuthoritiesManager;
+import com.axelixlabs.axelix.master.domain.RoleFeed;
 import com.axelixlabs.axelix.master.repository.RoleRepository;
+import com.axelixlabs.axelix.master.repository.RoleRepository.RoleMembers;
 import com.axelixlabs.axelix.master.repository.RoleRepository.RoleParentBond;
 import com.axelixlabs.axelix.master.repository.RoleRepository.RoleWithAuthorityName;
 
@@ -75,6 +77,17 @@ public class DefaultRoleService implements RoleService {
                 .map(graph::composeRole)
                 .flatMap(Optional::stream)
                 .collect(Collectors.toSet());
+    }
+
+    @Override
+    public List<RoleFeed> getRolesFeed() {
+        Map<String, Integer> membersByRoleId = roleRepository.findAllMembersCounts().stream()
+                .collect(Collectors.toMap(RoleMembers::roleId, RoleMembers::members));
+
+        return roleRepository.findAll().stream()
+                .map(role -> new RoleFeed(
+                        role.id(), role.name(), membersByRoleId.getOrDefault(role.id(), 0), role.description()))
+                .toList();
     }
 
     private RoleGraph getGraph() {

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/RoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/RoleService.java
@@ -17,12 +17,14 @@
  */
 package com.axelixlabs.axelix.master.service.state.auth;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import org.jspecify.annotations.NullMarked;
 
 import com.axelixlabs.axelix.common.auth.core.Role;
+import com.axelixlabs.axelix.master.domain.RoleFeed;
 import com.axelixlabs.axelix.master.service.auth.provider.SuperAdminUserAuthenticator;
 
 /**
@@ -62,4 +64,11 @@ public interface RoleService {
      * @return Roles of the user.
      */
     Set<Role> findRolesOfUser(String userId) throws IllegalStateException;
+
+    /**
+     * Returns the feed of all the roles.
+     *
+     * @return An entry per role, in no particular order.
+     */
+    List<RoleFeed> getRolesFeed();
 }

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/RolesApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/RolesApiTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.api.external.endpoint;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+
+import com.axelixlabs.axelix.common.testfixtures.TestRoles;
+import com.axelixlabs.axelix.master.repository.UserRepository;
+import com.axelixlabs.axelix.master.service.auth.MasterWebEndpoints;
+import com.axelixlabs.axelix.master.service.state.auth.UserService;
+import com.axelixlabs.axelix.master.utils.IdentityAwareTestRestTemplate;
+import com.axelixlabs.axelix.master.utils.TestRestTemplateBuilder;
+import com.axelixlabs.axelix.master.utils.auth.AbstractProtectedEndpointTest;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link RolesApi}.
+ *
+ * @author Sergey Cherkasov
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
+@TestPropertySource(
+        properties = {
+            "axelix.master.auth.options.local.enabled=true",
+            "axelix.master.auth.options.super-admin.credentials.username=admin",
+            "axelix.master.auth.options.super-admin.credentials.password=admin",
+        })
+class RolesApiTest extends AbstractProtectedEndpointTest {
+
+    private static final String ROLES_FEED_PATH = "/api/external/roles/feed";
+
+    @Autowired
+    private TestRestTemplateBuilder restTemplateBuilder;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @BeforeEach
+    void cleanUsersTable() {
+        userRepository.findAll().forEach(user -> userService.deleteById(user.id()));
+    }
+
+    @Test
+    void shouldReturnTheFeedOfTheBuiltInRoles() {
+        // given.
+        userService.createLocal(
+                "alice", null, null, "alice@example.com", null, null, "aliceSecret", TestRoles.EDITOR.getName());
+
+        // language=json
+        String expectedFeed = """
+                [
+                  {
+                    "id": "00000000-0000-0000-0000-0000000000b1",
+                    "name": "VIEWER",
+                    "membersCount": 0,
+                    "description": "Read-only access to the monitored applications."
+                  },
+                  {
+                    "id": "00000000-0000-0000-0000-0000000000b2",
+                    "name": "EDITOR",
+                    "membersCount": 1,
+                    "description": "Performs runtime operations on the monitored applications, including destructive ones such as clearing caches."
+                  },
+                  {
+                    "id": "00000000-0000-0000-0000-0000000000b3",
+                    "name": "ADMIN",
+                    "membersCount": 0,
+                    "description": "Everything an editor can do, plus reading sensitive configuration values."
+                  }
+                ]
+                """;
+
+        // when.
+        IdentityAwareTestRestTemplate rolesViewer = restTemplateBuilder.asUsersFeedViewer();
+        ResponseEntity<String> response = rolesViewer.getForEntity(ROLES_FEED_PATH, String.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+        assertThatJson(response.getBody()).when(IGNORING_ARRAY_ORDER).isEqualTo(expectedFeed);
+        assertSuccessfulCallback(MasterWebEndpoints.ROLES_READ, rolesViewer.getActor());
+    }
+
+    @Override
+    protected Set<TestableMasterWebEndpoint> endpointsUnderTest() {
+        return Set.of(new TestableMasterWebEndpoint(MasterWebEndpoints.ROLES_READ, ROLES_FEED_PATH));
+    }
+}

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DefaultRoleServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DefaultRoleServiceTest.java
@@ -17,11 +17,11 @@
  */
 package com.axelixlabs.axelix.master.service.state;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -32,13 +32,16 @@ import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
 import org.springframework.jdbc.core.simple.JdbcClient;
 
 import com.axelixlabs.axelix.common.auth.core.Authority;
+import com.axelixlabs.axelix.common.auth.core.DefaultRole;
 import com.axelixlabs.axelix.common.auth.core.OssAuthority;
 import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.common.testfixtures.TestRoles;
 import com.axelixlabs.axelix.master.domain.RoleEntity;
+import com.axelixlabs.axelix.master.domain.RoleFeed;
 import com.axelixlabs.axelix.master.domain.RoleOrigin;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.repository.UserRepository;
+import com.axelixlabs.axelix.master.service.auth.provider.SuperAdminUserAuthenticator;
 import com.axelixlabs.axelix.master.service.state.auth.DefaultRoleService;
 import com.axelixlabs.axelix.master.service.state.auth.RoleService;
 import com.axelixlabs.axelix.master.service.state.auth.UserService;
@@ -46,6 +49,7 @@ import com.axelixlabs.axelix.master.utils.database.DatabaseMatrixTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 /**
  * Integration tests of {@link DefaultRoleService}.
@@ -71,11 +75,26 @@ class DefaultRoleServiceTest {
     @Autowired
     private JdbcClient jdbcClient;
 
+    @BeforeEach
+    @AfterEach
+    void cleanCustomRolesAndUsers() {
+        userRepository.findAll().forEach(user -> userService.deleteById(user.id()));
+        jdbcClient.sql("DELETE FROM roles_parents").update();
+        jdbcClient
+                .sql("DELETE FROM roles_authorities WHERE role_id IN (SELECT id FROM roles WHERE role_origin <> ?)")
+                .param(RoleOrigin.BUILT_IN.name())
+                .update();
+        jdbcClient
+                .sql("DELETE FROM roles WHERE role_origin <> ?")
+                .param(RoleOrigin.BUILT_IN.name())
+                .update();
+    }
+
     @Nested
     class FindByName {
 
         @Test
-        void findByName_shouldReturnBuiltInRolesMatchingTheOnesTestsAreBuiltUpon() {
+        void shouldReturnBuiltInRolesMatchingTheOnesTestsAreBuiltUpon() {
             // when.
             Optional<Role> viewer = roleService.findByName(TestRoles.VIEWER.getName());
             Optional<Role> editor = roleService.findByName(TestRoles.EDITOR.getName());
@@ -88,10 +107,10 @@ class DefaultRoleServiceTest {
         }
 
         @Test
-        void findByName_shouldNotResolveInternalRoles() {
+        void shouldNotResolveInternalRoles() {
             // when.
-            Optional<Role> superAdmin = roleService.findByName("SUPER_ADMIN");
-            Optional<Role> managedService = roleService.findByName("MANAGED_SERVICE");
+            Optional<Role> superAdmin = roleService.findByName(SuperAdminUserAuthenticator.SUPER_ADMIN_ROLE_NAME);
+            Optional<Role> managedService = roleService.findByName(DefaultRole.MANAGED_SERVICE.getName());
 
             // then.
             assertThat(superAdmin).isEmpty();
@@ -99,7 +118,7 @@ class DefaultRoleServiceTest {
         }
 
         @Test
-        void findByName_shouldReturnEmptyForAnUnknownRole() {
+        void shouldReturnEmptyForAnUnknownRole() {
             // when.
             Optional<Role> role = roleService.findByName("THERE_IS_NO_SUCH_ROLE");
 
@@ -111,16 +130,10 @@ class DefaultRoleServiceTest {
     @Nested
     class FindRolesOfUser {
 
-        @BeforeEach
-        @AfterEach
-        void cleanUsers() {
-            userRepository.findAll().forEach(user -> userService.deleteById(user.id()));
-        }
-
         @Test
-        void findRolesOfUser_shouldReturnTheSingleRoleGrantedToTheUser() {
+        void shouldReturnTheSingleRoleGrantedToTheUser() {
             // given.
-            String userId = createUserWithRoles("VIEWER");
+            String userId = createUserWithRoles(TestRoles.VIEWER.getName());
 
             // when.
             Set<Role> roles = roleService.findRolesOfUser(userId);
@@ -130,21 +143,23 @@ class DefaultRoleServiceTest {
         }
 
         @Test
-        void findRolesOfUser_shouldReturnEveryRoleWithItsAuthorities() {
+        void shouldReturnEveryRoleWithItsAuthorities() {
             // given.
-            String userId = createUserWithRoles("ADMIN", "EDITOR");
+            String userId = createUserWithRoles(TestRoles.ADMIN.getName(), TestRoles.EDITOR.getName());
 
             // when.
             Set<Role> roles = roleService.findRolesOfUser(userId);
 
             // then.
             assertThat(roles).hasSize(2);
-            assertThat(roleNamed(roles, "ADMIN")).satisfies(role -> assertGrantsSameAs(role, TestRoles.ADMIN));
-            assertThat(roleNamed(roles, "EDITOR")).satisfies(role -> assertGrantsSameAs(role, TestRoles.EDITOR));
+            assertThat(roleNamed(roles, TestRoles.ADMIN.getName()))
+                    .satisfies(role -> assertGrantsSameAs(role, TestRoles.ADMIN));
+            assertThat(roleNamed(roles, TestRoles.EDITOR.getName()))
+                    .satisfies(role -> assertGrantsSameAs(role, TestRoles.EDITOR));
         }
 
         @Test
-        void findRolesOfUser_shouldReturnEmptyForAUserWithoutAnyRoles() {
+        void shouldReturnEmptyForAUserWithoutAnyRoles() {
             // when.
             Set<Role> roles = roleService.findRolesOfUser("there-is-no-such-user");
 
@@ -170,34 +185,14 @@ class DefaultRoleServiceTest {
         }
     }
 
-    /**
-     * The bonds of {@code roles_parents} are resolved into the components of the role, which is what makes an
-     * inherited authority reach the checks. The built-in roles carry no bonds, so nothing else in this class covers
-     * it.
-     */
     @Nested
     class Inheritance {
-
-        @BeforeEach
-        @AfterEach
-        void cleanCustomRoles() {
-            userRepository.findAll().forEach(user -> userService.deleteById(user.id()));
-            jdbcClient.sql("DELETE FROM roles_parents").update();
-            jdbcClient
-                    .sql("DELETE FROM roles_authorities WHERE role_id IN (SELECT id FROM roles WHERE role_origin <> ?)")
-                    .param(RoleOrigin.BUILT_IN.name())
-                    .update();
-            jdbcClient
-                    .sql("DELETE FROM roles WHERE role_origin <> ?")
-                    .param(RoleOrigin.BUILT_IN.name())
-                    .update();
-        }
 
         @Test
         void shouldExposeTheRoleItDerivesFromAsAComponent() {
             // given.
-            String parentId = customRole("PARENT", OssAuthority.CACHES_CLEAR);
-            String childId = customRole("CHILD", OssAuthority.GARBAGE_COLLECTOR);
+            String parentId = createCustomRole("PARENT", OssAuthority.CACHES_CLEAR);
+            String childId = createCustomRole("CHILD", OssAuthority.GARBAGE_COLLECTOR);
             createBond(childId, parentId);
 
             // when.
@@ -218,9 +213,9 @@ class DefaultRoleServiceTest {
         @Test
         void shouldResolveTheBondsTransitively() {
             // given. C derives from B, B derives from A
-            String grandParent = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
-            String parent = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
-            String child = customRole("ROLE C", OssAuthority.GARBAGE_COLLECTOR);
+            String grandParent = createCustomRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            String parent = createCustomRole("ROLE B", OssAuthority.CACHES_CLEAR);
+            String child = createCustomRole("ROLE C", OssAuthority.GARBAGE_COLLECTOR);
             createBond(parent, grandParent);
             createBond(child, parent);
 
@@ -239,10 +234,10 @@ class DefaultRoleServiceTest {
         @Test
         void shouldUnionTheAuthoritiesReachedThroughSeveralChains() {
             // given. A diamond: the top role is reached through both branches
-            String top = customRole("TOP", OssAuthority.ENV_VALUES_READ);
-            String left = customRole("LEFT", OssAuthority.CACHES_CLEAR);
-            String right = customRole("RIGHT", OssAuthority.CACHES_TOGGLE);
-            String bottom = customRole("BOTTOM", OssAuthority.GARBAGE_COLLECTOR);
+            String top = createCustomRole("TOP", OssAuthority.ENV_VALUES_READ);
+            String left = createCustomRole("LEFT", OssAuthority.CACHES_CLEAR);
+            String right = createCustomRole("RIGHT", OssAuthority.CACHES_TOGGLE);
+            String bottom = createCustomRole("BOTTOM", OssAuthority.GARBAGE_COLLECTOR);
             createBond(left, top);
             createBond(right, top);
             createBond(bottom, left);
@@ -264,8 +259,8 @@ class DefaultRoleServiceTest {
         @Test
         void shouldResolveTheBondsOfEveryRoleTheUserHolds() {
             // given.
-            String parentId = customRole("PARENT", OssAuthority.CACHES_CLEAR);
-            String childId = customRole("CHILD", OssAuthority.GARBAGE_COLLECTOR);
+            String parentId = createCustomRole("PARENT", OssAuthority.CACHES_CLEAR);
+            String childId = createCustomRole("CHILD", OssAuthority.GARBAGE_COLLECTOR);
             createBond(childId, parentId);
 
             userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "CHILD");
@@ -284,120 +279,153 @@ class DefaultRoleServiceTest {
         }
     }
 
-    /**
-     * Dedicated nested class that covers the case when roles DAG for any reason creates a cycle. If the role is created by
-     * any standard means that cannot/should not happen, but in any case, we may have a bug, or somebody may alter the state
-     * of the database directly so we have to cover that as well.
-     */
     @Nested
-    class Cycles {
+    class GetRolesFeed {
 
-        @BeforeEach
-        @AfterEach
-        void cleanCustomRoles() {
-            userRepository.findAll().forEach(user -> userService.deleteById(user.id()));
-            jdbcClient.sql("DELETE FROM roles_parents").update();
-            jdbcClient
-                    .sql("DELETE FROM roles_authorities WHERE role_id IN (SELECT id FROM roles WHERE role_origin <> ?)")
-                    .param(RoleOrigin.BUILT_IN.name())
-                    .update();
-            jdbcClient
-                    .sql("DELETE FROM roles WHERE role_origin <> ?")
-                    .param(RoleOrigin.BUILT_IN.name())
-                    .update();
+        @Test
+        void shouldSeedTheSameThreeBuiltInRolesInEveryDialect() {
+            // when.
+            List<RoleFeed> feed = roleService.getRolesFeed();
+
+            // then.
+            assertThat(feed)
+                    .extracting(RoleFeed::id, RoleFeed::name, RoleFeed::description)
+                    .containsExactlyInAnyOrder(
+                            tuple(
+                                    "00000000-0000-0000-0000-0000000000b1",
+                                    TestRoles.VIEWER.getName(),
+                                    "Read-only access to the monitored applications."),
+                            tuple(
+                                    "00000000-0000-0000-0000-0000000000b2",
+                                    TestRoles.EDITOR.getName(),
+                                    "Performs runtime operations on the monitored applications, including destructive"
+                                            + " ones such as clearing caches."),
+                            tuple(
+                                    "00000000-0000-0000-0000-0000000000b3",
+                                    TestRoles.ADMIN.getName(),
+                                    "Everything an editor can do, plus reading sensitive configuration values."));
         }
 
         @Test
+        void shouldCountTheUsersEachRoleIsAssignedTo() {
+            // given.
+            userService.createLocal(
+                    "alice", null, null, "alice@example.com", null, null, "p", TestRoles.EDITOR.getName());
+            userService.createLocal("bob", null, null, "bob@example.com", null, null, "p", TestRoles.EDITOR.getName());
+            userService.createLocal(
+                    "carol", null, null, "carol@example.com", null, null, "p", TestRoles.VIEWER.getName());
+
+            // when.
+            List<RoleFeed> feed = roleService.getRolesFeed();
+
+            // then.
+            assertThat(entryNamed(feed, TestRoles.EDITOR.getName()).membersCount())
+                    .isEqualTo(2);
+            assertThat(entryNamed(feed, TestRoles.VIEWER.getName()).membersCount())
+                    .isEqualTo(1);
+            assertThat(entryNamed(feed, TestRoles.ADMIN.getName()).membersCount())
+                    .isZero();
+        }
+
+        @Test
+        void shouldReturnACustomRoleWithItsOwnIdAndDescription() {
+            // given.
+            String derivedId = createCustomRole("DERIVED", OssAuthority.ENV_VALUES_READ);
+
+            // when.
+            List<RoleFeed> feed = roleService.getRolesFeed();
+
+            // then.
+            RoleFeed derived = entryNamed(feed, "DERIVED");
+            assertThat(derived.id()).isEqualTo(derivedId);
+            assertThat(derived.description()).isEqualTo("Description");
+            assertThat(derived.membersCount()).isZero();
+        }
+
+        private static RoleFeed entryNamed(List<RoleFeed> feed, String name) {
+            return feed.stream()
+                    .filter(role -> role.name().equals(name))
+                    .findFirst()
+                    .orElseThrow();
+        }
+    }
+
+    @Nested
+    class Cycles {
+
+        @Test
         void shouldTerminateOnABondCycleWrittenAroundTheApplication() {
-            // given. Neither lane can write this, but a hand-written row could - and the resolution runs on the
-            // login path, so looping here would leave nobody able to log in
-            String roleA = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
-            String roleB = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
+            // given.
+            String roleA = createCustomRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            String roleB = createCustomRole("ROLE B", OssAuthority.CACHES_CLEAR);
             createBond(roleA, roleB);
             createBond(roleB, roleA);
 
-            // when.
-            ThrowableAssert.ThrowingCallable callable = () -> roleService.findByName("ROLE A");
-
-            // then.
-            assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+            // when & then.
+            assertThatThrownBy(() -> roleService.findByName("ROLE A")).isInstanceOf(IllegalStateException.class);
         }
 
         @Test
         void shouldTerminateOnARoleThatDerivesFromItself() {
-            // given. A self-loop is the shortest cycle a hand-written row can introduce
-            String role = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            // given.
+            String role = createCustomRole("ROLE A", OssAuthority.ENV_VALUES_READ);
             createBond(role, role);
 
-            // when.
-            ThrowableAssert.ThrowingCallable callable = () -> roleService.findByName("ROLE A");
-
-            // then.
-            assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+            // when & then.
+            assertThatThrownBy(() -> roleService.findByName("ROLE A")).isInstanceOf(IllegalStateException.class);
         }
 
         @Test
         void shouldTerminateOnACycleSpanningThreeRoles() {
             // given. A --> B --> C --> A
-            String roleA = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
-            String roleB = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
-            String roleC = customRole("ROLE C", OssAuthority.CACHES_TOGGLE);
+            String roleA = createCustomRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            String roleB = createCustomRole("ROLE B", OssAuthority.CACHES_CLEAR);
+            String roleC = createCustomRole("ROLE C", OssAuthority.CACHES_TOGGLE);
             createBond(roleA, roleB);
             createBond(roleB, roleC);
             createBond(roleC, roleA);
 
-            // when.
-            ThrowableAssert.ThrowingCallable callable = () -> roleService.findByName("ROLE A");
-
-            // then. The message spells out the offending chain to make the hand-written row diagnosable
-            assertThatThrownBy(callable)
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("ROLE A --> ROLE B --> ROLE C --> ROLE A");
+            // when & then.
+            assertThatThrownBy(() -> roleService.findByName("ROLE A")).isInstanceOf(IllegalStateException.class);
         }
 
         @Test
         void shouldTerminateWhenTheCycleSitsAboveTheQueriedRole() {
-            // given. The queried role is itself acyclic, but its ancestry loops: LEAF --> A --> B --> A
-            String leaf = customRole("LEAF", OssAuthority.GARBAGE_COLLECTOR);
-            String roleA = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
-            String roleB = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
+            // given.
+            String leaf = createCustomRole("LEAF", OssAuthority.GARBAGE_COLLECTOR);
+            String roleA = createCustomRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            String roleB = createCustomRole("ROLE B", OssAuthority.CACHES_CLEAR);
             createBond(leaf, roleA);
             createBond(roleA, roleB);
             createBond(roleB, roleA);
 
-            // when.
-            ThrowableAssert.ThrowingCallable callable = () -> roleService.findByName("LEAF");
-
-            // then.
-            assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+            // when & then.
+            assertThatThrownBy(() -> roleService.findByName("LEAF")).isInstanceOf(IllegalStateException.class);
         }
 
         @Test
         void shouldTerminateWhenResolvingTheRolesOfAUserCaughtInACycle() {
-            // given. The cycle is reached through the other resolution entry point - the login path
-            String roleA = customRole("ROLE A", OssAuthority.ENV_VALUES_READ);
-            String roleB = customRole("ROLE B", OssAuthority.CACHES_CLEAR);
+            // given.
+            String roleA = createCustomRole("ROLE A", OssAuthority.ENV_VALUES_READ);
+            String roleB = createCustomRole("ROLE B", OssAuthority.CACHES_CLEAR);
             createBond(roleA, roleB);
             createBond(roleB, roleA);
 
             userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "ROLE A");
             String userId = userRepository.findByUsername("alice").orElseThrow().id();
 
-            // when.
-            ThrowableAssert.ThrowingCallable callable = () -> roleService.findRolesOfUser(userId);
-
-            // then.
-            assertThatThrownBy(callable).isInstanceOf(IllegalStateException.class);
+            // when & then.
+            assertThatThrownBy(() -> roleService.findRolesOfUser(userId)).isInstanceOf(IllegalStateException.class);
         }
 
         @Test
         void shouldNotReportACycleForADiamondSharedAncestor() {
             // given. A diamond reaches the same ancestor through two branches - that is a DAG, not a cycle, and the
             // colouring must not mistake the second visit for a back-edge
-            String top = customRole("TOP", OssAuthority.ENV_VALUES_READ);
-            String left = customRole("LEFT", OssAuthority.CACHES_CLEAR);
-            String right = customRole("RIGHT", OssAuthority.CACHES_TOGGLE);
-            String bottom = customRole("BOTTOM", OssAuthority.GARBAGE_COLLECTOR);
+            String top = createCustomRole("TOP", OssAuthority.ENV_VALUES_READ);
+            String left = createCustomRole("LEFT", OssAuthority.CACHES_CLEAR);
+            String right = createCustomRole("RIGHT", OssAuthority.CACHES_TOGGLE);
+            String bottom = createCustomRole("BOTTOM", OssAuthority.GARBAGE_COLLECTOR);
             createBond(left, top);
             createBond(right, top);
             createBond(bottom, left);
@@ -417,10 +445,17 @@ class DefaultRoleServiceTest {
         }
     }
 
-    private String customRole(String name, OssAuthority authority) {
+    private String createCustomRole(String name) {
         String id = UUID.randomUUID().toString();
 
         jdbcAggregateTemplate.insert(new RoleEntity(id, name, "Description", RoleOrigin.WEB_UI));
+
+        return id;
+    }
+
+    private String createCustomRole(String name, OssAuthority authority) {
+        String id = createCustomRole(name);
+
         jdbcClient
                 .sql("INSERT INTO roles_authorities (role_id, authority_id)"
                         + " SELECT ?, id FROM authorities WHERE name = ?")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a protected roles feed endpoint at `/api/external/roles/feed`.
  * Role entries include an identifier, name, description, and number of assigned members.
  * Access requires permission to view users.
  * Member counts default to zero when no users are assigned.

* **Tests**
  * Added coverage for the roles feed endpoint and service behavior, including built-in roles, membership counts, inheritance, and role relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->