### PR TITLE
Bulk-insert user-role mappings instead of one INSERT per role.

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UserRoleNotFoundException.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UserRoleNotFoundException.java
@@ -17,6 +17,8 @@
  */
 package com.axelixlabs.axelix.master.exception.auth;
 
+import java.util.Collection;
+
 import org.jspecify.annotations.Nullable;
 
 import com.axelixlabs.axelix.common.auth.core.Role;
@@ -26,10 +28,15 @@ import com.axelixlabs.axelix.common.auth.core.Role;
  *
  * @see Role
  * @author Sergey Cherkasov
+ * @author Vyacheslav Yanin
  */
 public class UserRoleNotFoundException extends RuntimeException {
 
     public UserRoleNotFoundException(@Nullable String role) {
         super("Role '%s' is not allowed".formatted(role));
+    }
+
+    public UserRoleNotFoundException(Collection<String> roles) {
+        super("Roles %s are not allowed".formatted(roles));
     }
 }

--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/UserRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/UserRepository.java
@@ -20,6 +20,7 @@ package com.axelixlabs.axelix.master.repository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
 
@@ -56,6 +57,16 @@ public interface UserRepository extends ListCrudRepository<UserEntity, String> {
     @Modifying
     @Query("INSERT INTO users_roles (user_id, role_id) SELECT :userId, r.id FROM roles r WHERE r.name = :roleName")
     int attachRole(@Param("userId") String userId, @Param("roleName") String roleName);
+
+    /**
+     * @return the amount of rows affected (should equal {@code roleNames.size()} when every role exists)
+     */
+    @Modifying
+    @Query("""
+        INSERT INTO users_roles (user_id, role_id)
+        SELECT :userId, r.id FROM roles r WHERE r.name IN (:roleNames)
+        """)
+    int bulkAttachRoles(@Param("userId") String userId, @Param("roleNames") Set<String> roleNames);
 
     @Modifying
     @Query("DELETE FROM users_roles WHERE user_id = :userId")

--- a/master/src/main/java/com/axelixlabs/axelix/master/repository/UserRepository.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/repository/UserRepository.java
@@ -36,6 +36,7 @@ import com.axelixlabs.axelix.master.domain.UserStatus;
  * Repository for {@link UserEntity} aggregate.
  *
  * @author Sergey Cherkasov
+ * @author Vyacheslav Yanin
  */
 public interface UserRepository extends ListCrudRepository<UserEntity, String> {
 

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DatabaseUserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DatabaseUserService.java
@@ -51,6 +51,7 @@ import com.axelixlabs.axelix.master.repository.UserRepository;
  * JDBC-based implementation of {@link UserService} that persists users in a relational database.
  *
  * @author Sergey Cherkasov
+ * @author Vyacheslav Yanin
  */
 @Service
 @NullMarked

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DatabaseUserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DatabaseUserService.java
@@ -256,16 +256,15 @@ public class DatabaseUserService implements UserService {
         grantRoles(id, roles);
     }
 
-    // TODO: Right now this is acceptable (i.e. a non-bulk INSERT) but in the future that may need optimization
     private void grantRoles(String userId, Set<String> roleNames) {
-        roleNames.forEach(roleName -> {
-            String normalizedRole = validateAndNormalizeRole(roleName);
-            int rowsAffected = userRepository.attachRole(userId, normalizedRole);
+        Set<String> normalizedRoles =
+                roleNames.stream().map(this::validateAndNormalizeRole).collect(Collectors.toUnmodifiableSet());
 
-            if (rowsAffected != 1) {
-                throw new UserRoleNotFoundException(normalizedRole);
-            }
-        });
+        int rowsAffected = userRepository.bulkAttachRoles(userId, normalizedRoles);
+
+        if (rowsAffected != normalizedRoles.size()) {
+            throw new UserRoleNotFoundException(normalizedRoles);
+        }
     }
 
     private String validateAndNormalizeRole(@Nullable String role) throws UserInvalidValueException {


### PR DESCRIPTION
Replace the loop-based grantRoles() implementation in DatabaseUserService with a single bulkAttachRoles() query in UserRepository. A new constructor UserRoleNotFoundException(Collection<String>) is added so the exception can report all missing role names at once when the bulk insert affects fewer rows than expected.

Closes #1539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Role assignments can now be processed in bulk when granting multiple roles to a user.
  - Error messages now list the requested roles that could not be found, making configuration issues easier to resolve.

- **Bug Fixes**
  - Duplicate or repeated role names are handled consistently during assignment.
  - Role assignment results are validated against the complete set of requested roles, improving reporting when one or more roles are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->