### PR TITLE
Add the clone function into CachingEndpointProber and clone results of methods before returning

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/probers/EndpointProbersAutoConfiguration.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/probers/EndpointProbersAutoConfiguration.java
@@ -34,6 +34,8 @@ import com.axelixlabs.axelix.master.service.transport.DiscardingAbstractEndpoint
 import com.axelixlabs.axelix.master.service.transport.EndpointProber;
 import com.axelixlabs.axelix.master.service.transport.ProxyingEndpointProber;
 
+import java.util.Arrays;
+
 /**
  * Configuration that creates necessary {@link EndpointProber} instances to
  * access the API on the managed service side.
@@ -41,6 +43,7 @@ import com.axelixlabs.axelix.master.service.transport.ProxyingEndpointProber;
  * @author Mikhail Polivakha
  * @author Sergey Cherkasov
  * @author Nikita Kirillov
+ * @author Vyacheslav Yanin
  */
 @AutoConfiguration
 public class EndpointProbersAutoConfiguration {
@@ -149,7 +152,8 @@ public class EndpointProbersAutoConfiguration {
     @Bean
     public EndpointProber<byte[]> getBeansEndpointProber() {
         return new CachingEndpointProber<>(
-                new ProxyingEndpointProber(instanceRegistry, ActuatorEndpoints.GET_BEANS, securityContextExecutor));
+                new ProxyingEndpointProber(instanceRegistry, ActuatorEndpoints.GET_BEANS, securityContextExecutor),
+            bytes -> Arrays.copyOf(bytes, bytes.length));
     }
 
     // ThreadDump
@@ -271,7 +275,8 @@ public class EndpointProbersAutoConfiguration {
     @Bean
     public EndpointProber<byte[]> getConditionsProber() {
         return new CachingEndpointProber<>(new ProxyingEndpointProber(
-                instanceRegistry, ActuatorEndpoints.GET_CONDITIONS, securityContextExecutor));
+                instanceRegistry, ActuatorEndpoints.GET_CONDITIONS, securityContextExecutor),
+            bytes -> Arrays.copyOf(bytes, bytes.length));
     }
 
     // Configuration Properties

--- a/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/probers/EndpointProbersAutoConfiguration.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/autoconfiguration/probers/EndpointProbersAutoConfiguration.java
@@ -17,6 +17,8 @@
  */
 package com.axelixlabs.axelix.master.autoconfiguration.probers;
 
+import java.util.Arrays;
+
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.Resource;
@@ -33,8 +35,6 @@ import com.axelixlabs.axelix.master.service.transport.DefaultEndpointProber;
 import com.axelixlabs.axelix.master.service.transport.DiscardingAbstractEndpointProber;
 import com.axelixlabs.axelix.master.service.transport.EndpointProber;
 import com.axelixlabs.axelix.master.service.transport.ProxyingEndpointProber;
-
-import java.util.Arrays;
 
 /**
  * Configuration that creates necessary {@link EndpointProber} instances to
@@ -153,7 +153,7 @@ public class EndpointProbersAutoConfiguration {
     public EndpointProber<byte[]> getBeansEndpointProber() {
         return new CachingEndpointProber<>(
                 new ProxyingEndpointProber(instanceRegistry, ActuatorEndpoints.GET_BEANS, securityContextExecutor),
-            bytes -> Arrays.copyOf(bytes, bytes.length));
+                bytes -> Arrays.copyOf(bytes, bytes.length));
     }
 
     // ThreadDump
@@ -274,9 +274,9 @@ public class EndpointProbersAutoConfiguration {
     // Conditions
     @Bean
     public EndpointProber<byte[]> getConditionsProber() {
-        return new CachingEndpointProber<>(new ProxyingEndpointProber(
-                instanceRegistry, ActuatorEndpoints.GET_CONDITIONS, securityContextExecutor),
-            bytes -> Arrays.copyOf(bytes, bytes.length));
+        return new CachingEndpointProber<>(
+                new ProxyingEndpointProber(instanceRegistry, ActuatorEndpoints.GET_CONDITIONS, securityContextExecutor),
+                bytes -> Arrays.copyOf(bytes, bytes.length));
     }
 
     // Configuration Properties

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/transport/CachingEndpointProber.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/transport/CachingEndpointProber.java
@@ -19,6 +19,7 @@ package com.axelixlabs.axelix.master.service.transport;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.function.Function;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -37,19 +38,39 @@ import com.axelixlabs.axelix.master.mcp.auth.McpIdentityAccessManager;
  *
  * @author Abubakar Muradov
  * @author Mikhail Polivakha
+ * @author Vyacheslav Yanin
  */
 public class CachingEndpointProber<T> implements EndpointProber<T> {
 
     private final EndpointProber<T> delegate;
     private final Cache<CacheKey, T> cache;
+    private final Function<T, T> cloner;
 
+    /**
+     * Constructor for immutable generic type, it sets the default value for the clone function.
+     */
     public CachingEndpointProber(EndpointProber<T> delegate) {
-        this(delegate, defaultCache());
+        this(delegate, defaultCache(), Function.identity());
     }
 
+    /**
+     * Constructor for immutable generic type, it sets the default value for the clone function.
+     */
     CachingEndpointProber(EndpointProber<T> delegate, Cache<CacheKey, T> cache) {
+        this(delegate, cache, Function.identity());
+    }
+
+    /**
+     * Constructor for mutable generic type, it sets the passed value for the clone function.
+     */
+    public CachingEndpointProber(EndpointProber<T> delegate, Function<T, T> cloner) {
+        this(delegate, defaultCache(), cloner);
+    }
+
+    CachingEndpointProber(EndpointProber<T> delegate, Cache<CacheKey, T> cache, Function<T, T> cloner) {
         this.delegate = delegate;
         this.cache = cache;
+        this.cloner = cloner;
     }
 
     private static <T> Cache<CacheKey, T> defaultCache() {
@@ -63,14 +84,15 @@ public class CachingEndpointProber<T> implements EndpointProber<T> {
     @Override
     public @NonNull T invoke(@NonNull InstanceId instanceId, HttpPayload httpPayload)
             throws EndpointInvocationException, BadRequestException, InstanceNotFoundException {
-        return cache.get(
+        T cacheResult =  cache.get(
                 new CacheKey(instanceId, httpPayload), key -> delegate.invoke(key.instanceId(), key.httpPayload()));
+        return cloner.apply(cacheResult);
     }
 
     @Override
     public @NonNull T invoke(@NonNull String baseUrl, HttpPayload httpPayload)
             throws EndpointInvocationException, BadRequestException {
-        return delegate.invoke(baseUrl, httpPayload);
+        return cloner.apply(delegate.invoke(baseUrl, httpPayload));
     }
 
     @Override

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/transport/CachingEndpointProber.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/transport/CachingEndpointProber.java
@@ -84,7 +84,7 @@ public class CachingEndpointProber<T> implements EndpointProber<T> {
     @Override
     public @NonNull T invoke(@NonNull InstanceId instanceId, HttpPayload httpPayload)
             throws EndpointInvocationException, BadRequestException, InstanceNotFoundException {
-        T cacheResult =  cache.get(
+        T cacheResult = cache.get(
                 new CacheKey(instanceId, httpPayload), key -> delegate.invoke(key.instanceId(), key.httpPayload()));
         return cloner.apply(cacheResult);
     }

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/transport/CachingEndpointProberTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/transport/CachingEndpointProberTest.java
@@ -17,6 +17,7 @@
  */
 package com.axelixlabs.axelix.master.service.transport;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link CachingEndpointProber}.
  *
  * @author Mikhail Polivakha
+ * @author Vyacheslav Yanin
  */
 @ExtendWith(MockitoExtension.class)
 class CachingEndpointProberTest {
@@ -76,7 +78,7 @@ class CachingEndpointProberTest {
     @BeforeEach
     void setUp() {
         Cache<CacheKey, byte[]> cache = Caffeine.newBuilder().build();
-        subject = new CachingEndpointProber<>(delegate, cache);
+        subject = new CachingEndpointProber<>(delegate, cache, bytes -> Arrays.copyOf(bytes, bytes.length));
     }
 
     @Nested

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/transport/CachingEndpointProberTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/transport/CachingEndpointProberTest.java
@@ -94,8 +94,10 @@ class CachingEndpointProberTest {
             byte[] second = subject.invoke(INSTANCE_A, NoHttpPayload.INSTANCE);
 
             // then.
-            assertThat(first).isSameAs(CACHED_BODY);
-            assertThat(second).isSameAs(CACHED_BODY);
+            assertThat(first).isEqualTo(CACHED_BODY);
+            assertThat(first).isNotSameAs(CACHED_BODY);
+            assertThat(second).isEqualTo(CACHED_BODY);
+            assertThat(second).isNotSameAs(CACHED_BODY);
             verify(delegate, times(1)).invoke(eq(INSTANCE_A), same(NoHttpPayload.INSTANCE));
         }
 
@@ -110,8 +112,10 @@ class CachingEndpointProberTest {
             byte[] resultB = subject.invoke(INSTANCE_B, NoHttpPayload.INSTANCE);
 
             // then.
-            assertThat(resultA).isSameAs(CACHED_BODY);
-            assertThat(resultB).isSameAs(OTHER_BODY);
+            assertThat(resultA).isEqualTo(CACHED_BODY);
+            assertThat(resultA).isNotSameAs(CACHED_BODY);
+            assertThat(resultB).isEqualTo(OTHER_BODY);
+            assertThat(resultB).isNotSameAs(OTHER_BODY);
             verify(delegate).invoke(eq(INSTANCE_A), same(NoHttpPayload.INSTANCE));
             verify(delegate).invoke(eq(INSTANCE_B), same(NoHttpPayload.INSTANCE));
         }
@@ -133,8 +137,8 @@ class CachingEndpointProberTest {
             byte[] second = subject.invoke(INSTANCE_A, secondPayload);
 
             // then.
-            assertThat(first).isSameAs(CACHED_BODY);
-            assertThat(second).isSameAs(OTHER_BODY);
+            assertThat(first).isEqualTo(CACHED_BODY);
+            assertThat(second).isEqualTo(OTHER_BODY);
             verify(delegate).invoke(eq(INSTANCE_A), same(firstPayload));
             verify(delegate).invoke(eq(INSTANCE_A), same(secondPayload));
         }
@@ -152,8 +156,10 @@ class CachingEndpointProberTest {
         byte[] second = subject.invoke(BASE_URL, NoHttpPayload.INSTANCE);
 
         // then.
-        assertThat(first).isSameAs(CACHED_BODY);
-        assertThat(second).isSameAs(OTHER_BODY);
+        assertThat(first).isEqualTo(CACHED_BODY);
+        assertThat(first).isNotSameAs(CACHED_BODY);
+        assertThat(second).isEqualTo(OTHER_BODY);
+        assertThat(second).isNotSameAs(OTHER_BODY);
         verify(delegate, times(2)).invoke(eq(BASE_URL), same(NoHttpPayload.INSTANCE));
         verifyNoMoreInteractions(delegate);
     }
@@ -172,7 +178,7 @@ class CachingEndpointProberTest {
         byte[] result = subject.invoke(INSTANCE_A, NoHttpPayload.INSTANCE);
 
         // then.
-        assertThat(result).isSameAs(CACHED_BODY);
+        assertThat(result).isEqualTo(CACHED_BODY);
         verify(delegate, times(2)).invoke(eq(INSTANCE_A), same(NoHttpPayload.INSTANCE));
     }
 
@@ -186,7 +192,7 @@ class CachingEndpointProberTest {
         ActuatorEndpoint result = subject.supports();
 
         // then.
-        assertThat(result).isSameAs(endpoint);
+        assertThat(result).isEqualTo(endpoint);
         verify(delegate).supports();
     }
 


### PR DESCRIPTION
Embed the clone function(Function<T, T>) in the main constructor and implement the default constructors for the clone function for an immutable generic type. I also add the implemented clone function wherever a CachingEndpointProber with a mutable generic type is created.

Closes #1133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cached byte-array results from being modified unintentionally by callers.
  * Ensured probed results are copied before being returned where mutable data is used.
* **Compatibility**
  * Existing caching behavior remains unchanged for result types that do not require copying.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->