### PR TITLE
GH-1583 Extend HistoricalApplicationSnapshotRepository

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/HistoricalApplicationSnapshotRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/HistoricalApplicationSnapshotRepository.java
@@ -17,6 +17,7 @@
  */
 package com.axelixlabs.axelix.master.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.data.jdbc.repository.query.Query;
@@ -155,6 +156,29 @@ public interface HistoricalApplicationSnapshotRepository
         """)
     HistoricalApplicationSnapshot findLatestApplicationSnapshot(
             @Param("groupId") String groupId, @Param("artifactId") String artifactId);
+
+    /**
+     * Every (service, date) pair with at least one snapshot on or after {@code from} - one row per day a
+     * service was actually observed, not deduplicated by month.
+     *
+     * @param from the earliest date (inclusive) to include.
+     * @return the matching (service, date) pairs, unordered.
+     */
+    @Query("""
+            SELECT group_id, artifact_id, date
+            FROM historical_application_snapshots
+            WHERE date >= :from
+            """)
+    List<ApplicationSnapshotDate> findSnapshotDatesFrom(@Param("from") LocalDate from);
+
+    /**
+     * A single (service, date) pair: {@code artifactId} is used as the service's displayable name.
+     *
+     * @param groupId the group id of the service.
+     * @param artifactId the artifact id of the service.
+     * @param date the snapshot date this row refers to.
+     */
+    record ApplicationSnapshotDate(String groupId, String artifactId, LocalDate date) {}
 
     /**
      * Aggregated, ecosystem-wide adoption counters for the tracked Java/JVM features.

--- a/master/src/testFixtures/java/com/axelixlabs/axelix/master/utils/TestHistoricalApplicationSnapshotFactory.java
+++ b/master/src/testFixtures/java/com/axelixlabs/axelix/master/utils/TestHistoricalApplicationSnapshotFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.utils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
+
+import com.axelixlabs.axelix.common.api.registration.insights.persistence.PersistenceInsights;
+import com.axelixlabs.axelix.common.domain.insights.GarbageCollector;
+import com.axelixlabs.axelix.master.domain.HistoricalApplicationSnapshot;
+import com.axelixlabs.axelix.master.domain.HistoricalApplicationSnapshot.SnapshotId;
+import com.axelixlabs.axelix.master.domain.Insights;
+
+/**
+ * Inserts a {@link HistoricalApplicationSnapshot} row for tests.
+ */
+public final class TestHistoricalApplicationSnapshotFactory {
+
+    private TestHistoricalApplicationSnapshotFactory() {}
+
+    public static void insert(
+            JdbcAggregateTemplate jdbcAggregateTemplate, String groupId, String artifactId, LocalDate date) {
+        jdbcAggregateTemplate.insert(new HistoricalApplicationSnapshot(
+                new SnapshotId(groupId, artifactId, date),
+                new Insights(
+                        new Insights.HotSpot(
+                                new Insights.HotSpot.ProjectLeyden(false, false),
+                                new Insights.HotSpot.GarbageCollector(false, GarbageCollector.UNKNOWN),
+                                new Insights.HotSpot.ProjectLilliput(false)),
+                        new Insights.SpringFramework(false),
+                        new PersistenceInsights(List.of()))));
+    }
+}


### PR DESCRIPTION
close #1583 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for finding application snapshot dates from a specified date onward, including the associated service identifiers.

* **Tests**
  * Added testing utilities for creating historical application snapshots with specified services and dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->