### PR TITLE
GH-1570 Assign roles by role ID when creating a user

### DIFF
--- a/master-e2e-tests/src/test/java/com/axelixlabs/axelix/e2e/auth/LocalAuthE2ETest.java
+++ b/master-e2e-tests/src/test/java/com/axelixlabs/axelix/e2e/auth/LocalAuthE2ETest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import com.axelixlabs.axelix.e2e.client.AxelixMasterApiClient;
 import com.axelixlabs.axelix.e2e.config.E2ETestConfig;
 
+import static com.axelixlabs.axelix.e2e.utils.UserUtils.EDITOR_ROLE_ID;
 import static com.axelixlabs.axelix.e2e.utils.UserUtils.PASSWORD;
 import static com.axelixlabs.axelix.e2e.utils.UserUtils.generateUniqueEmail;
 import static com.axelixlabs.axelix.e2e.utils.UserUtils.generateUniqueUsername;
@@ -50,7 +51,7 @@ public class LocalAuthE2ETest {
     void shouldLoginLocalUser() {
         // given when.
         String username = generateUniqueUsername();
-        client.registerLocalUser(username, generateUniqueEmail(), PASSWORD, "EDITOR");
+        client.registerLocalUser(username, generateUniqueEmail(), PASSWORD, EDITOR_ROLE_ID);
 
         // logout as super-admin
         client.logout();
@@ -63,7 +64,7 @@ public class LocalAuthE2ETest {
     void shouldPreventSuspendedUserFromLoggingIn() {
         // given.
         String username = generateUniqueUsername();
-        client.registerLocalUser(username, generateUniqueEmail(), PASSWORD, "EDITOR");
+        client.registerLocalUser(username, generateUniqueEmail(), PASSWORD, EDITOR_ROLE_ID);
         String userId = client.getUserId(username);
 
         // when.

--- a/master-e2e-tests/src/test/java/com/axelixlabs/axelix/e2e/client/AxelixMasterApiClient.java
+++ b/master-e2e-tests/src/test/java/com/axelixlabs/axelix/e2e/client/AxelixMasterApiClient.java
@@ -78,13 +78,13 @@ public class AxelixMasterApiClient {
         requestSpec().post(EXTERNAL_API_BASE_PATH + "/users/logout");
     }
 
-    public void registerLocalUser(String username, @Nullable String email, String password, String role) {
+    public void registerLocalUser(String username, @Nullable String email, String password, String roleId) {
         // Using a Map instead of text blocks because the email can be null.
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("username", username);
         body.put("email", email);
         body.put("password", password);
-        body.put("role", role);
+        body.put("roleIds", Set.of(roleId));
 
         requestSpec()
                 .body(body)

--- a/master-e2e-tests/src/test/java/com/axelixlabs/axelix/e2e/mcp/McpLoginAuthLocalE2ETest.java
+++ b/master-e2e-tests/src/test/java/com/axelixlabs/axelix/e2e/mcp/McpLoginAuthLocalE2ETest.java
@@ -24,6 +24,7 @@ import com.axelixlabs.axelix.e2e.client.AxelixMasterApiClient;
 import com.axelixlabs.axelix.e2e.client.McpClient;
 import com.axelixlabs.axelix.e2e.config.E2ETestConfig;
 
+import static com.axelixlabs.axelix.e2e.utils.UserUtils.EDITOR_ROLE_ID;
 import static com.axelixlabs.axelix.e2e.utils.UserUtils.PASSWORD;
 import static com.axelixlabs.axelix.e2e.utils.UserUtils.generateUniqueUsername;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -52,7 +53,7 @@ public class McpLoginAuthLocalE2ETest {
     void shouldLoginLocalUser() {
         // given.
         String username = generateUniqueUsername();
-        client.registerLocalUser(username, null, PASSWORD, "EDITOR");
+        client.registerLocalUser(username, null, PASSWORD, EDITOR_ROLE_ID);
 
         // when.
         McpClient mcpClient = new McpClient(E2ETestConfig.masterBaseUrl(), username, PASSWORD);

--- a/master-e2e-tests/src/test/java/com/axelixlabs/axelix/e2e/utils/UserUtils.java
+++ b/master-e2e-tests/src/test/java/com/axelixlabs/axelix/e2e/utils/UserUtils.java
@@ -28,6 +28,9 @@ public class UserUtils {
 
     public static final String PASSWORD = "password";
 
+    // TODO: Pending issue GH-1559 – take the role id from the roles feed
+    public static final String EDITOR_ROLE_ID = "00000000-0000-0000-0000-0000000000b2";
+
     public static String generateUniqueUsername() {
         return "user-" + UUID.randomUUID();
     }

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApi.java
@@ -68,7 +68,7 @@ public class UserManagementApi {
                     request.jobTitle(),
                     request.organizationalUnit(),
                     request.password(),
-                    request.role());
+                    request.roleIds());
             return ResponseEntity.status(HttpStatus.CREATED).build();
 
         } catch (UserInvalidValueException

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/request/user/UserCreateRequest.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/request/user/UserCreateRequest.java
@@ -17,6 +17,8 @@
  */
 package com.axelixlabs.axelix.master.api.external.request.user;
 
+import java.util.Set;
+
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -29,7 +31,7 @@ import org.jspecify.annotations.Nullable;
  * @param jobTitle   The user's job title, which may be {@code null}.
  * @param organizationalUnit The user's organizational unit, which may be {@code null}.
  * @param password   Plain-text password.
- * @param role       Name of the role to grant to the user.
+ * @param roleIds    Ids of the roles to grant to the user.
  *
  * @author Sergey Cherkasov
  * @author Mikhail Polivakha
@@ -42,12 +44,12 @@ public record UserCreateRequest(
         @Nullable String jobTitle,
         @Nullable String organizationalUnit,
         String password,
-        String role) {
+        Set<String> roleIds) {
 
     @Override
     public String toString() {
         return "UserCreateRequest[username=[%s], firstName=[REDACTED], lastName=[REDACTED],"
                 + " email=[REDACTED], jobTitle=[REDACTED], organizationalUnit=[REDACTED],"
-                + " password=[REDACTED], role=%s]".formatted(username, role);
+                + " password=[REDACTED], roleIds=%s]".formatted(username, roleIds);
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UserRoleNotFoundException.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UserRoleNotFoundException.java
@@ -22,7 +22,7 @@ import org.jspecify.annotations.Nullable;
 import com.axelixlabs.axelix.common.auth.core.Role;
 
 /**
- * Thrown if the role name is not found in the Axelix system {@link Role}.
+ * Thrown if the role is not found.
  *
  * @see Role
  * @author Sergey Cherkasov

--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/RoleRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/RoleRepository.java
@@ -18,6 +18,7 @@
 package com.axelixlabs.axelix.master.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.jspecify.annotations.Nullable;
 
@@ -47,6 +48,9 @@ public interface RoleRepository extends ListCrudRepository<RoleEntity, String> {
 
     @Query("SELECT role_id FROM users_roles WHERE user_id = :userId")
     List<String> findRoleIdsOfUser(@Param("userId") String userId);
+
+    @Query("SELECT id FROM roles WHERE name = :roleName")
+    Optional<String> findIdByName(@Param("roleName") String roleName);
 
     record RoleWithAuthorityName(
             String roleId, String roleName, @Nullable String authorityName) {}

--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/UserRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/UserRepository.java
@@ -58,6 +58,10 @@ public interface UserRepository extends ListCrudRepository<UserEntity, String> {
     int attachRole(@Param("userId") String userId, @Param("roleName") String roleName);
 
     @Modifying
+    @Query("INSERT INTO users_roles (user_id, role_id) SELECT :userId, r.id FROM roles r WHERE r.id = :roleId")
+    int attachRoleById(@Param("userId") String userId, @Param("roleId") String roleId);
+
+    @Modifying
     @Query("DELETE FROM users_roles WHERE user_id = :userId")
     void deleteUserRolesMappings(@Param("userId") String userId);
 

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DatabaseUserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DatabaseUserService.java
@@ -18,7 +18,6 @@
 package com.axelixlabs.axelix.master.service.state.auth;
 
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -84,7 +83,7 @@ public class DatabaseUserService implements UserService {
             @Nullable String jobTitle,
             @Nullable String organizationalUnit,
             String password,
-            String role)
+            Set<String> roleIds)
             throws UserRoleNotFoundException, UserInvalidValueException {
 
         UserEntity userEntity = new UserEntity(
@@ -113,7 +112,7 @@ public class DatabaseUserService implements UserService {
         }
 
         jdbcAggregateTemplate.insert(userEntity);
-        grantRoles(userEntity.id(), Collections.singleton(role));
+        grantRolesByIds(userEntity.id(), roleIds);
     }
 
     @Override
@@ -258,6 +257,25 @@ public class DatabaseUserService implements UserService {
 
         userRepository.deleteUserRolesMappings(id);
         grantRoles(id, roles);
+    }
+
+    private void grantRolesByIds(String userId, @Nullable Set<String> roleIds) {
+        if (roleIds == null || roleIds.isEmpty()) {
+            throw new UserInvalidValueException(null);
+        }
+
+        roleIds.forEach(roleId -> {
+            if (roleId == null) {
+                throw new UserInvalidValueException(null);
+            }
+
+            String normalizedRoleId = requireNonBlankTrimmed(roleId);
+            int rowsAffected = userRepository.attachRoleById(userId, normalizedRoleId);
+
+            if (rowsAffected != 1) {
+                throw new UserRoleNotFoundException(normalizedRoleId);
+            }
+        });
     }
 
     // TODO: Right now this is acceptable (i.e. a non-bulk INSERT) but in the future that may need optimization

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/UserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/UserService.java
@@ -59,9 +59,9 @@ public interface UserService {
      * @param jobTitle Job title of the new user, or {@code null} if not provided.
      * @param organizationalUnit Organizational unit of the new user, or {@code null} if not provided.
      * @param password Plain-text password (must be hashed server-side before persistence).
-     * @param role     Role name to assign to the new user. Must not be blank or {@code null}.
+     * @param roleIds  Ids of the roles to assign to the new user. Must not be empty or contain blanks.
      *
-     * @throws UserRoleNotFoundException if the provided role does not exist in the service.
+     * @throws UserRoleNotFoundException if any of the provided role ids does not exist in the service.
      * @throws UserInvalidValueException if any of the provided string fields is blank.
      * @throws UsernameAlreadyExistsException if a user with the given username already exists.
      * @throws EmailAlreadyExistsException if a user with the given email already exists.
@@ -74,7 +74,7 @@ public interface UserService {
             @Nullable String jobTitle,
             @Nullable String organizationalUnit,
             String password,
-            String role);
+            Set<String> roleIds);
 
     /**
      * Creates a new {@link UserOrigin#OIDC} user.

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserApiTest.java
@@ -39,6 +39,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import com.axelixlabs.axelix.common.auth.core.PasswordlessUser;
 import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
+import com.axelixlabs.axelix.common.testfixtures.TestRoles;
 import com.axelixlabs.axelix.common.testfixtures.UserUtils;
 import com.axelixlabs.axelix.master.api.external.request.LoginRequest;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.properties.CookieProperties;
@@ -170,7 +171,7 @@ class UserApiTest extends AbstractProtectedEndpointTest {
                 null,
                 null,
                 password,
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity user = userRepository.findByUsername(username).orElseThrow();
 
         LoginRequest loginRequest = new LoginRequest(username, password);
@@ -198,7 +199,7 @@ class UserApiTest extends AbstractProtectedEndpointTest {
                 null,
                 null,
                 "db-password",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
 
         LoginRequest loginRequest = new LoginRequest("db-user", "wrong-password");
 
@@ -223,7 +224,7 @@ class UserApiTest extends AbstractProtectedEndpointTest {
                 null,
                 null,
                 "db-password",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity user = userRepository.findByUsername("db-user").orElseThrow();
         userService.updateStatus(user.id(), UserStatus.SUSPENDED);
         LoginRequest loginRequest = new LoginRequest("db-user", "db-password");
@@ -256,7 +257,7 @@ class UserApiTest extends AbstractProtectedEndpointTest {
                 null,
                 null,
                 password,
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity user = userRepository.findByUsername(username).orElseThrow();
         userService.updateStatus(user.id(), UserStatus.SUSPENDED);
         userService.updateStatus(user.id(), UserStatus.ACTIVE);
@@ -330,7 +331,7 @@ class UserApiTest extends AbstractProtectedEndpointTest {
                 null,
                 null,
                 "aliceSecret",
-                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.ADMIN.getName()).orElseThrow()));
         UserEntity alice = userRepository.findByUsername("alice").orElseThrow();
 
         userService.createFromOidc("bob", "Bob", null, "bob@example.com", null, null, "hash-bob", "VIEWER");
@@ -391,7 +392,7 @@ class UserApiTest extends AbstractProtectedEndpointTest {
                 "Engineering Manager",
                 "Engineering",
                 "aliceSecret",
-                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.ADMIN.getName()).orElseThrow()));
         UserEntity alice = userRepository.findByUsername("alice").orElseThrow();
         userService.updateStatus(alice.id(), UserStatus.SUSPENDED);
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserApiTest.java
@@ -39,13 +39,13 @@ import org.springframework.test.context.TestPropertySource;
 
 import com.axelixlabs.axelix.common.auth.core.PasswordlessUser;
 import com.axelixlabs.axelix.common.auth.service.JwtEncoderService;
-import com.axelixlabs.axelix.common.testfixtures.TestRoles;
 import com.axelixlabs.axelix.common.testfixtures.UserUtils;
 import com.axelixlabs.axelix.master.api.external.request.LoginRequest;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.properties.CookieProperties;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.properties.JwtProperties;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserStatus;
+import com.axelixlabs.axelix.master.repository.RoleRepository;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.service.auth.MasterWebEndpoints;
 import com.axelixlabs.axelix.master.service.state.auth.UserService;
@@ -95,6 +95,9 @@ class UserApiTest extends AbstractProtectedEndpointTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
 
     @Autowired
     private UserService userService;
@@ -159,7 +162,15 @@ class UserApiTest extends AbstractProtectedEndpointTest {
         String username = "db-user";
         String password = "db-password";
 
-        userService.createLocal(username, null, null, "db-user@example.com", null, null, password, "VIEWER");
+        userService.createLocal(
+                username,
+                null,
+                null,
+                "db-user@example.com",
+                null,
+                null,
+                password,
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity user = userRepository.findByUsername(username).orElseThrow();
 
         LoginRequest loginRequest = new LoginRequest(username, password);
@@ -180,7 +191,14 @@ class UserApiTest extends AbstractProtectedEndpointTest {
     @Test
     void shouldNotAuthenticateUserFromDatabaseWithInvalidCredentials() {
         userService.createLocal(
-                "db-user", null, null, "db-user@example.com", null, null, "db-password", TestRoles.VIEWER.getName());
+                "db-user",
+                null,
+                null,
+                "db-user@example.com",
+                null,
+                null,
+                "db-password",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
         LoginRequest loginRequest = new LoginRequest("db-user", "wrong-password");
 
@@ -197,7 +215,15 @@ class UserApiTest extends AbstractProtectedEndpointTest {
     @Test
     void shouldReturnForbiddenForSuspendedDatabaseUser() {
         // given.
-        userService.createLocal("db-user", null, null, "db-user@example.com", null, null, "db-password", "VIEWER");
+        userService.createLocal(
+                "db-user",
+                null,
+                null,
+                "db-user@example.com",
+                null,
+                null,
+                "db-password",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity user = userRepository.findByUsername("db-user").orElseThrow();
         userService.updateStatus(user.id(), UserStatus.SUSPENDED);
         LoginRequest loginRequest = new LoginRequest("db-user", "db-password");
@@ -222,7 +248,15 @@ class UserApiTest extends AbstractProtectedEndpointTest {
         String password = "db-password";
 
         // and.
-        userService.createLocal(username, null, null, "db-user@example.com", null, null, password, "VIEWER");
+        userService.createLocal(
+                username,
+                null,
+                null,
+                "db-user@example.com",
+                null,
+                null,
+                password,
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity user = userRepository.findByUsername(username).orElseThrow();
         userService.updateStatus(user.id(), UserStatus.SUSPENDED);
         userService.updateStatus(user.id(), UserStatus.ACTIVE);
@@ -288,7 +322,15 @@ class UserApiTest extends AbstractProtectedEndpointTest {
     @Test
     void shouldReturnAllManagedUsers() {
         // given.
-        userService.createLocal("alice", "Alice", "Smith", "alice@example.com", null, null, "aliceSecret", "ADMIN");
+        userService.createLocal(
+                "alice",
+                "Alice",
+                "Smith",
+                "alice@example.com",
+                null,
+                null,
+                "aliceSecret",
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
         UserEntity alice = userRepository.findByUsername("alice").orElseThrow();
 
         userService.createFromOidc("bob", "Bob", null, "bob@example.com", null, null, "hash-bob", "VIEWER");
@@ -349,7 +391,7 @@ class UserApiTest extends AbstractProtectedEndpointTest {
                 "Engineering Manager",
                 "Engineering",
                 "aliceSecret",
-                "ADMIN");
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
         UserEntity alice = userRepository.findByUsername("alice").orElseThrow();
         userService.updateStatus(alice.id(), UserStatus.SUSPENDED);
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
@@ -37,6 +37,7 @@ import org.springframework.test.context.TestPropertySource;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.domain.UserStatus;
+import com.axelixlabs.axelix.master.repository.RoleRepository;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.service.auth.MasterWebEndpoints;
 import com.axelixlabs.axelix.master.service.state.auth.UserService;
@@ -69,6 +70,9 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
     private UserRepository userRepository;
 
     @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
     private UserService userService;
 
     @Autowired
@@ -92,9 +96,9 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "jobTitle": "Software Engineer",
                   "organizationalUnit": "Engineering",
                   "password": "plainPassword",
-                  "role": "EDITOR"
+                  "roleIds": ["%s"]
                 }
-                """;
+                """.formatted(roleRepository.findIdByName("EDITOR").orElseThrow());
 
         // when.
         IdentityAwareTestRestTemplate superAdmin = restTemplate.asUsersFeedEditor();
@@ -138,9 +142,9 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "jobTitle": null,
                   "organizationalUnit": null,
                   "password": "plainPassword",
-                  "role": "EDITOR"
+                  "roleIds": ["%s"]
                 }
-                """;
+                """.formatted(roleRepository.findIdByName("EDITOR").orElseThrow());
 
         // when.
         IdentityAwareTestRestTemplate superAdmin = restTemplate.asUsersFeedEditor();
@@ -164,7 +168,7 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "username": "u",
                   "email": "u@example.com",
                   "password": "p",
-                  "role": null
+                  "roleIds": null
                 }
                 """;
 
@@ -186,7 +190,7 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "username": "u",
                   "email": "u@example.com",
                   "password": "p",
-                  "role": "   "
+                  "roleIds": ["   "]
                 }
                 """;
 
@@ -208,7 +212,7 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "username": "u",
                   "email": "u@example.com",
                   "password": "p",
-                  "role": "  super_admin  "
+                  "roleIds": ["  super_admin  "]
                 }
                 """;
 
@@ -230,7 +234,7 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "username": "u",
                   "email": "u@example.com",
                   "password": "p",
-                  "role": "NOT_A_REAL_ROLE"
+                  "roleIds": ["NOT_A_REAL_ROLE"]
                 }
                 """;
 
@@ -245,6 +249,68 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
     }
 
     @Test
+    void shouldCreateUserWithSeveralRoleIds() {
+        // given.
+        // language=json
+        String request = """
+                {
+                  "username": "newUser",
+                  "email": "newUser@example.com",
+                  "password": "plainPassword",
+                  "roleIds": [
+                    "%s",
+                    "%s"
+                  ]
+                }
+                """.formatted(
+                        roleRepository.findIdByName("VIEWER").orElseThrow(),
+                        roleRepository.findIdByName("EDITOR").orElseThrow());
+
+        // when.
+        IdentityAwareTestRestTemplate superAdmin = restTemplate.asUsersFeedEditor();
+
+        ResponseEntity<Void> response =
+                superAdmin.exchange(USERS_CREATE_PATH, HttpMethod.POST, defaultEntity(request), Void.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        UserEntity saved = userRepository.findByUsername("newUser").orElseThrow();
+        assertThat(userService.findRoleNamesByUserId(saved.id())).containsExactlyInAnyOrder("VIEWER", "EDITOR");
+        assertSuccessfulCallback(MasterWebEndpoints.USER_CREATE, superAdmin.getActor());
+    }
+
+    @Test
+    void shouldGrantTheRoleOnce_WhenCreateRequest_RepeatsTheSameRoleId() {
+        // given.
+        // language=json
+        String request = """
+                {
+                  "username": "newUser",
+                  "email": "newUser@example.com",
+                  "password": "plainPassword",
+                  "roleIds": [
+                    "%s",
+                    "%s"
+                  ]
+                }
+                """.formatted(
+                        roleRepository.findIdByName("EDITOR").orElseThrow(),
+                        roleRepository.findIdByName("EDITOR").orElseThrow());
+
+        // when.
+        ResponseEntity<Void> response = restTemplate
+                .asUsersFeedEditor()
+                .exchange(USERS_CREATE_PATH, HttpMethod.POST, defaultEntity(request), Void.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+
+        UserEntity saved = userRepository.findByUsername("newUser").orElseThrow();
+        assertThat(userService.findRoleNamesByUserId(saved.id())).containsExactly("EDITOR");
+    }
+
+    @Test
     void shouldReturnBadRequest_WhenCreateRequest_UsernameIsDuplicate() {
         createUser("existingUser", "existing@example.com", "p");
 
@@ -254,9 +320,9 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "username": "existingUser",
                   "email": "other@example.com",
                   "password": "p",
-                  "role": "VIEWER"
+                  "roleIds": ["%s"]
                 }
-                """;
+                """.formatted(roleRepository.findIdByName("VIEWER").orElseThrow());
 
         // when.
         ResponseEntity<String> response = restTemplate
@@ -279,9 +345,9 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "username": "existingUser",
                   "email": "user_test@example.com",
                   "password": "p",
-                  "role": "VIEWER"
+                  "roleIds": ["%s"]
                 }
-                """;
+                """.formatted(roleRepository.findIdByName("VIEWER").orElseThrow());
 
         // when.
         ResponseEntity<String> response = restTemplate
@@ -691,7 +757,15 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
     }
 
     private UserEntity createUser(String username, String email, String password) {
-        userService.createLocal(username, null, null, email, null, null, password, "VIEWER");
+        userService.createLocal(
+                username,
+                null,
+                null,
+                email,
+                null,
+                null,
+                password,
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         return userRepository.findByUsername(username).orElseThrow();
     }
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
@@ -34,6 +34,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.TestPropertySource;
 
+import com.axelixlabs.axelix.common.testfixtures.TestRoles;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.domain.UserStatus;
@@ -98,7 +99,8 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "password": "plainPassword",
                   "roleIds": ["%s"]
                 }
-                """.formatted(roleRepository.findIdByName("EDITOR").orElseThrow());
+                """.formatted(
+                        roleRepository.findIdByName(TestRoles.EDITOR.getName()).orElseThrow());
 
         // when.
         IdentityAwareTestRestTemplate superAdmin = restTemplate.asUsersFeedEditor();
@@ -144,7 +146,8 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "password": "plainPassword",
                   "roleIds": ["%s"]
                 }
-                """.formatted(roleRepository.findIdByName("EDITOR").orElseThrow());
+                """.formatted(
+                        roleRepository.findIdByName(TestRoles.EDITOR.getName()).orElseThrow());
 
         // when.
         IdentityAwareTestRestTemplate superAdmin = restTemplate.asUsersFeedEditor();
@@ -263,8 +266,8 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   ]
                 }
                 """.formatted(
-                        roleRepository.findIdByName("VIEWER").orElseThrow(),
-                        roleRepository.findIdByName("EDITOR").orElseThrow());
+                        roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow(),
+                        roleRepository.findIdByName(TestRoles.EDITOR.getName()).orElseThrow());
 
         // when.
         IdentityAwareTestRestTemplate superAdmin = restTemplate.asUsersFeedEditor();
@@ -295,8 +298,8 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   ]
                 }
                 """.formatted(
-                        roleRepository.findIdByName("EDITOR").orElseThrow(),
-                        roleRepository.findIdByName("EDITOR").orElseThrow());
+                        roleRepository.findIdByName(TestRoles.EDITOR.getName()).orElseThrow(),
+                        roleRepository.findIdByName(TestRoles.EDITOR.getName()).orElseThrow());
 
         // when.
         ResponseEntity<Void> response = restTemplate
@@ -322,7 +325,8 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "password": "p",
                   "roleIds": ["%s"]
                 }
-                """.formatted(roleRepository.findIdByName("VIEWER").orElseThrow());
+                """.formatted(
+                        roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow());
 
         // when.
         ResponseEntity<String> response = restTemplate
@@ -347,7 +351,8 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "password": "p",
                   "roleIds": ["%s"]
                 }
-                """.formatted(roleRepository.findIdByName("VIEWER").orElseThrow());
+                """.formatted(
+                        roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow());
 
         // when.
         ResponseEntity<String> response = restTemplate
@@ -765,7 +770,7 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                 null,
                 null,
                 password,
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         return userRepository.findByUsername(username).orElseThrow();
     }
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
@@ -55,6 +55,7 @@ import com.axelixlabs.axelix.master.domain.UserStatus;
 import com.axelixlabs.axelix.master.exception.auth.OAuth2AuthenticationException;
 import com.axelixlabs.axelix.master.exception.auth.OidcMetadataUnavailableException;
 import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
+import com.axelixlabs.axelix.master.repository.RoleRepository;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.service.auth.MasterWebEndpoints;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
@@ -118,6 +119,9 @@ class OAuth2CallbackControllerTest extends AbstractProtectedEndpointTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
 
     @Autowired
     private UserService userService;
@@ -322,7 +326,15 @@ class OAuth2CallbackControllerTest extends AbstractProtectedEndpointTest {
     void shouldReturn400WhenOidcUserConflictsWithExistingLocalAccount() {
         // given.
         String username = "test-user";
-        userService.createLocal(username, null, null, null, null, null, "test-password", "ADMIN");
+        userService.createLocal(
+                username,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "test-password",
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
 
         // and.
         String userInfoJson = "someJson";

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
@@ -334,7 +334,7 @@ class OAuth2CallbackControllerTest extends AbstractProtectedEndpointTest {
                 null,
                 null,
                 "test-password",
-                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.ADMIN.getName()).orElseThrow()));
 
         // and.
         String userInfoJson = "someJson";

--- a/master/src/test/java/com/axelixlabs/axelix/master/filter/auth/AbstractMcpAuthorizationFilterTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/filter/auth/AbstractMcpAuthorizationFilterTest.java
@@ -221,9 +221,6 @@ abstract class AbstractMcpAuthorizationFilterTest {
             String password = "test-password";
 
             userService.createLocal(
-                    username, null, null, "test-email@example.com", null, null, password, TestRoles.VIEWER.getName());
-            String userId =
-                    userService.findUserByUsername(username).orElseThrow().id();
                     username,
                     null,
                     null,
@@ -231,7 +228,11 @@ abstract class AbstractMcpAuthorizationFilterTest {
                     null,
                     null,
                     password,
-                    Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                    Set.of(roleRepository
+                            .findIdByName(TestRoles.VIEWER.getName())
+                            .orElseThrow()));
+            String userId =
+                    userService.findUserByUsername(username).orElseThrow().id();
 
             // and.
             registerInstanceForBeansTool(activeInstanceId);
@@ -295,7 +296,9 @@ abstract class AbstractMcpAuthorizationFilterTest {
                     null,
                     null,
                     password,
-                    Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                    Set.of(roleRepository
+                            .findIdByName(TestRoles.VIEWER.getName())
+                            .orElseThrow()));
 
             HttpHeaders headers = commonMcpHeaders();
             headers.set(HttpHeaders.AUTHORIZATION, "Basic " + basicCredentials(username, password));
@@ -323,7 +326,9 @@ abstract class AbstractMcpAuthorizationFilterTest {
                     null,
                     null,
                     password,
-                    Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                    Set.of(roleRepository
+                            .findIdByName(TestRoles.VIEWER.getName())
+                            .orElseThrow()));
 
             HttpHeaders headers = commonMcpHeaders();
             headers.set(HttpHeaders.AUTHORIZATION, "Basic " + basicCredentials(username, password));

--- a/master/src/test/java/com/axelixlabs/axelix/master/filter/auth/AbstractMcpAuthorizationFilterTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/filter/auth/AbstractMcpAuthorizationFilterTest.java
@@ -20,6 +20,7 @@ package com.axelixlabs.axelix.master.filter.auth;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -59,6 +60,7 @@ import com.axelixlabs.axelix.master.exception.auth.OidcTokenExchangeException;
 import com.axelixlabs.axelix.master.mcp.McpEndpoint;
 import com.axelixlabs.axelix.master.mcp.McpEndpoints;
 import com.axelixlabs.axelix.master.repository.InstanceRepository;
+import com.axelixlabs.axelix.master.repository.RoleRepository;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcSubjectHash;
@@ -108,6 +110,9 @@ abstract class AbstractMcpAuthorizationFilterTest {
 
     @Autowired
     protected UserRepository userRepository;
+
+    @Autowired
+    protected RoleRepository roleRepository;
 
     @Autowired
     protected McpServerStreamableHttpProperties mcpProperties;
@@ -219,6 +224,14 @@ abstract class AbstractMcpAuthorizationFilterTest {
                     username, null, null, "test-email@example.com", null, null, password, TestRoles.VIEWER.getName());
             String userId =
                     userService.findUserByUsername(username).orElseThrow().id();
+                    username,
+                    null,
+                    null,
+                    "test-email@example.com",
+                    null,
+                    null,
+                    password,
+                    Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
             // and.
             registerInstanceForBeansTool(activeInstanceId);
@@ -275,7 +288,14 @@ abstract class AbstractMcpAuthorizationFilterTest {
             String username = "viewer-user";
             String password = "viewer-password";
             userService.createLocal(
-                    username, null, null, username + "@example.com", null, null, password, TestRoles.VIEWER.getName());
+                    username,
+                    null,
+                    null,
+                    username + "@example.com",
+                    null,
+                    null,
+                    password,
+                    Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
             HttpHeaders headers = commonMcpHeaders();
             headers.set(HttpHeaders.AUTHORIZATION, "Basic " + basicCredentials(username, password));
@@ -296,7 +316,14 @@ abstract class AbstractMcpAuthorizationFilterTest {
             String username = "viewer-user";
             String password = "viewer-password";
             userService.createLocal(
-                    username, null, null, username + "@example.com", null, null, password, TestRoles.VIEWER.getName());
+                    username,
+                    null,
+                    null,
+                    username + "@example.com",
+                    null,
+                    null,
+                    password,
+                    Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
             HttpHeaders headers = commonMcpHeaders();
             headers.set(HttpHeaders.AUTHORIZATION, "Basic " + basicCredentials(username, password));

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
@@ -39,6 +39,7 @@ import com.axelixlabs.axelix.master.exception.auth.UserNotFoundException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 import com.axelixlabs.axelix.master.exception.auth.UserStatusChangeNotAllowedException;
 import com.axelixlabs.axelix.master.exception.auth.UsernameAlreadyExistsException;
+import com.axelixlabs.axelix.master.repository.RoleRepository;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.service.state.auth.DatabaseUserService;
 import com.axelixlabs.axelix.master.service.state.auth.UserService;
@@ -65,6 +66,9 @@ class DatabaseUserServiceTest {
     private UserRepository userRepository;
 
     @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
     private PasswordEncoder passwordEncoder;
 
     @Autowired
@@ -87,7 +91,7 @@ class DatabaseUserServiceTest {
                 " Software Engineer ",
                 " Platform ",
                 "plainPass",
-                "ADMIN");
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
 
         // then.
         List<UserEntity> users = userRepository.findAll();
@@ -148,17 +152,17 @@ class DatabaseUserServiceTest {
     void createLocal_shouldThrowWhenRoleIsNotAllowed() {
         // when.
         assertThatThrownBy(() -> userService.createLocal(
-                        "alice", null, null, "alice@example.com", null, null, "p", "SUPER_ADMIN"))
+                        "alice", null, null, "alice@example.com", null, null, "p", Set.of("SUPER_ADMIN")))
                 // then.
                 .isInstanceOf(UserRoleNotFoundException.class);
         assertThat(userRepository.findAll()).isEmpty();
     }
 
-    @Test // TODO: This test should be revisited since in enterprise we're going to be able to supply many roles
+    @Test
     void createLocal_shouldThrowWhenRoleDoesNotExist() {
         // when.
         assertThatThrownBy(() -> userService.createLocal(
-                        "alice", null, null, "alice@example.com", null, null, "p", "NOT_A_ROLE"))
+                        "alice", null, null, "alice@example.com", null, null, "p", Set.of("NOT_A_ROLE")))
                 // then.
                 .isInstanceOf(UserRoleNotFoundException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -167,8 +171,15 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldThrowWhenUsernameIsBlank() {
         // when.
-        assertThatThrownBy(() ->
-                        userService.createLocal("   ", null, null, "alice@example.com", null, null, "p", "VIEWER"))
+        assertThatThrownBy(() -> userService.createLocal(
+                        "   ",
+                        null,
+                        null,
+                        "alice@example.com",
+                        null,
+                        null,
+                        "p",
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -177,7 +188,15 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldThrowWhenEmailIsBlank() {
         // when.
-        assertThatThrownBy(() -> userService.createLocal("alice", null, null, "   ", null, null, "p", "VIEWER"))
+        assertThatThrownBy(() -> userService.createLocal(
+                        "alice",
+                        null,
+                        null,
+                        "   ",
+                        null,
+                        null,
+                        "p",
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -186,8 +205,15 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldThrowWhenPasswordIsBlank() {
         // when.
-        assertThatThrownBy(() ->
-                        userService.createLocal("alice", null, null, "alice@example.com", null, null, "   ", "VIEWER"))
+        assertThatThrownBy(() -> userService.createLocal(
+                        "alice",
+                        null,
+                        null,
+                        "alice@example.com",
+                        null,
+                        null,
+                        "   ",
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -196,8 +222,8 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldThrowWhenRoleIsBlank() {
         // when.
-        assertThatThrownBy(
-                        () -> userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "   "))
+        assertThatThrownBy(() -> userService.createLocal(
+                        "alice", null, null, "alice@example.com", null, null, "p", Set.of("   ")))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -206,11 +232,26 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldThrowWhenUsernameAlreadyExists() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
         // when.
-        assertThatThrownBy(() ->
-                        userService.createLocal("alice", null, null, "other@example.com", null, null, "p", "VIEWER"))
+        assertThatThrownBy(() -> userService.createLocal(
+                        "alice",
+                        null,
+                        null,
+                        "other@example.com",
+                        null,
+                        null,
+                        "p",
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
                 // then.
                 .isInstanceOf(UsernameAlreadyExistsException.class);
         assertThat(userRepository.findAll()).hasSize(1);
@@ -227,7 +268,7 @@ class DatabaseUserServiceTest {
                         null,
                         null,
                         "p",
-                        "VIEWER"))
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
                 // then.
                 .isInstanceOf(UsernameAlreadyExistsException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -236,11 +277,26 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldThrowWhenEmailAlreadyExists() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
         // when.
-        assertThatThrownBy(() ->
-                        userService.createLocal("bob", null, null, "alice@example.com", null, null, "p", "VIEWER"))
+        assertThatThrownBy(() -> userService.createLocal(
+                        "bob",
+                        null,
+                        null,
+                        "alice@example.com",
+                        null,
+                        null,
+                        "p",
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
                 // then.
                 .isInstanceOf(EmailAlreadyExistsException.class);
         assertThat(userRepository.findAll()).hasSize(1);
@@ -248,7 +304,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void deleteAllById_shouldRemoveUser() {
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -268,6 +332,16 @@ class DatabaseUserServiceTest {
     void findAll_shouldReturnAllUsers() {
         userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
         userService.createFromOidc("bob", null, null, "b@example.com", null, null, "hash-bob", "ADMIN");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+        userService.createFromOidc("bob", null, null, "b@example.com", null, null, "ADMIN");
 
         // when.
         List<UserEntity> all = userService.findAll();
@@ -284,7 +358,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void findUserByUsername_shouldReturnMatchingUser() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
         // when.
         Optional<UserEntity> found = userService.findUserByUsername("alice");
@@ -304,7 +386,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void findUserById_shouldReturnMatchingUser() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -325,7 +415,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateLastLoginAt_shouldSetLastLoginAtToNow() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
         // when.
         userService.updateLastLoginAt("alice");
@@ -338,7 +436,15 @@ class DatabaseUserServiceTest {
     @Test
     void updateStatus_shouldUpdateOnlyStatus() {
         // given.
-        userService.createLocal("alice", "Alice", "Smith", "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                "Alice",
+                "Smith",
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -353,7 +459,15 @@ class DatabaseUserServiceTest {
     @Test
     void updateStatus_shouldBeIdempotent() {
         // given.
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -389,7 +503,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldUpdateAllProvidedFields() {
-        userService.createLocal("oldName", "First", "Last", "old@example.com", null, null, "oldPass", "VIEWER");
+        userService.createLocal(
+                "oldName",
+                "First",
+                "Last",
+                "old@example.com",
+                null,
+                null,
+                "oldPass",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("oldName").orElseThrow();
 
         // when.
@@ -421,7 +543,15 @@ class DatabaseUserServiceTest {
     void updateUserPatch_shouldUpdateAllProvidedFields_PasswordIsNotProvided() {
         // given.
         String oldPassword = "oldPass";
-        userService.createLocal("oldName", null, null, "old@example.com", null, null, oldPassword, "VIEWER");
+        userService.createLocal(
+                "oldName",
+                null,
+                null,
+                "old@example.com",
+                null,
+                null,
+                oldPassword,
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("oldName").orElseThrow();
 
         // when.
@@ -447,7 +577,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldHashNewPassword() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "oldPass", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "oldPass",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -471,7 +609,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenRoleIsNotAllowed() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -485,7 +631,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenUsernameIsBlank() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -499,7 +653,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenEmailIsBlank() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -513,7 +675,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenPasswordIsBlank() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -536,7 +706,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenRolesAreEmpty() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -550,7 +728,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenRolesContainBlank() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -574,8 +760,24 @@ class DatabaseUserServiceTest {
     @Test
     void updateUserPatch_shouldThrowWhenUsernameAlreadyExists() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
-        userService.createLocal("bob", null, null, "bob@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+        userService.createLocal(
+                "bob",
+                null,
+                null,
+                "bob@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity bob = userRepository.findByUsername("bob").orElseThrow();
 
         // when.
@@ -591,7 +793,15 @@ class DatabaseUserServiceTest {
     @Test
     void updateUserPatch_shouldThrowWhenUsernameIsReservedForSuperAdmin() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity alice = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -616,8 +826,24 @@ class DatabaseUserServiceTest {
     @Test
     void updateUserPatch_shouldThrowWhenEmailAlreadyExists() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
-        userService.createLocal("bob", null, null, "bob@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+        userService.createLocal(
+                "bob",
+                null,
+                null,
+                "bob@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity bob = userRepository.findByUsername("bob").orElseThrow();
 
         // when.
@@ -633,7 +859,15 @@ class DatabaseUserServiceTest {
     @Test
     void updateUserPatch_shouldAllowUserToKeepItsOwnUsernameAndEmail() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity alice = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -649,7 +883,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldReplaceRolesCompletely() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -674,11 +916,49 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldGrantRolesThroughUsersRolesTable() {
         // when.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "plainPass", "ADMIN");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "plainPass",
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
 
         // then.
         UserEntity saved = userRepository.findByUsername("alice").orElseThrow();
         assertThat(userService.findRoleNamesByUserId(saved.id())).containsExactly("ADMIN");
+    }
+
+    @Test
+    void createLocal_shouldGrantEveryRequestedRole() {
+        // when.
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "plainPass",
+                Set.of(
+                        roleRepository.findIdByName("VIEWER").orElseThrow(),
+                        roleRepository.findIdByName("EDITOR").orElseThrow()));
+
+        // then.
+        UserEntity saved = userRepository.findByUsername("alice").orElseThrow();
+        assertThat(userService.findRoleNamesByUserId(saved.id())).containsExactlyInAnyOrder("VIEWER", "EDITOR");
+    }
+
+    @Test
+    void createLocal_shouldThrowWhenRolesAreEmpty() {
+        // when.
+        assertThatThrownBy(() ->
+                        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", Set.of()))
+                // then.
+                .isInstanceOf(UserInvalidValueException.class);
+        assertThat(userRepository.findAll()).isEmpty();
     }
 
     @Test
@@ -694,7 +974,15 @@ class DatabaseUserServiceTest {
     @Test
     void updateUserPatch_shouldReplaceRolesInUsersRolesTableRatherThanAddToThem() {
         // given.
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -717,7 +1005,15 @@ class DatabaseUserServiceTest {
     @Test
     void deleteById_shouldRevokeRoles() {
         // given.
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "ADMIN");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -730,8 +1026,24 @@ class DatabaseUserServiceTest {
     @Test
     void findAllRoleNamesByUserId_shouldReturnAssignmentsOfEveryUser() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "ADMIN");
-        userService.createLocal("bob", null, null, "bob@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
+        userService.createLocal(
+                "bob",
+                null,
+                null,
+                "bob@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
         String aliceId = userRepository.findByUsername("alice").orElseThrow().id();
         String bobId = userRepository.findByUsername("bob").orElseThrow().id();

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import com.axelixlabs.axelix.common.testfixtures.TestRoles;
 import com.axelixlabs.axelix.master.autoconfiguration.auth.properties.SuperAdminConfigurationProperties;
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserOrigin;
@@ -91,7 +92,7 @@ class DatabaseUserServiceTest {
                 " Software Engineer ",
                 " Platform ",
                 "plainPass",
-                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.ADMIN.getName()).orElseThrow()));
 
         // then.
         List<UserEntity> users = userRepository.findAll();
@@ -179,7 +180,9 @@ class DatabaseUserServiceTest {
                         null,
                         null,
                         "p",
-                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
+                        Set.of(roleRepository
+                                .findIdByName(TestRoles.VIEWER.getName())
+                                .orElseThrow())))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -196,7 +199,9 @@ class DatabaseUserServiceTest {
                         null,
                         null,
                         "p",
-                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
+                        Set.of(roleRepository
+                                .findIdByName(TestRoles.VIEWER.getName())
+                                .orElseThrow())))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -213,7 +218,9 @@ class DatabaseUserServiceTest {
                         null,
                         null,
                         "   ",
-                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
+                        Set.of(roleRepository
+                                .findIdByName(TestRoles.VIEWER.getName())
+                                .orElseThrow())))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -240,7 +247,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
 
         // when.
         assertThatThrownBy(() -> userService.createLocal(
@@ -251,7 +258,9 @@ class DatabaseUserServiceTest {
                         null,
                         null,
                         "p",
-                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
+                        Set.of(roleRepository
+                                .findIdByName(TestRoles.VIEWER.getName())
+                                .orElseThrow())))
                 // then.
                 .isInstanceOf(UsernameAlreadyExistsException.class);
         assertThat(userRepository.findAll()).hasSize(1);
@@ -268,7 +277,9 @@ class DatabaseUserServiceTest {
                         null,
                         null,
                         "p",
-                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
+                        Set.of(roleRepository
+                                .findIdByName(TestRoles.VIEWER.getName())
+                                .orElseThrow())))
                 // then.
                 .isInstanceOf(UsernameAlreadyExistsException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -285,7 +296,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
 
         // when.
         assertThatThrownBy(() -> userService.createLocal(
@@ -296,7 +307,9 @@ class DatabaseUserServiceTest {
                         null,
                         null,
                         "p",
-                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
+                        Set.of(roleRepository
+                                .findIdByName(TestRoles.VIEWER.getName())
+                                .orElseThrow())))
                 // then.
                 .isInstanceOf(EmailAlreadyExistsException.class);
         assertThat(userRepository.findAll()).hasSize(1);
@@ -312,7 +325,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -330,8 +343,6 @@ class DatabaseUserServiceTest {
 
     @Test
     void findAll_shouldReturnAllUsers() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
-        userService.createFromOidc("bob", null, null, "b@example.com", null, null, "hash-bob", "ADMIN");
         userService.createLocal(
                 "alice",
                 null,
@@ -340,8 +351,8 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
-        userService.createFromOidc("bob", null, null, "b@example.com", null, null, "ADMIN");
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
+        userService.createFromOidc("bob", null, null, "b@example.com", null, null, "hash-bob", "ADMIN");
 
         // when.
         List<UserEntity> all = userService.findAll();
@@ -366,7 +377,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
 
         // when.
         Optional<UserEntity> found = userService.findUserByUsername("alice");
@@ -394,7 +405,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -423,7 +434,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
 
         // when.
         userService.updateLastLoginAt("alice");
@@ -444,7 +455,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -467,7 +478,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -511,7 +522,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "oldPass",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("oldName").orElseThrow();
 
         // when.
@@ -551,7 +562,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 oldPassword,
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("oldName").orElseThrow();
 
         // when.
@@ -585,7 +596,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "oldPass",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -617,7 +628,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -639,7 +650,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -661,7 +672,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -683,7 +694,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -714,7 +725,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -736,7 +747,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -768,7 +779,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         userService.createLocal(
                 "bob",
                 null,
@@ -777,7 +788,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity bob = userRepository.findByUsername("bob").orElseThrow();
 
         // when.
@@ -801,7 +812,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity alice = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -834,7 +845,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         userService.createLocal(
                 "bob",
                 null,
@@ -843,7 +854,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity bob = userRepository.findByUsername("bob").orElseThrow();
 
         // when.
@@ -867,7 +878,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity alice = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -891,7 +902,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -924,7 +935,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "plainPass",
-                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.ADMIN.getName()).orElseThrow()));
 
         // then.
         UserEntity saved = userRepository.findByUsername("alice").orElseThrow();
@@ -943,8 +954,8 @@ class DatabaseUserServiceTest {
                 null,
                 "plainPass",
                 Set.of(
-                        roleRepository.findIdByName("VIEWER").orElseThrow(),
-                        roleRepository.findIdByName("EDITOR").orElseThrow()));
+                        roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow(),
+                        roleRepository.findIdByName(TestRoles.EDITOR.getName()).orElseThrow()));
 
         // then.
         UserEntity saved = userRepository.findByUsername("alice").orElseThrow();
@@ -982,7 +993,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -1013,7 +1024,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.ADMIN.getName()).orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -1034,7 +1045,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.ADMIN.getName()).orElseThrow()));
         userService.createLocal(
                 "bob",
                 null,
@@ -1043,7 +1054,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "p",
-                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+                Set.of(roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow()));
 
         String aliceId = userRepository.findByUsername("alice").orElseThrow().id();
         String bobId = userRepository.findByUsername("bob").orElseThrow().id();

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DefaultRoleServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DefaultRoleServiceTest.java
@@ -37,7 +37,7 @@ import com.axelixlabs.axelix.common.auth.core.Role;
 import com.axelixlabs.axelix.common.testfixtures.TestRoles;
 import com.axelixlabs.axelix.master.domain.RoleEntity;
 import com.axelixlabs.axelix.master.domain.RoleOrigin;
-import com.axelixlabs.axelix.master.domain.UserEntity;
+import com.axelixlabs.axelix.master.repository.RoleRepository;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.service.state.auth.DefaultRoleService;
 import com.axelixlabs.axelix.master.service.state.auth.RoleService;
@@ -64,6 +64,9 @@ class DefaultRoleServiceTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
 
     @Autowired
     private JdbcAggregateTemplate jdbcAggregateTemplate;
@@ -120,7 +123,8 @@ class DefaultRoleServiceTest {
         @Test
         void findRolesOfUser_shouldReturnTheSingleRoleGrantedToTheUser() {
             // given.
-            String userId = createUserWithRoles("VIEWER");
+            String userId =
+                    createUserWithRoles(roleRepository.findIdByName("VIEWER").orElseThrow());
 
             // when.
             Set<Role> roles = roleService.findRolesOfUser(userId);
@@ -132,7 +136,9 @@ class DefaultRoleServiceTest {
         @Test
         void findRolesOfUser_shouldReturnEveryRoleWithItsAuthorities() {
             // given.
-            String userId = createUserWithRoles("ADMIN", "EDITOR");
+            String userId = createUserWithRoles(
+                    roleRepository.findIdByName("ADMIN").orElseThrow(),
+                    roleRepository.findIdByName("EDITOR").orElseThrow());
 
             // when.
             Set<Role> roles = roleService.findRolesOfUser(userId);
@@ -152,14 +158,9 @@ class DefaultRoleServiceTest {
             assertThat(roles).isEmpty();
         }
 
-        private String createUserWithRoles(String... roles) {
-            userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", roles[0]);
-            UserEntity user = userRepository.findByUsername("alice").orElseThrow();
-            if (roles.length > 1) {
-                userService.updateUserPatch(
-                        user.id(), "alice", null, null, "alice@example.com", null, null, null, Set.of(roles), null);
-            }
-            return user.id();
+        private String createUserWithRoles(String... roleIds) {
+            userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", Set.of(roleIds));
+            return userRepository.findByUsername("alice").orElseThrow().id();
         }
 
         private static Role roleNamed(Set<Role> roles, String name) {
@@ -268,7 +269,7 @@ class DefaultRoleServiceTest {
             String childId = customRole("CHILD", OssAuthority.GARBAGE_COLLECTOR);
             createBond(childId, parentId);
 
-            userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "CHILD");
+            userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", Set.of(childId));
             String userId = userRepository.findByUsername("alice").orElseThrow().id();
 
             // when.
@@ -380,7 +381,7 @@ class DefaultRoleServiceTest {
             createBond(roleA, roleB);
             createBond(roleB, roleA);
 
-            userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "ROLE A");
+            userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", Set.of(roleA));
             String userId = userRepository.findByUsername("alice").orElseThrow().id();
 
             // when.

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DefaultRoleServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DefaultRoleServiceTest.java
@@ -123,8 +123,8 @@ class DefaultRoleServiceTest {
         @Test
         void findRolesOfUser_shouldReturnTheSingleRoleGrantedToTheUser() {
             // given.
-            String userId =
-                    createUserWithRoles(roleRepository.findIdByName("VIEWER").orElseThrow());
+            String userId = createUserWithRoles(
+                    roleRepository.findIdByName(TestRoles.VIEWER.getName()).orElseThrow());
 
             // when.
             Set<Role> roles = roleService.findRolesOfUser(userId);
@@ -137,8 +137,8 @@ class DefaultRoleServiceTest {
         void findRolesOfUser_shouldReturnEveryRoleWithItsAuthorities() {
             // given.
             String userId = createUserWithRoles(
-                    roleRepository.findIdByName("ADMIN").orElseThrow(),
-                    roleRepository.findIdByName("EDITOR").orElseThrow());
+                    roleRepository.findIdByName(TestRoles.ADMIN.getName()).orElseThrow(),
+                    roleRepository.findIdByName(TestRoles.EDITOR.getName()).orElseThrow());
 
             // when.
             Set<Role> roles = roleService.findRolesOfUser(userId);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local user creation now supports assigning one or more roles by role ID.
  * Duplicate role assignments are consolidated, while invalid or unknown role IDs are rejected.
  * Role IDs can be resolved from role names where needed.

* **Bug Fixes**
  * Improved consistency when assigning roles during local user registration.

* **Tests**
  * Expanded coverage for multiple roles, duplicate assignments, and invalid role identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->