### PR TITLE
GH-1599 Only locally-registered users should be suspendable via the user-management API

### DIFF
--- a/master/src/main/java/com/axelixlabs/axelix/master/api/error/handle/ApiErrorCodes.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/error/handle/ApiErrorCodes.java
@@ -21,6 +21,8 @@ package com.axelixlabs.axelix.master.api.error.handle;
  * The error codes that are be returned from the HTTP API.
  *
  * @author Mikhail Polivakha
+ * @author Nikita Kirillov
+ * @author Sergey Cherkasov
  */
 public enum ApiErrorCodes {
 
@@ -42,6 +44,7 @@ public enum ApiErrorCodes {
     USERNAME_ALREADY_EXISTS("USERNAME_ALREADY_EXISTS"),
     EMAIL_ALREADY_EXISTS("EMAIL_ALREADY_EXISTS"),
     USER_NOT_FOUND("USER_NOT_FOUND"),
+    USER_STATUS_CHANGE_NOT_ALLOWED("USER_STATUS_CHANGE_NOT_ALLOWED"),
     PARTIALLY_UPDATED("PARTIALLY_UPDATED");
 
     /**

--- a/master/src/main/java/com/axelixlabs/axelix/master/api/error/handle/impl/UserStatusChangeNotAllowedExceptionHandler.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/api/error/handle/impl/UserStatusChangeNotAllowedExceptionHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.api.error.handle.impl;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import com.axelixlabs.axelix.master.api.error.ApiError;
+import com.axelixlabs.axelix.master.api.error.SimpleApiError;
+import com.axelixlabs.axelix.master.api.error.handle.ApiErrorCodes;
+import com.axelixlabs.axelix.master.api.error.handle.ExceptionHandler;
+import com.axelixlabs.axelix.master.exception.auth.UserStatusChangeNotAllowedException;
+
+/**
+ * The exception handler for {@link UserStatusChangeNotAllowedException}.
+ *
+ * @author Nikita Kirillov
+ */
+@Component
+public class UserStatusChangeNotAllowedExceptionHandler
+        implements ExceptionHandler<UserStatusChangeNotAllowedException> {
+
+    @Override
+    public ApiError handle(HttpServletRequest request, UserStatusChangeNotAllowedException exception) {
+        return new SimpleApiError(
+                ApiErrorCodes.USER_STATUS_CHANGE_NOT_ALLOWED.getErrorCode(), HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Override
+    public Class<UserStatusChangeNotAllowedException> supported() {
+        return UserStatusChangeNotAllowedException.class;
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UserStatusChangeNotAllowedException.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/exception/auth/UserStatusChangeNotAllowedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025-2026 Axelix Labs
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.axelixlabs.axelix.master.exception.auth;
+
+import com.axelixlabs.axelix.master.domain.UserOrigin;
+
+/**
+ * Thrown when attempting to change the status of a user whose {@link UserOrigin} is not
+ * {@link UserOrigin#LOCAL}.
+ *
+ * @author Nikita Kirillov
+ */
+public class UserStatusChangeNotAllowedException extends RuntimeException {
+
+    public UserStatusChangeNotAllowedException(String id, UserOrigin origin) {
+        super(
+                "Cannot change status of user '%s': status changes are only supported for %s-origin users, but this user originates from %s"
+                        .formatted(id, UserOrigin.LOCAL, origin));
+    }
+}

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DatabaseUserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/DatabaseUserService.java
@@ -44,6 +44,7 @@ import com.axelixlabs.axelix.master.exception.auth.EmailAlreadyExistsException;
 import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
 import com.axelixlabs.axelix.master.exception.auth.UserNotFoundException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
+import com.axelixlabs.axelix.master.exception.auth.UserStatusChangeNotAllowedException;
 import com.axelixlabs.axelix.master.exception.auth.UsernameAlreadyExistsException;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 
@@ -51,6 +52,7 @@ import com.axelixlabs.axelix.master.repository.UserRepository;
  * JDBC-based implementation of {@link UserService} that persists users in a relational database.
  *
  * @author Sergey Cherkasov
+ * @author Nikita Kirillov
  */
 @Service
 @NullMarked
@@ -197,8 +199,10 @@ public class DatabaseUserService implements UserService {
 
     @Override
     public void updateStatus(String id, UserStatus status) {
-        if (!userRepository.existsById(id)) {
-            throw new UserNotFoundException(id);
+        UserEntity user = userRepository.findById(id).orElseThrow(() -> new UserNotFoundException(id));
+
+        if (user.userOrigin() != UserOrigin.LOCAL) {
+            throw new UserStatusChangeNotAllowedException(id, user.userOrigin());
         }
 
         userRepository.updateStatus(id, status);

--- a/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/UserService.java
+++ b/master/src/main/java/com/axelixlabs/axelix/master/service/state/auth/UserService.java
@@ -33,6 +33,7 @@ import com.axelixlabs.axelix.master.exception.auth.EmailAlreadyExistsException;
 import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
 import com.axelixlabs.axelix.master.exception.auth.UserNotFoundException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
+import com.axelixlabs.axelix.master.exception.auth.UserStatusChangeNotAllowedException;
 import com.axelixlabs.axelix.master.exception.auth.UsernameAlreadyExistsException;
 
 /**
@@ -43,6 +44,7 @@ import com.axelixlabs.axelix.master.exception.auth.UsernameAlreadyExistsExceptio
  *
  * @author Sergey Cherkasov
  * @author Mikhail Polivakha
+ * @author Nikita Kirillov
  */
 @NullMarked
 public interface UserService {
@@ -165,11 +167,13 @@ public interface UserService {
     void updateLastLoginAt(String username);
 
     /**
-     * Changes the status of a persisted user without modifying other user data.
+     * Changes the status of a persisted user without modifying other user data. Only supported for
+     * users of {@link UserOrigin#LOCAL} origin;
      *
      * @param id Unique identifier of the user.
      * @param status New status of the user.
      * @throws UserNotFoundException if no user with the given id exists.
+     * @throws UserStatusChangeNotAllowedException if the user's origin is not {@link UserOrigin#LOCAL}.
      */
     void updateStatus(String id, UserStatus status);
 

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserApiTest.java
@@ -293,7 +293,6 @@ class UserApiTest extends AbstractProtectedEndpointTest {
 
         userService.createFromOidc("bob", "Bob", null, "bob@example.com", null, null, "hash-bob", "VIEWER");
         UserEntity bob = userRepository.findByUsername("bob").orElseThrow();
-        userService.updateStatus(bob.id(), UserStatus.SUSPENDED);
 
         // language=json
         String expectedFeed = """
@@ -321,7 +320,7 @@ class UserApiTest extends AbstractProtectedEndpointTest {
                     "organizationalUnit": null,
                     "roles": ["VIEWER"],
                     "userOrigin": "OAUTH2/OIDC",
-                    "status": "SUSPENDED",
+                    "status": "ACTIVE",
                     "lastLoginAt": "${json-unit.any-string}"
                   }
                 ]

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/external/endpoint/UserManagementApiTest.java
@@ -51,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Sergey Cherkasov
  * @author Mikhail Polivakha
+ * @author Nikita Kirillov
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = "axelix.master.auth.options.local.enabled=true")
@@ -633,6 +634,28 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
     }
 
     @Test
+    void shouldReturnBadRequest_WhenChangingStatusOfOidcUser() {
+        // given.
+        UserEntity user = createOidcUser("u", "u@example.com", "hash-u");
+        String request = """
+                {
+                  "id": "%s",
+                  "status": "SUSPENDED"
+                }
+                """.formatted(user.id());
+
+        // when.
+        ResponseEntity<String> response = restTemplate
+                .asUsersFeedEditor()
+                .exchange(USERS_STATUS_PATH, HttpMethod.PUT, defaultEntity(request), String.class);
+
+        // then.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).contains("USER_STATUS_CHANGE_NOT_ALLOWED");
+        assertThat(userRepository.findById(user.id()).orElseThrow().status()).isEqualTo(UserStatus.ACTIVE);
+    }
+
+    @Test
     void shouldReturnNotFound_WhenChangingStatusOfUnknownUser() {
         // given.
         String request = """
@@ -669,6 +692,11 @@ public class UserManagementApiTest extends AbstractProtectedEndpointTest {
 
     private UserEntity createUser(String username, String email, String password) {
         userService.createLocal(username, null, null, email, null, null, password, "VIEWER");
+        return userRepository.findByUsername(username).orElseThrow();
+    }
+
+    private UserEntity createOidcUser(String username, String email, String oidcSubject) {
+        userService.createFromOidc(username, null, null, email, null, null, oidcSubject, "VIEWER");
         return userRepository.findByUsername(username).orElseThrow();
     }
 }

--- a/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/api/infrastructure/OAuth2CallbackControllerTest.java
@@ -281,42 +281,6 @@ class OAuth2CallbackControllerTest extends AbstractProtectedEndpointTest {
     }
 
     @Test
-    void shouldReturnForbiddenForSuspendedOidcUserWithoutUpdatingIt() {
-        // given.
-        String username = "test-user";
-        userService.createFromOidc(
-                username,
-                "Original",
-                "Name",
-                "original@gmail.com",
-                null,
-                null,
-                expectedOidcSubject(SUBJECT),
-                TestRoles.VIEWER.getName());
-        UserEntity created = userRepository.findByUsername(username).orElseThrow();
-        userService.updateStatus(created.id(), UserStatus.SUSPENDED);
-        UserEntity suspended = userRepository.findById(created.id()).orElseThrow();
-
-        // and.
-        String userInfoJson = "{\"email\": \"updated@gmail.com\"}";
-        when(oidcClient.exchangeCodeForTokens(CODE)).thenReturn(tokens);
-        when(oidcClient.validateIdToken(ID_TOKEN)).thenReturn(new ValidatedOidcIdentity(username, SUBJECT, Map.of()));
-        when(oidcClient.validateAccessTokenAndExtractUserInfo(ACCESS_TOKEN)).thenReturn(userInfoJson);
-        when(userInfoJsonAccessor.extractRole(userInfoJson)).thenReturn(TestRoles.EDITOR);
-
-        // when.
-        ResponseEntity<String> response = restTemplate.getForEntity(
-                "http://localhost:" + port + "/api/external/oauth2/callback?code=" + CODE, String.class);
-
-        // then.
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
-        assertThat(response.getBody()).contains("USER_SUSPENDED");
-        assertThat(response.getHeaders().get(HttpHeaders.SET_COOKIE)).isNullOrEmpty();
-        assertThat(userRepository.findById(created.id()).orElseThrow()).isEqualTo(suspended);
-        assertAccessDenied(MasterWebEndpoints.OIDC_AUTH_COMPLETE);
-    }
-
-    @Test
     void shouldDeduplicateByOidcSubjectAcrossUsernameChange() {
         // given an existing OIDC user provisioned under the original username.
         String originalUsername = "john.old";

--- a/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
+++ b/master/src/test/java/com/axelixlabs/axelix/master/service/state/DatabaseUserServiceTest.java
@@ -37,6 +37,7 @@ import com.axelixlabs.axelix.master.exception.auth.EmailAlreadyExistsException;
 import com.axelixlabs.axelix.master.exception.auth.UserInvalidValueException;
 import com.axelixlabs.axelix.master.exception.auth.UserNotFoundException;
 import com.axelixlabs.axelix.master.exception.auth.UserRoleNotFoundException;
+import com.axelixlabs.axelix.master.exception.auth.UserStatusChangeNotAllowedException;
 import com.axelixlabs.axelix.master.exception.auth.UsernameAlreadyExistsException;
 import com.axelixlabs.axelix.master.repository.UserRepository;
 import com.axelixlabs.axelix.master.service.state.auth.DatabaseUserService;
@@ -370,6 +371,20 @@ class DatabaseUserServiceTest {
                 // then.
                 .isInstanceOf(UserNotFoundException.class);
         assertThat(userRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void updateStatus_shouldRejectOidcUser() {
+        // given.
+        userService.createFromOidc("bob", null, null, null, null, null, "hash-bob", "VIEWER");
+        UserEntity existing = userRepository.findByUsername("bob").orElseThrow();
+
+        // when.
+        assertThatThrownBy(() -> userService.updateStatus(existing.id(), UserStatus.SUSPENDED))
+                // then.
+                .isInstanceOf(UserStatusChangeNotAllowedException.class);
+        assertThat(userRepository.findById(existing.id()).orElseThrow().status())
+                .isEqualTo(existing.status());
     }
 
     @Test


### PR DESCRIPTION
close #1599 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safeguards preventing status changes for users managed through external identity providers.
  * API requests attempting unsupported status changes now return a clear bad-request error with a dedicated error code.
  * Locally managed users continue to support status updates.

* **Tests**
  * Added coverage for rejected external-user status changes and unchanged user status.
  * Updated user listing expectations to reflect the preserved active status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->