### PR TITLE
GH-1550 Centralized auto-configuration exclusions via AxelixMasterApplication 

### DIFF
--- a/master-oss/src/main/java/com/axelixlabs/axelix/master/app/MasterApplication.java
+++ b/master-oss/src/main/java/com/axelixlabs/axelix/master/app/MasterApplication.java
@@ -19,21 +19,20 @@ package com.axelixlabs.axelix.master.app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClientAutoConfiguration;
-import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import com.axelixlabs.axelix.master.AxelixMasterApplication;
+
 /**
  * The entrypoint of the OSS (community) distribution of Axelix Master.
  *
  * @author Mikhail Polivakha
+ * @author Dmitry Mazurov
  */
-@SpringBootApplication(
-        exclude = {CompositeDiscoveryClientAutoConfiguration.class, SimpleDiscoveryClientAutoConfiguration.class})
+@AxelixMasterApplication
 @ComponentScan(
         basePackages = {"com.axelixlabs.axelix.master"},
         excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = AutoConfiguration.class))

--- a/master/src/main/java/com/axelixlabs/axelix/master/AxelixMasterApplication.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/AxelixMasterApplication.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.prometheus.PrometheusMetricsExportAutoConfiguration;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClientAutoConfiguration;
+import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration;
+
+/**
+ * Composed {@link SpringBootApplication} meta-annotation shared by every Axelix Master entrypoint.
+ * Centralizes the auto-configurations that Axelix replaces with its own wiring.
+ *
+ * @author Dmitry Mazurov
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootApplication(
+        exclude = {
+            CompositeDiscoveryClientAutoConfiguration.class,
+            SimpleDiscoveryClientAutoConfiguration.class,
+            OtlpMetricsExportAutoConfiguration.class,
+            PrometheusMetricsExportAutoConfiguration.class
+        })
+public @interface AxelixMasterApplication {}

--- a/master/src/main/resources/application.yaml
+++ b/master/src/main/resources/application.yaml
@@ -3,12 +3,6 @@ server:
   port: 8080
 
 spring:
-  autoconfigure:
-    # OTLP and Prometheus metrics export are owned by OtlpTransportMetricsAutoConfiguration and
-    # PrometheusMetricsAutoConfiguration respectively, not Spring Boot's own auto-configurations.
-    exclude:
-      - org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration
-      - org.springframework.boot.micrometer.metrics.autoconfigure.export.prometheus.PrometheusMetricsExportAutoConfiguration
   cloud:
     compatibility-verifier:
       # TODO: This is a temporary fix, until we wait for the official cloud support of boot 4.1

--- a/master/src/test/java/com/axelixlabs/axelix/master/Main.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/Main.java
@@ -18,17 +18,14 @@
 package com.axelixlabs.axelix.master;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClientAutoConfiguration;
-import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration;
 
 /**
  * Minimal Spring Boot application used exclusively for testing this application.
  *
  * @author Nikita Kirillov
+ * @author Dmitry Mazurov
  */
-@SpringBootApplication(
-        exclude = {CompositeDiscoveryClientAutoConfiguration.class, SimpleDiscoveryClientAutoConfiguration.class})
+@AxelixMasterApplication
 public class Main {
 
     static void main(String[] args) {

--- a/master/src/test/java/com/axelixlabs/axelix/master/MainAutoConfigurationExclusionsTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/MainAutoConfigurationExclusionsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.prometheus.PrometheusMetricsExportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.discovery.composite.CompositeDiscoveryClientAutoConfiguration;
+import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the auto-configurations excluded on {@link Main} are absent from the application context.
+ *
+ * @author Dmitry Mazurov
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class MainAutoConfigurationExclusionsTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test // GH-1550
+    void excludedAutoConfigurationsAreAbsentFromContext() {
+        // given.
+        List<Class<?>> excludedAutoConfigurations = List.of(
+                CompositeDiscoveryClientAutoConfiguration.class,
+                SimpleDiscoveryClientAutoConfiguration.class,
+                OtlpMetricsExportAutoConfiguration.class,
+                PrometheusMetricsExportAutoConfiguration.class);
+
+        // when.
+        List<String> beanNames = excludedAutoConfigurations.stream()
+                .map(applicationContext::getBeanNamesForType)
+                .flatMap(Arrays::stream)
+                .toList();
+
+        // then.
+        assertThat(beanNames).isEmpty();
+    }
+}

--- a/master/src/testFixtures/resources/application.yaml
+++ b/master/src/testFixtures/resources/application.yaml
@@ -1,10 +1,4 @@
 spring:
-  autoconfigure:
-    # OTLP and Prometheus metrics export are owned by OtlpTransportMetricsAutoConfiguration and
-    # PrometheusMetricsAutoConfiguration respectively, not Spring Boot's own auto-configurations.
-    exclude:
-      - org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration
-      - org.springframework.boot.micrometer.metrics.autoconfigure.export.prometheus.PrometheusMetricsExportAutoConfiguration
   config:
     # spring-cloud-starter-config is on the classpath, so Spring Cloud requires a spring.config.import. Mirror the
     # production application.yaml with an 'optional:configserver:' import so tests boot without a Config Server.


### PR DESCRIPTION
Previously OtlpMetricsExportAutoConfiguration and PrometheusMetricsExportAutoConfiguration were excluded via a spring.autoconfigure.exclude property in application.yaml and testFixtures/resources/application.yaml, separately from the discovery client exclusions already declared on Main's `@SpringBootApplication(exclude = {...})` attribute. 

Consolidated both into a shared AxelixMasterApplication meta-annotation, used by both Main and master-oss's MasterApplication, so the exclude list is defined in one place.

#1550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Standardized application startup configuration across the main application and test environments.
  - Centralized exclusions for discovery clients and metrics exporters, preventing these automatic integrations from being enabled by default.
  - Removed redundant configuration entries while preserving existing application behavior.

- **Tests**
  - Added coverage confirming that the excluded discovery and metrics integrations do not register in the application context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->