### PR TITLE
GH-1574 Assign roles by role ID when updating a user

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApi.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApi.java
@@ -111,7 +111,7 @@ public class UserManagementApi {
                     request.jobTitle(),
                     request.organizationalUnit(),
                     request.password(),
-                    request.roles(),
+                    request.roleIds(),
                     null);
 
             return ResponseEntity.noContent().build();

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/external/request/user/UserUpdateRequest.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/external/request/user/UserUpdateRequest.java
@@ -31,7 +31,7 @@ import org.jspecify.annotations.Nullable;
  * @param email    New email address. Must be unique when provided.
  * @param jobTitle New job title, which may be {@code null}.
  * @param organizationalUnit New organizational unit, which may be {@code null}.
- * @param roles    New set of role names.
+ * @param roleIds  New set of role ids.
  * @param password Plain-text new password, or null, if it should not be changed.
  *
  * @author Sergey Cherkasov
@@ -44,13 +44,13 @@ public record UserUpdateRequest(
         @Nullable String email,
         @Nullable String jobTitle,
         @Nullable String organizationalUnit,
-        Set<String> roles,
+        Set<String> roleIds,
         @Nullable String password) {
 
     @Override
     public String toString() {
         return "UserUpdateRequest[id=%s, username=[REDACTED], firstName=[REDACTED],"
                 + " lastName=[REDACTED], email=[REDACTED], jobTitle=[REDACTED],"
-                + " organizationalUnit=[REDACTED], roles=%s, password=[REDACTED]]".formatted(id, roles);
+                + " organizationalUnit=[REDACTED], roleIds=%s, password=[REDACTED]]".formatted(id, roleIds);
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackController.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackController.java
@@ -41,6 +41,7 @@ import com.axelixlabs.axelix.master.autoconfiguration.auth.properties.OAuth2Prop
 import com.axelixlabs.axelix.master.domain.UserEntity;
 import com.axelixlabs.axelix.master.domain.UserOrigin;
 import com.axelixlabs.axelix.master.domain.UserStatus;
+import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 import com.axelixlabs.axelix.master.exception.auth.UserSuspendedException;
 import com.axelixlabs.axelix.master.service.auth.CookieService;
 import com.axelixlabs.axelix.master.service.auth.oauth.OidcClient;
@@ -48,6 +49,7 @@ import com.axelixlabs.axelix.master.service.auth.oauth.OidcIdTokenClaimsValidato
 import com.axelixlabs.axelix.master.service.auth.oauth.Tokens;
 import com.axelixlabs.axelix.master.service.auth.oauth.UserInfoJsonAccessor;
 import com.axelixlabs.axelix.master.service.auth.oauth.ValidatedOidcIdentity;
+import com.axelixlabs.axelix.master.service.state.auth.RoleService;
 import com.axelixlabs.axelix.master.service.state.auth.UserService;
 import com.axelixlabs.axelix.master.service.transport.BadRequestException;
 
@@ -77,6 +79,7 @@ public class OAuth2CallbackController {
     private final OAuth2Properties oAuth2Properties;
     private final UserService userService;
     private final UserInfoJsonAccessor userInfoJsonAccessor;
+    private final RoleService roleService;
     private final List<OidcIdTokenClaimsValidator> claimsValidators;
 
     public OAuth2CallbackController(
@@ -86,6 +89,7 @@ public class OAuth2CallbackController {
             OAuth2Properties oAuth2Properties,
             UserService userService,
             UserInfoJsonAccessor userInfoJsonAccessor,
+            RoleService roleService,
             List<OidcIdTokenClaimsValidator> claimsValidators) {
         this.oidcClient = oidcClient;
         this.cookieService = cookieService;
@@ -93,6 +97,7 @@ public class OAuth2CallbackController {
         this.oAuth2Properties = oAuth2Properties;
         this.userService = userService;
         this.userInfoJsonAccessor = userInfoJsonAccessor;
+        this.roleService = roleService;
         this.claimsValidators = claimsValidators;
     }
 
@@ -153,7 +158,7 @@ public class OAuth2CallbackController {
                     metadata.jobTitle() == null ? entity.jobTitle() : metadata.jobTitle(),
                     metadata.organizationalUnit() == null ? entity.organizationalUnit() : metadata.organizationalUnit(),
                     null,
-                    Set.of(role.getName()),
+                    Set.of(resolveRoleId(role)),
                     Instant.now());
         } else {
             userService.createFromOidc(
@@ -165,6 +170,12 @@ public class OAuth2CallbackController {
                     metadata.organizationalUnit(),
                     role.getName());
         }
+    }
+
+    private String resolveRoleId(Role role) {
+        return roleService
+                .findIdByName(role.getName())
+                .orElseThrow(() -> new UserRoleNotFoundException(role.getName()));
     }
 
     private static void checkUserIsSuspended(User user, UserEntity entity) {

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DatabaseUserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DatabaseUserService.java
@@ -204,11 +204,11 @@ public class DatabaseUserService implements UserService {
             @Nullable String jobTitle,
             @Nullable String organizationalUnit,
             @Nullable String password,
-            Set<String> roles,
+            Set<String> roleIds,
             @Nullable Instant lastLoginAt)
             throws UserRoleNotFoundException, UserInvalidValueException {
 
-        if (roles.isEmpty()) {
+        if (roleIds.isEmpty()) {
             throw new UserInvalidValueException(null);
         }
 
@@ -242,7 +242,7 @@ public class DatabaseUserService implements UserService {
                 lastLoginAt);
 
         userRepository.deleteUserRolesMappings(id);
-        grantRoles(id, roles);
+        grantRolesByIds(id, roleIds);
     }
 
     // TODO: Right now this is acceptable (i.e. a non-bulk INSERT) but in the future that may need optimization

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DefaultRoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DefaultRoleService.java
@@ -68,6 +68,11 @@ public class DefaultRoleService implements RoleService {
     }
 
     @Override
+    public Optional<String> findIdByName(String roleName) {
+        return roleRepository.findIdByName(roleName);
+    }
+
+    @Override
     public Set<Role> findRolesOfUser(String userId) throws IllegalStateException {
         RoleGraph graph = getGraph();
 

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/RoleService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/RoleService.java
@@ -52,6 +52,14 @@ public interface RoleService {
     Optional<Role> findByName(String name) throws IllegalStateException;
 
     /**
+     * Looks up the id of a role by its exact name.
+     *
+     * @param roleName Name of the role to look up.
+     * @return The id of the role, or {@link Optional#empty()} if no role with such a name exists.
+     */
+    Optional<String> findIdByName(String roleName);
+
+    /**
      * Looks up roles that belong to the given user.
      *
      * @throws IllegalStateException in case implementation cannot assemble the {@link Role} due to the fact that

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/UserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/UserService.java
@@ -166,7 +166,7 @@ public interface UserService {
      *
      * <p>Field semantics:
      * <ul>
-     *   <li>{@code username} and {@code roles} are required and must not be {@code null}.</li>
+     *   <li>{@code username} and {@code roleIds} are required and must not be {@code null}.</li>
      *   <li>{@code firstName}, {@code lastName}, {@code email}, {@code jobTitle}, and
      *       {@code organizationalUnit} are nullable: passing {@code null} clears them.</li>
      *   <li>{@code password} is nullable: passing {@code null} <b>preserves</b> the previously stored password.</li>
@@ -182,9 +182,9 @@ public interface UserService {
      * @param organizationalUnit New organizational unit, or {@code null} to clear the stored organizational unit.
      * @param password New plain-text password (hashed server-side), or {@code null} to keep the existing password.
      *                 Must not be blank when.
-     * @param roles    New set of role names. Replaces any roles previously assigned. Each role must not be blank or {@code null}.
+     * @param roleIds  New set of role ids. Replaces any roles previously assigned. Must not be empty or contain blanks.
      * @param lastLoginAt New last-login timestamp, or {@code null} to preserve the stored timestamp.
-     * @throws UserRoleNotFoundException if any of the provided role names does not exist in the service.
+     * @throws UserRoleNotFoundException if any of the provided role ids does not exist in the service.
      * @throws UserInvalidValueException if any of the provided string fields is blank.
      * @throws UsernameAlreadyExistsException if another user with the given username already exists.
      * @throws EmailAlreadyExistsException if another user with the given email already exists.
@@ -198,7 +198,7 @@ public interface UserService {
             @Nullable String jobTitle,
             @Nullable String organizationalUnit,
             @Nullable String password,
-            Set<String> roles,
+            Set<String> roleIds,
             @Nullable Instant lastLoginAt)
             throws UserRoleNotFoundException, UserInvalidValueException;
 }

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
@@ -331,10 +331,13 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "email": "new@example.com",
                   "jobTitle": "Engineering Manager",
                   "organizationalUnit": "Engineering",
-                  "roles": ["ADMIN", "EDITOR"],
+                  "roleIds": ["%s", "%s"],
                   "password": "newPass"
                 }
-                """.formatted(user.id());
+                """.formatted(
+                        user.id(),
+                        roleRepository.findIdByName("ADMIN").orElseThrow(),
+                        roleRepository.findIdByName("EDITOR").orElseThrow());
 
         // when.
         IdentityAwareTestRestTemplate superAdmin = restTemplate.asUsersFeedEditor();
@@ -370,10 +373,11 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "id": "%s",
                   "username": "%s",
                   "email": null,
-                  "roles": ["VIEWER"],
+                  "roleIds": ["%s"],
                   "password": null
                 }
-                """.formatted(user.id(), newUsername);
+                """.formatted(
+                user.id(), newUsername, roleRepository.findIdByName("VIEWER").orElseThrow());
 
         // when.
         IdentityAwareTestRestTemplate superAdmin = restTemplate.asUsersFeedEditor();
@@ -399,15 +403,16 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
         UserEntity bob = createUser("bob", "bob@example.com", "p");
 
         // language=json
-        String request = """
+        String request =
+                """
                 {
                   "id": "%s",
                   "username": "alice",
                   "email": "bob@example.com",
-                  "roles": ["VIEWER"],
+                  "roleIds": ["%s"],
                   "password": null
                 }
-                """.formatted(bob.id());
+                """.formatted(bob.id(), roleRepository.findIdByName("VIEWER").orElseThrow());
 
         // when.
         ResponseEntity<String> response = restTemplate
@@ -429,15 +434,16 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
         UserEntity bob = createUser("bob", "bob@example.com", "p");
 
         // language=json
-        String request = """
+        String request =
+                """
                 {
                   "id": "%s",
                   "username": "bob",
                   "email": "alice@example.com",
-                  "roles": ["VIEWER"],
+                  "roleIds": ["%s"],
                   "password": null
                 }
-                """.formatted(bob.id());
+                """.formatted(bob.id(), roleRepository.findIdByName("VIEWER").orElseThrow());
 
         // when.
         ResponseEntity<String> response = restTemplate
@@ -461,7 +467,7 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                 {
                   "id": "%s",
                   "username": "u",
-                  "roles": ["VIEWER", "  SUPER_ADMIN "]
+                  "roleIds": ["%s", "  SUPER_ADMIN "]
                 }
                 """.formatted(user.id());
 
@@ -505,7 +511,7 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                 {
                   "id": "%s",
                   "username": "u",
-                  "roles": []
+                  "roleIds": []
                 }
                 """.formatted(user.id());
 
@@ -524,13 +530,14 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
         UserEntity user = createUser("u", "u@example.com", "p");
 
         // language=json
-        String request = """
+        String request =
+                """
                 {
                   "id": "%s",
                   "username": "u",
-                  "roles": ["VIEWER", "   "]
+                  "roleIds": ["%s", "   "]
                 }
-                """.formatted(user.id());
+                """.formatted(user.id(), roleRepository.findIdByName("VIEWER").orElseThrow());
 
         // when.
         ResponseEntity<Void> response = restTemplate
@@ -546,11 +553,12 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
         UserEntity user = createUser("u", "u@example.com", "p");
 
         // language=json
-        String request = """
+        String request =
+                """
                 {
                   "id": "%s",
                   "username": "u",
-                  "roles": ["NOT_A_REAL_ROLE"]
+                  "roleIds": ["NOT_A_REAL_ROLE"]
                 }
                 """.formatted(user.id());
 
@@ -561,6 +569,32 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
 
         // then.
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void shouldGrantTheRoleOnce_WhenUpdateRepeatsTheSameRoleId() {
+        UserEntity user = createUser("u", "u@example.com", "p");
+
+        // language=json
+        String request = """
+                {
+                  "id": "%s",
+                  "username": "u",
+                  "roleIds": ["%s", "%s"]
+                }
+                """.formatted(
+                        user.id(),
+                        roleRepository.findIdByName("ADMIN").orElseThrow(),
+                        roleRepository.findIdByName("ADMIN").orElseThrow());
+
+        // when.
+        ResponseEntity<Void> response = restTemplate
+                .asUsersFeedEditor()
+                .exchange(USERS_UPDATE_PATH, HttpMethod.PUT, defaultEntity(request), Void.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(userService.findRoleNamesByUserId(user.id())).containsExactly("ADMIN");
     }
 
     @Test
@@ -620,7 +654,7 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
                   "id": "%s",
                   "status": "UNKNOWN"
                 }
-                """.formatted(user.id());
+                """.formatted(user.id(), roleRepository.findIdByName("VIEWER").orElseThrow());
 
         // when.
         ResponseEntity<Void> response = restTemplate

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
@@ -38,6 +38,7 @@ import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
 import com.axelixlabs.axelix.master.exception.auth.UserNotFoundException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
 import com.axelixlabs.axelix.master.exception.auth.UsernameAlreadyExistsException;
+import com.axelixlabs.axelix.master.repository.RoleRepository;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.service.state.auth.DatabaseUserService;
 import com.axelixlabs.axelix.master.service.state.auth.UserService;
@@ -64,6 +65,9 @@ class DatabaseUserServiceTest {
     private UserRepository userRepository;
 
     @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
     private PasswordEncoder passwordEncoder;
 
     @Autowired
@@ -86,7 +90,7 @@ class DatabaseUserServiceTest {
                 " Software Engineer ",
                 " Platform ",
                 "plainPass",
-                "ADMIN");
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
 
         // then.
         List<UserEntity> users = userRepository.findAll();
@@ -145,17 +149,17 @@ class DatabaseUserServiceTest {
     void createLocal_shouldThrowWhenRoleIsNotAllowed() {
         // when.
         assertThatThrownBy(() -> userService.createLocal(
-                        "alice", null, null, "alice@example.com", null, null, "p", "SUPER_ADMIN"))
+                        "alice", null, null, "alice@example.com", null, null, "p", Set.of("SUPER_ADMIN")))
                 // then.
                 .isInstanceOf(UserRoleNotFoundException.class);
         assertThat(userRepository.findAll()).isEmpty();
     }
 
-    @Test // TODO: This test should be revisited since in enterprise we're going to be able to supply many roles
+    @Test
     void createLocal_shouldThrowWhenRoleDoesNotExist() {
         // when.
         assertThatThrownBy(() -> userService.createLocal(
-                        "alice", null, null, "alice@example.com", null, null, "p", "NOT_A_ROLE"))
+                        "alice", null, null, "alice@example.com", null, null, "p", Set.of("NOT_A_ROLE")))
                 // then.
                 .isInstanceOf(UserRoleNotFoundException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -164,8 +168,15 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldThrowWhenUsernameIsBlank() {
         // when.
-        assertThatThrownBy(() ->
-                        userService.createLocal("   ", null, null, "alice@example.com", null, null, "p", "VIEWER"))
+        assertThatThrownBy(() -> userService.createLocal(
+                        "   ",
+                        null,
+                        null,
+                        "alice@example.com",
+                        null,
+                        null,
+                        "p",
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -174,7 +185,15 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldThrowWhenEmailIsBlank() {
         // when.
-        assertThatThrownBy(() -> userService.createLocal("alice", null, null, "   ", null, null, "p", "VIEWER"))
+        assertThatThrownBy(() -> userService.createLocal(
+                        "alice",
+                        null,
+                        null,
+                        "   ",
+                        null,
+                        null,
+                        "p",
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -183,8 +202,15 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldThrowWhenPasswordIsBlank() {
         // when.
-        assertThatThrownBy(() ->
-                        userService.createLocal("alice", null, null, "alice@example.com", null, null, "   ", "VIEWER"))
+        assertThatThrownBy(() -> userService.createLocal(
+                        "alice",
+                        null,
+                        null,
+                        "alice@example.com",
+                        null,
+                        null,
+                        "   ",
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -193,8 +219,8 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldThrowWhenRoleIsBlank() {
         // when.
-        assertThatThrownBy(
-                        () -> userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "   "))
+        assertThatThrownBy(() -> userService.createLocal(
+                        "alice", null, null, "alice@example.com", null, null, "p", Set.of("   ")))
                 // then.
                 .isInstanceOf(UserInvalidValueException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -203,11 +229,26 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldThrowWhenUsernameAlreadyExists() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
         // when.
-        assertThatThrownBy(() ->
-                        userService.createLocal("alice", null, null, "other@example.com", null, null, "p", "VIEWER"))
+        assertThatThrownBy(() -> userService.createLocal(
+                        "alice",
+                        null,
+                        null,
+                        "other@example.com",
+                        null,
+                        null,
+                        "p",
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
                 // then.
                 .isInstanceOf(UsernameAlreadyExistsException.class);
         assertThat(userRepository.findAll()).hasSize(1);
@@ -224,7 +265,7 @@ class DatabaseUserServiceTest {
                         null,
                         null,
                         "p",
-                        "VIEWER"))
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
                 // then.
                 .isInstanceOf(UsernameAlreadyExistsException.class);
         assertThat(userRepository.findAll()).isEmpty();
@@ -233,11 +274,26 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldThrowWhenEmailAlreadyExists() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
         // when.
-        assertThatThrownBy(() ->
-                        userService.createLocal("bob", null, null, "alice@example.com", null, null, "p", "VIEWER"))
+        assertThatThrownBy(() -> userService.createLocal(
+                        "bob",
+                        null,
+                        null,
+                        "alice@example.com",
+                        null,
+                        null,
+                        "p",
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow())))
                 // then.
                 .isInstanceOf(EmailAlreadyExistsException.class);
         assertThat(userRepository.findAll()).hasSize(1);
@@ -245,7 +301,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void deleteAllById_shouldRemoveUser() {
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -263,7 +327,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void findAll_shouldReturnAllUsers() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         userService.createFromOidc("bob", null, null, "b@example.com", null, null, "ADMIN");
 
         // when.
@@ -281,7 +353,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void findUserByUsername_shouldReturnMatchingUser() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
         // when.
         Optional<UserEntity> found = userService.findUserByUsername("alice");
@@ -301,7 +381,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void findUserById_shouldReturnMatchingUser() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -322,7 +410,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateLastLoginAt_shouldSetLastLoginAtToNow() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
         // when.
         userService.updateLastLoginAt("alice");
@@ -335,7 +431,15 @@ class DatabaseUserServiceTest {
     @Test
     void updateStatus_shouldUpdateOnlyStatus() {
         // given.
-        userService.createLocal("alice", "Alice", "Smith", "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                "Alice",
+                "Smith",
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -350,7 +454,15 @@ class DatabaseUserServiceTest {
     @Test
     void updateStatus_shouldBeIdempotent() {
         // given.
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -372,7 +484,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldUpdateAllProvidedFields() {
-        userService.createLocal("oldName", "First", "Last", "old@example.com", null, null, "oldPass", "VIEWER");
+        userService.createLocal(
+                "oldName",
+                "First",
+                "Last",
+                "old@example.com",
+                null,
+                null,
+                "oldPass",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("oldName").orElseThrow();
 
         // when.
@@ -385,7 +505,9 @@ class DatabaseUserServiceTest {
                 "Engineering Manager",
                 "Engineering",
                 "newPass",
-                Set.of("ADMIN", "EDITOR"),
+                Set.of(
+                        roleRepository.findIdByName("ADMIN").orElseThrow(),
+                        roleRepository.findIdByName("EDITOR").orElseThrow()),
                 null);
 
         // then.
@@ -404,7 +526,15 @@ class DatabaseUserServiceTest {
     void updateUserPatch_shouldUpdateAllProvidedFields_PasswordIsNotProvided() {
         // given.
         String oldPassword = "oldPass";
-        userService.createLocal("oldName", null, null, "old@example.com", null, null, oldPassword, "VIEWER");
+        userService.createLocal(
+                "oldName",
+                null,
+                null,
+                "old@example.com",
+                null,
+                null,
+                oldPassword,
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("oldName").orElseThrow();
 
         // when.
@@ -417,7 +547,9 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 null,
-                Set.of("ADMIN", "EDITOR"),
+                Set.of(
+                        roleRepository.findIdByName("ADMIN").orElseThrow(),
+                        roleRepository.findIdByName("EDITOR").orElseThrow()),
                 null);
 
         // then.
@@ -430,7 +562,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldHashNewPassword() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "oldPass", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "oldPass",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -443,7 +583,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "newPass",
-                userService.findRoleNamesByUserId(existing.id()),
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()),
                 null);
 
         // then.
@@ -454,7 +594,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenRoleIsNotAllowed() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -468,12 +616,29 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenUsernameIsBlank() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
         assertThatThrownBy(() -> userService.updateUserPatch(
-                        existing.id(), "   ", null, null, "alice@example.com", null, null, "p", Set.of("VIEWER"), null))
+                        existing.id(),
+                        "   ",
+                        null,
+                        null,
+                        "alice@example.com",
+                        null,
+                        null,
+                        "p",
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()),
+                        null))
                 .isInstanceOf(UserInvalidValueException.class);
 
         UserEntity untouched = userRepository.findById(existing.id()).orElseThrow();
@@ -482,12 +647,29 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenEmailIsBlank() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
         assertThatThrownBy(() -> userService.updateUserPatch(
-                        existing.id(), "alice", null, null, "   ", null, null, "p", Set.of("VIEWER"), null))
+                        existing.id(),
+                        "alice",
+                        null,
+                        null,
+                        "   ",
+                        null,
+                        null,
+                        "p",
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()),
+                        null))
                 .isInstanceOf(UserInvalidValueException.class);
 
         UserEntity untouched = userRepository.findById(existing.id()).orElseThrow();
@@ -496,7 +678,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenPasswordIsBlank() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -509,7 +699,7 @@ class DatabaseUserServiceTest {
                         null,
                         null,
                         "   ",
-                        Set.of("VIEWER"),
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()),
                         null))
                 .isInstanceOf(UserInvalidValueException.class);
 
@@ -519,7 +709,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenRolesAreEmpty() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -533,7 +731,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldThrowWhenRolesContainBlank() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when. / then.
@@ -546,7 +752,7 @@ class DatabaseUserServiceTest {
                         null,
                         null,
                         "p",
-                        Set.of("VIEWER", "   "),
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow(), "   "),
                         null))
                 .isInstanceOf(UserInvalidValueException.class);
 
@@ -557,13 +763,38 @@ class DatabaseUserServiceTest {
     @Test
     void updateUserPatch_shouldThrowWhenUsernameAlreadyExists() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
-        userService.createLocal("bob", null, null, "bob@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+        userService.createLocal(
+                "bob",
+                null,
+                null,
+                "bob@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity bob = userRepository.findByUsername("bob").orElseThrow();
 
         // when.
         assertThatThrownBy(() -> userService.updateUserPatch(
-                        bob.id(), "alice", null, null, "bob@example.com", null, null, null, Set.of("VIEWER"), null))
+                        bob.id(),
+                        "alice",
+                        null,
+                        null,
+                        "bob@example.com",
+                        null,
+                        null,
+                        null,
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()),
+                        null))
                 // then.
                 .isInstanceOf(UsernameAlreadyExistsException.class);
 
@@ -574,7 +805,15 @@ class DatabaseUserServiceTest {
     @Test
     void updateUserPatch_shouldThrowWhenUsernameIsReservedForSuperAdmin() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity alice = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -587,7 +826,7 @@ class DatabaseUserServiceTest {
                         null,
                         null,
                         null,
-                        Set.of("VIEWER"),
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()),
                         null))
                 // then.
                 .isInstanceOf(UsernameAlreadyExistsException.class);
@@ -599,13 +838,38 @@ class DatabaseUserServiceTest {
     @Test
     void updateUserPatch_shouldThrowWhenEmailAlreadyExists() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
-        userService.createLocal("bob", null, null, "bob@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
+        userService.createLocal(
+                "bob",
+                null,
+                null,
+                "bob@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity bob = userRepository.findByUsername("bob").orElseThrow();
 
         // when.
         assertThatThrownBy(() -> userService.updateUserPatch(
-                        bob.id(), "bob", null, null, "alice@example.com", null, null, null, Set.of("VIEWER"), null))
+                        bob.id(),
+                        "bob",
+                        null,
+                        null,
+                        "alice@example.com",
+                        null,
+                        null,
+                        null,
+                        Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()),
+                        null))
                 // then.
                 .isInstanceOf(EmailAlreadyExistsException.class);
 
@@ -616,12 +880,29 @@ class DatabaseUserServiceTest {
     @Test
     void updateUserPatch_shouldAllowUserToKeepItsOwnUsernameAndEmail() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity alice = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
         userService.updateUserPatch(
-                alice.id(), "alice", null, null, "alice@example.com", null, null, null, Set.of("ADMIN"), null);
+                alice.id(),
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                null,
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()),
+                null);
 
         // then.
         UserEntity updated = userRepository.findById(alice.id()).orElseThrow();
@@ -632,7 +913,15 @@ class DatabaseUserServiceTest {
 
     @Test
     void updateUserPatch_shouldReplaceRolesCompletely() {
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -645,7 +934,7 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 "newPass",
-                Set.of("ADMIN"),
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()),
                 null);
 
         // then.
@@ -657,11 +946,49 @@ class DatabaseUserServiceTest {
     @Test
     void createLocal_shouldGrantRolesThroughUsersRolesTable() {
         // when.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "plainPass", "ADMIN");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "plainPass",
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
 
         // then.
         UserEntity saved = userRepository.findByUsername("alice").orElseThrow();
         assertThat(userService.findRoleNamesByUserId(saved.id())).containsExactly("ADMIN");
+    }
+
+    @Test
+    void createLocal_shouldGrantEveryRequestedRole() {
+        // when.
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "plainPass",
+                Set.of(
+                        roleRepository.findIdByName("VIEWER").orElseThrow(),
+                        roleRepository.findIdByName("EDITOR").orElseThrow()));
+
+        // then.
+        UserEntity saved = userRepository.findByUsername("alice").orElseThrow();
+        assertThat(userService.findRoleNamesByUserId(saved.id())).containsExactlyInAnyOrder("VIEWER", "EDITOR");
+    }
+
+    @Test
+    void createLocal_shouldThrowWhenRolesAreEmpty() {
+        // when.
+        assertThatThrownBy(() ->
+                        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", Set.of()))
+                // then.
+                .isInstanceOf(UserInvalidValueException.class);
+        assertThat(userRepository.findAll()).isEmpty();
     }
 
     @Test
@@ -677,7 +1004,15 @@ class DatabaseUserServiceTest {
     @Test
     void updateUserPatch_shouldReplaceRolesInUsersRolesTableRatherThanAddToThem() {
         // given.
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -690,7 +1025,9 @@ class DatabaseUserServiceTest {
                 null,
                 null,
                 null,
-                Set.of("ADMIN", "EDITOR"),
+                Set.of(
+                        roleRepository.findIdByName("ADMIN").orElseThrow(),
+                        roleRepository.findIdByName("EDITOR").orElseThrow()),
                 null);
 
         // then.
@@ -700,7 +1037,15 @@ class DatabaseUserServiceTest {
     @Test
     void deleteById_shouldRevokeRoles() {
         // given.
-        userService.createLocal("alice", null, null, "a@example.com", null, null, "p", "ADMIN");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "a@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
         UserEntity existing = userRepository.findByUsername("alice").orElseThrow();
 
         // when.
@@ -713,8 +1058,24 @@ class DatabaseUserServiceTest {
     @Test
     void findAllRoleNamesByUserId_shouldReturnAssignmentsOfEveryUser() {
         // given.
-        userService.createLocal("alice", null, null, "alice@example.com", null, null, "p", "ADMIN");
-        userService.createLocal("bob", null, null, "bob@example.com", null, null, "p", "VIEWER");
+        userService.createLocal(
+                "alice",
+                null,
+                null,
+                "alice@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("ADMIN").orElseThrow()));
+        userService.createLocal(
+                "bob",
+                null,
+                null,
+                "bob@example.com",
+                null,
+                null,
+                "p",
+                Set.of(roleRepository.findIdByName("VIEWER").orElseThrow()));
 
         String aliceId = userRepository.findByUsername("alice").orElseThrow().id();
         String bobId = userRepository.findByUsername("bob").orElseThrow().id();


### PR DESCRIPTION
@coderabbitai pause

This PR should be reviewed only after [#1573 — Assign roles by role ID when creating a user](https://github.com/axelixlabs/axelix/pull/1573) has been merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User update requests now accept role IDs when assigning roles.
  - OAuth sign-ins resolve assigned roles to their stored IDs automatically.
- **Bug Fixes**
  - Prevented duplicate role assignments when the same role ID is provided more than once.
  - User updates now correctly handle role lookup failures when a requested role does not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->